### PR TITLE
Wave 10: the wing statistic is refuted by its own population check, and a pinned arm was never pinned

### DIFF
--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/StarDetection/Optimization/ExposureRecommenderTests.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/StarDetection/Optimization/ExposureRecommenderTests.cs
@@ -1,4 +1,4 @@
-#region "copyright"
+﻿#region "copyright"
 
 /*
     Copyright © 2021 - 2026 George Hilios <ghilios+NINA@googlemail.com>
@@ -897,79 +897,77 @@ public class ExposureRecommenderTests {
         };
     }
 
+    // ── F19: the wing VERDICT was withdrawn in wave 10. These four tests are REWRITTEN, not deleted. ───────
+    //
+    // W1-W4 asserted behaviour that wave 9 validated on TWO datasets and that wave 10's full-bank population
+    // check refuted: the statistic fires on the great majority of runs; four real-bank runs reject FEWER
+    // candidates in their wings than in their cores and fire anyway; and the measured fractions are 0.000 or
+    // >= 0.352 with nothing between, so every threshold in (0, 0.352) selects the same runs.
+    //
+    // They are kept as the record of what was withdrawn and why, because a deleted test leaves no trace that a
+    // behaviour was ever asserted -- and the fixtures are exactly what shows how the threshold came to look
+    // reasonable: they span a rejected fraction of 0.002 to 0.75, and NO REAL RUN RESEMBLES THE 0.002 POLE.
+
     [Test]
-    public void Recommend_W1_SheddingWings_AskForMoreExposureEvenThoughEveryAcceptedStarClearsTheTarget() {
-        // THE DEFECT, in one fixture. Every accepted star measures S/N 40 against a target of 10, so the shipped
-        // statistic reports "exposure is not the limit" -- while the sweep's OUTER frames are forming 800
-        // candidates and losing 600 of them to the gate. Measured on D02_rich_135mm, whose wings shed 67% of their
-        // candidates at its derived exposure and whose sigma_focus is 48% better at 8x it.
+    public void Recommend_TheWingFractionIsSTILLMEASURED_ItIsTheVERDICTThatWasWithdrawn() {
+        // The measurement is real and correctly computed; it is what the successor is specified against. Only
+        // the claim attached to it is gone.
+        var rec = ExposureRecommender.Recommend(
+            WingMetrics(wingRejected: 600, wingAccepted: 200), DefaultConstants(), currentExposureSeconds: 0.5);
+
+        Assert.That(rec.WingRejectedFraction, Is.EqualTo(0.75).Within(1e-9));
+    }
+
+    [Test]
+    public void Recommend_SheddingWings_NoLongerRaiseTheAsk_NorFlipTheVerdict() {
+        // WAS W1. Every accepted star measures S/N 40 against a target of 10, so the accepted-star statistic
+        // says "exposure is not the limit"; wave 9 had the wing fraction (0.75) override that and ask 2x.
         //
-        // DISCRIMINATING: delete the wing probe and this fails on BOTH assertions.
+        // DISCRIMINATING: restore either action site and both of these fail.
         var rec = ExposureRecommender.Recommend(
             WingMetrics(wingRejected: 600, wingAccepted: 200), DefaultConstants(), currentExposureSeconds: 0.5);
 
         Assert.Multiple(() => {
-            Assert.That(rec.WingRejectedFraction, Is.EqualTo(0.75).Within(1e-9));
-            Assert.That(rec.WingIsShedding, Is.True);
-            Assert.That(rec.RecommendedSeconds, Is.GreaterThanOrEqualTo(2.0 * 0.5), "W1: at least 2x current");
-            Assert.That(rec.IncreasesExposure, Is.True);
-            Assert.That(rec.ExposureIsNotTheLimit, Is.False,
-                "a shedding wing means exposure IS the limit, whatever the accepted stars say -- otherwise the copy "
-                + "would say 'star brightness is not the problem' directly above a row asking for more exposure");
+            Assert.That(rec.IncreasesExposure, Is.False, "the 2x probe is withdrawn");
+            Assert.That(rec.ExposureIsNotTheLimit, Is.True,
+                "the accepted-star verdict stands on its own again -- the wing fraction no longer overrides it");
         });
     }
 
     [Test]
-    public void Recommend_W2_HealthyWings_AskForNothingMore_EvenAtAFlooredGate() {
-        // THE CONTROL, and it is the whole reason the arm-E ladder was rendered. D16_esprit550_ha3's sigma_focus
-        // MINIMUM sits at its derived exposure and gets WORSE above it, so a statistic that fires here has traded
-        // one blind spot for another. Its wings reject nothing.
+    public void Recommend_TheFIXTUREGAPThatMadeTheThresholdLookReasonable() {
+        // WAS W2, and it is the most useful of the four now. Its "healthy wings" fixture reads 1/(1+200) = 0.005
+        // and the shedding one reads 0.75, so a threshold of 0.20 sits sensibly between two poles two orders of
+        // magnitude apart. The REAL BANK occupies 0.000 or 0.352-0.879 -- it has no 0.005-like population at all,
+        // and the 0.20 that looked well-separated here selected 16 of 19 runs there.
         //
-        // DISCRIMINATING: drop the WingSheddingThreshold test (fire on any rejection at all) and this fails.
-        var rec = ExposureRecommender.Recommend(
+        // This is not a defect in the fixtures; it is the limit of what a fixture can tell you. A unit test
+        // cannot notice that its own range is not the population's.
+        var healthy = ExposureRecommender.Recommend(
             WingMetrics(wingRejected: 1, wingAccepted: 200), DefaultConstants(), currentExposureSeconds: 2.0);
-
-        Assert.Multiple(() => {
-            Assert.That(rec.WingRejectedFraction, Is.LessThan(ExposureRecommender.WingSheddingThreshold));
-            Assert.That(rec.WingIsShedding, Is.False);
-            Assert.That(rec.IncreasesExposure, Is.False, "W2: no material increase where sigma_focus is minimised");
-            Assert.That(rec.ExposureIsNotTheLimit, Is.True);
-        });
-    }
-
-    [Test]
-    public void Recommend_W3_TheProbeCONVERGES_UnlikeTheStatisticItWidens() {
-        // S_now SATURATES HARDER as exposure rises -- measured 992 -> 1226 -> 1864 -> 2309 on D02 -- so it could
-        // never converge toward asking for more even if its trigger were widened. The wing fraction does the
-        // opposite: as exposure rises the gate stops rejecting, so the ask falls away. Measured on D02: 0.67 /
-        // 0.29 / 0.30 below its optimum and EXACTLY 0.00 at and above it.
-        //
-        // DISCRIMINATING: make the probe unconditional and the second half fails.
         var shedding = ExposureRecommender.Recommend(
-            WingMetrics(wingRejected: 600, wingAccepted: 200), DefaultConstants(), currentExposureSeconds: 0.5);
-        var converged = ExposureRecommender.Recommend(
-            WingMetrics(wingRejected: 0, wingAccepted: 800), DefaultConstants(), currentExposureSeconds: 4.0);
+            WingMetrics(wingRejected: 600, wingAccepted: 200), DefaultConstants(), currentExposureSeconds: 2.0);
 
         Assert.Multiple(() => {
-            Assert.That(shedding.IncreasesExposure, Is.True, "asks while the wings shed");
-            Assert.That(converged.WingRejectedFraction, Is.EqualTo(0.0).Within(1e-12));
-            Assert.That(converged.IncreasesExposure, Is.False, "and stops once they do not");
+            Assert.That(healthy.WingRejectedFraction, Is.LessThan(0.01), "the fixture's healthy pole");
+            Assert.That(shedding.WingRejectedFraction, Is.GreaterThan(0.70), "and its shedding pole");
+            // Both now produce the same ACTION, which is the whole content of the withdrawal.
+            Assert.That(healthy.IncreasesExposure, Is.EqualTo(shedding.IncreasesExposure), Is.False.ToString());
+            Assert.That(healthy.ExposureIsNotTheLimit, Is.True);
+            Assert.That(shedding.ExposureIsNotTheLimit, Is.True);
         });
     }
 
     [Test]
-    public void Recommend_W4_TheProbeWIDENS_AndNeverRegressesARunTheSnrPathAlreadyServes() {
-        // The probe ALONE fails W4: D16 at half its derived exposure correctly asks 3x from S_now (6.5 against a
-        // target of 10), and its gate is INERT out there, so the wing test is silent. max(existing, probe) keeps
-        // that case. Both halves are load-bearing.
-        //
-        // DISCRIMINATING: replace the max() with a plain assignment of the probe factor and this fails -- 4x
-        // collapses to 2x.
+    public void Recommend_TheSNRPathIsUNTOUCHED_WhichIsWhatTheWithdrawalMustNotBreak() {
+        // WAS W4, and it still passes unchanged -- deliberately. D16_esprit550_ha3 at half its derived exposure
+        // asks 4x from S_now alone (5 against a target of 10), and that path never involved the wing test. The
+        // withdrawal removes the probe; it must not touch the derivation that was already serving these runs.
         const int n = 9;
         var starved = new RunEvaluationMetrics {
             FrameStarSnrs = Enumerable.Range(0, n).Select(_ => (IReadOnlyList<double>)FullFrame(5.0)).ToArray(),
             FrameStarCounts = Enumerable.Repeat(200, n).ToArray(),
-            FrameLowSensitivityCounts = Enumerable.Repeat(300, n).ToArray(),  // wings shed too
+            FrameLowSensitivityCounts = Enumerable.Repeat(300, n).ToArray(),
             FrameTooFlatCounts = new int[n],
             FrameFocuserPositions = Enumerable.Range(0, n).Select(i => 1000 + (i - 4) * 10).ToArray(),
             BestFocusPosition = 1000.0,
@@ -978,12 +976,8 @@ public class ExposureRecommenderTests {
 
         var rec = ExposureRecommender.Recommend(starved, DefaultConstants(), currentExposureSeconds: 1.0);
 
-        Assert.Multiple(() => {
-            Assert.That(rec.WingIsShedding, Is.True, "fixture guard: the probe is live here");
-            // S_now = 5 against a target of 10 => (10/5)^2 = 4x, which must WIN over the 2x probe.
-            Assert.That(rec.RawSeconds, Is.EqualTo(4.0).Within(1e-9),
-                "the S/N derivation is larger here, so max() must keep it rather than let the probe cap it at 2x");
-        });
+        Assert.That(rec.RawSeconds, Is.EqualTo(4.0).Within(1e-9),
+            "(10/5)^2 = 4x from the accepted-star derivation, with no wing probe involved");
     }
 
     [Test]
@@ -994,13 +988,10 @@ public class ExposureRecommenderTests {
         // an effective gate of 0.17-2.5 at EVERY rung of its ladder, so without this guard its zeros would read as
         // "the wings are fine" for a reason that has nothing to do with its wings.
         //
-        // THIS TEST PINS BEHAVIOUR, NOT THE CONJUNCT -- and that correction came from neutralizing it. Removing
-        // `!gateIsProvablyInert` from WingIsShedding fails NOTHING, because the conjunct is redundant by
-        // construction: a wing fraction at or above the threshold needs a non-zero entry in the same
-        // FrameLowSensitivityCounts array gateRejectedCount sums, so an inert gate (which requires that count to be
-        // zero) can never coexist with a shedding wing. The THRESHOLD is what makes this case pass. An earlier
-        // version of this comment claimed the guard was what discriminated here; it does not, and the code now says
-        // so at the conjunct.
+        // Wave 9 recorded that the `!gateIsProvablyInert` conjunct on WingIsShedding was redundant by
+        // construction -- an inert gate rejects nothing, so it cannot coexist with a wing fraction above any
+        // positive threshold. Wave 10 removed the verdict entirely, which makes that observation the whole
+        // story: the threshold and the inertness test were asking the same question.
         var inertParams = HocusFocusStarDetection.BuildDefaultStarDetectorParams();
         inertParams.Sensitivity = 0.0;   // at or below PeakResponse x StarClip => provably inert
 
@@ -1010,7 +1001,11 @@ public class ExposureRecommenderTests {
 
         Assert.Multiple(() => {
             Assert.That(rec.GateIsProvablyInert, Is.True, "fixture guard");
-            Assert.That(rec.WingIsShedding, Is.False);
+            // The F28 field survives the wave-10 withdrawal and is now the ONLY thing asking this question.
+            // Wave 10 found that the wing threshold was asking it too, badly: the bank's fractions are 0.000 or
+            // >= 0.352, so "fraction >= 0.20" was a re-spelling of "the gate rejected something".
+            Assert.That(rec.WingRejectedFraction, Is.EqualTo(0.0).Within(1e-12),
+                "an inert gate rejects nothing BY CONSTRUCTION, which is why its zero was never reassuring");
         });
     }
 
@@ -1024,10 +1019,7 @@ public class ExposureRecommenderTests {
             WingMetrics(wingRejected: 600, wingAccepted: 200, placeable: false),
             DefaultConstants(), currentExposureSeconds: 0.5);
 
-        Assert.Multiple(() => {
-            Assert.That(rec.WingRejectedFraction, Is.NaN);
-            Assert.That(rec.WingIsShedding, Is.False, "an unplaceable run cannot claim its wings are shedding");
-        });
+        Assert.That(rec.WingRejectedFraction, Is.NaN);
     }
 
     [Test]
@@ -1042,7 +1034,6 @@ public class ExposureRecommenderTests {
 
         Assert.Multiple(() => {
             Assert.That(rec.WingRejectedFraction, Is.NaN);
-            Assert.That(rec.WingIsShedding, Is.False);
             Assert.That(rec.ExposureIsNotTheLimit, Is.True, "unchanged from before the wing test existed");
             Assert.That(rec.IncreasesExposure, Is.False);
         });

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/StarDetection/Optimization/OptimizationSummaryTests.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/StarDetection/Optimization/OptimizationSummaryTests.cs
@@ -46,6 +46,59 @@ public class OptimizationSummaryTests {
         });
     }
 
+    /// <summary>
+    /// F49(c): a capped recommendation must say what it is converging TOWARD and that it terminates. The field
+    /// session behind F49/F51 accepted "capped by this sweep's width; re-run auto-focus to refine" four times —
+    /// 100 → 214 → 459 → 474 → 482, at 30–120 minutes a run — and experienced a converging sequence as a runaway.
+    /// </summary>
+    [Test]
+    public void StepSizeText_Capped_NamesTheTargetTheRatioAndThatItTerminates() {
+        var s = new OptimizationSummary {
+            CurrentStepSize = 214, RecommendedStepSize = 459, CurrentOffsetSteps = 4, RecommendedOffsetSteps = 4,
+            StepSizeWasCapped = true, StepSizeSampledHfrRange = 1.84, StepSizeCappedGrowthRatio = 1.5 * 5 / 3.5
+        };
+        Assert.Multiple(() => {
+            Assert.That(s.StepSizeText, Does.StartWith("214 → 459"), "the recommendation itself still leads");
+            Assert.That(s.StepSizeText, Does.Contain("1.8×"), "what this sweep MEASURED — no extrapolation in it");
+            Assert.That(s.StepSizeText, Does.Contain("3×"), "F49(c): say what it is converging toward");
+            Assert.That(s.StepSizeText, Does.Contain("2.1×"), "and by how much each run moves — exact, not projected");
+            Assert.That(s.StepSizeText, Does.Contain("partial step"), "the cap is deliberate, not a failure");
+            // The number a user would most like and the one that cannot honestly be given: a run COUNT would have
+            // to come from the extrapolated half-width, which is the quantity the cap exists to distrust.
+            Assert.That(s.StepSizeText, Does.Not.Contain("more run"));
+        });
+    }
+
+    /// <summary>
+    /// Each clause is dropped when its quantity is unavailable rather than filled with a guess — and the
+    /// sentence still has to say the useful thing. This is the state a caller that never measured HFRs produces.
+    /// </summary>
+    [Test]
+    public void StepSizeText_Capped_WithoutMeasurements_StillSaysWhatTheCapMeans() {
+        var s = new OptimizationSummary {
+            CurrentStepSize = 214, RecommendedStepSize = 459, StepSizeWasCapped = true,
+            StepSizeSampledHfrRange = double.NaN, StepSizeCappedGrowthRatio = double.NaN
+        };
+        Assert.Multiple(() => {
+            Assert.That(s.StepSizeText, Does.Contain("partial step"));
+            Assert.That(s.StepSizeText, Does.Contain("3×"), "the target is a constant and is always available");
+            Assert.That(s.StepSizeText, Does.Contain("re-run auto-focus to refine"));
+            Assert.That(s.StepSizeText, Does.Not.Contain("NaN"), "never print a missing measurement at the user");
+            Assert.That(s.StepSizeText, Does.Not.Contain("each run widens"), "no ratio means no ratio claim");
+        });
+    }
+
+    /// <summary>An UNCAPPED recommendation is byte-identical to what it has always been: the note is the cap's,
+    /// not the recommendation's, and an uncapped run has nothing extra to explain.</summary>
+    [Test]
+    public void StepSizeText_NotCapped_IsUnchangedByAnyOfThis() {
+        var s = new OptimizationSummary {
+            CurrentStepSize = 150, RecommendedStepSize = 105, StepSizeWasCapped = false,
+            StepSizeSampledHfrRange = 4.2, StepSizeCappedGrowthRatio = 1.714
+        };
+        Assert.That(s.StepSizeText, Is.EqualTo("150 → 105"));
+    }
+
     [Test]
     public void StepSizeOrOffsetChanged_TrueWhenEitherDiffers() {
         Assert.Multiple(() => {

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/StarDetection/Optimization/OptimizerProgressCostTests.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/StarDetection/Optimization/OptimizerProgressCostTests.cs
@@ -1,4 +1,4 @@
-#region "copyright"
+﻿#region "copyright"
 
 /*
     Copyright © 2021 - 2026 George Hilios <ghilios+NINA@googlemail.com>
@@ -122,7 +122,7 @@ public class OptimizerProgressCostTests {
     // what Cancel costs -- and withheld (c), because advice derived from the exposure statistic of the day "would
     // tell precisely the users who most need a longer exposure that theirs is already fine": on the reporting
     // user's own rig that statistic read S/N 1438.6 against a target of 10. The separation is kept exactly: facts
-    // about COST need no statistic; ADVICE needs one, and now has ExposureRecommendation.WingIsShedding.
+    // about COST need no statistic; ADVICE needs one -- and as of wave 10 it does not have one again.
 
     /// <summary>A 9-frame seed evaluation whose OUTER third sheds <paramref name="wingRejected"/> candidates
     /// against <paramref name="wingAccepted"/> accepted, placed on the wing axis.</summary>
@@ -142,62 +142,59 @@ public class OptimizerProgressCostTests {
         };
     }
 
+    // ── F52(c) IS WITHHELD AGAIN (wave 10). These three tests are REWRITTEN, not deleted. ─────────────────
+    //
+    // Wave 8 refused to ship this advice for want of a statistic; wave 9 shipped it on
+    // ExposureRecommendation.WingIsShedding; wave 10's full-bank population check refuted that statistic and
+    // withdrew the verdict. This advice tells the user to CANCEL a running two-hour optimization and is computed
+    // from the SEED evaluation -- i.e. in the first minute -- so a statistic that fires on the great majority of
+    // bank runs meant advising most users to abandon a search before it had done anything.
+    //
+    // The tests stay because the WITHDRAWAL is the thing that now needs guarding: the successor statistic
+    // re-enables this by changing one condition, and these are what will stop it shipping silently.
+
     [Test]
-    public void SearchExposureAdvice_SheddingWings_TellsTheUserToConsiderStopping_AndWhatCancelCosts() {
-        // The user's actual question, asked two hours into a search: "should I abort and try again with a longer
-        // exposure?". It is answered from the SEED evaluation, which runs BEFORE the search, so the answer existed
-        // in the first minute.
+    public void SearchExposureAdvice_IsWITHHELD_EvenOnTheFixtureThatUsedToTriggerIt() {
+        // The exact fixture that produced the advice in wave 9 -- a wing fraction of 0.75.
         //
-        // DISCRIMINATING: make BuildSearchExposureAdvice return string.Empty and every assertion fails.
+        // DISCRIMINATING: restore the WingIsShedding condition and this fails.
         var text = StarDetectionOptimizerWizardVM.BuildSearchExposureAdvice(
             new[] { SeedMetrics(wingRejected: 600, wingAccepted: 200) },
             HocusFocusStarDetection.BuildDefaultStarDetectorParams(), currentExposureSeconds: 2.0);
 
+        Assert.That(text, Is.Empty,
+            "no advice may be given until it has a statistic that survives a population -- wave 8's position, "
+            + "reached again on better evidence");
+    }
+
+    [Test]
+    public void SearchExposureAdvice_IsWithheldForEVERYWingFraction_NotJustTheHealthyOne() {
+        // The withdrawal has to be unconditional on the statistic, not a raised threshold. A higher bar would
+        // still be measuring the detector's global reject rate -- the bank's fractions are 0.000 or 0.352-0.879,
+        // so any threshold in that gap selects the same runs, and one above it would still not be measuring
+        // WINGS. Four real-bank runs reject FEWER candidates in their wings than in their cores.
         Assert.Multiple(() => {
-            Assert.That(text, Does.Contain("outer frames"), "it names the population the verdict rests on");
-            Assert.That(text, Does.Contain("longer exposure"));
-            Assert.That(text, Does.Contain("Cancel"), "the house rule: name a control that exists");
-            Assert.That(text, Does.Contain("nothing is written to your profile"),
-                "not knowing this is why the user sat through the two hours");
-            Assert.That(text, Does.Not.Contain("S/N"),
-                "the accepted-star S/N is exactly the number that would have said 'yours is already fine'");
+            foreach (var (rejected, accepted) in new[] { (1, 500), (300, 700), (600, 200), (900, 100) }) {
+                Assert.That(StarDetectionOptimizerWizardVM.BuildSearchExposureAdvice(
+                    new[] { SeedMetrics(rejected, accepted) },
+                    HocusFocusStarDetection.BuildDefaultStarDetectorParams(), 2.0),
+                    Is.Empty, $"wing fraction {(double)rejected / (rejected + accepted):F2}");
+            }
         });
     }
 
     [Test]
-    public void SearchExposureAdvice_HealthyWings_SaysNOTHING() {
-        // A note that always fires says nothing -- the same rule the cost note follows ("absent entirely when the
-        // search is in a cheap region"). This is also the case wave 8 refused to ship advice for.
-        //
-        // DISCRIMINATING: drop the WingIsShedding test and this fails.
+    public void SearchExposureAdvice_MultiRun_IsWithheldToo_SoTheWorstRunAggregationCannotLeakBack() {
+        // Wave 9's aggregation took the WORST run rather than an average, on the sound reasoning that one
+        // settings bundle lands on all of them. That reasoning is untouched and will be needed again; what is
+        // withdrawn is the statistic it aggregated. Pinned so a successor cannot re-enable the aggregation
+        // without also re-enabling the condition deliberately.
         var text = StarDetectionOptimizerWizardVM.BuildSearchExposureAdvice(
-            new[] { SeedMetrics(wingRejected: 1, wingAccepted: 500) },
+            new[] { SeedMetrics(wingRejected: 600, wingAccepted: 200),
+                    SeedMetrics(wingRejected: 300, wingAccepted: 700) },
             HocusFocusStarDetection.BuildDefaultStarDetectorParams(), currentExposureSeconds: 2.0);
 
         Assert.That(text, Is.Empty);
-    }
-
-    [Test]
-    public void SearchExposureAdvice_MultiRun_TakesTheWORSTRun_NotTheAverage() {
-        // A multi-run optimization lands ONE settings bundle across all of them, so the run that is worst off is
-        // what makes the search's answer untrustworthy. Averaging would understate it.
-        //
-        // BOTH RUNS MUST BE SHEDDING for this to discriminate, and that correction came from neutralizing it: the
-        // aggregation `continue`s past any run whose wings are healthy, so pairing a shedding run with a HEALTHY
-        // one leaves the worst and the average identical and the test proves nothing. An earlier version of this
-        // test did exactly that and passed under a deliberately-averaged implementation.
-        //
-        // DISCRIMINATING as written: 0.75 and 0.30 average to 0.525, which renders "53%", not "75%".
-        var text = StarDetectionOptimizerWizardVM.BuildSearchExposureAdvice(
-            new[] { SeedMetrics(wingRejected: 600, wingAccepted: 200),   // 600/800 = 0.75
-                    SeedMetrics(wingRejected: 300, wingAccepted: 700) }, // 300/1000 = 0.30
-            HocusFocusStarDetection.BuildDefaultStarDetectorParams(), currentExposureSeconds: 2.0);
-
-        Assert.Multiple(() => {
-            Assert.That(text, Is.Not.Empty);
-            Assert.That(text, Does.Contain("75%"), "the WORST run's fraction, not a blend");
-            Assert.That(text, Does.Not.Contain("53%"));
-        });
     }
 
     [Test]

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/StarDetection/Optimization/StepSizeRecommenderTests.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/StarDetection/Optimization/StepSizeRecommenderTests.cs
@@ -557,4 +557,132 @@ public class StepSizeRecommenderTests {
             sizeForExecutedSweep: true);
         Assert.That(b.StepSize, Is.EqualTo(a.StepSize));
     }
+
+    // ---- F49(c) / F51: what a CAPPED recommendation is able to say about itself -----------------------------
+
+    /// <summary>
+    /// The growth ratio is <c>MaxHalfWidthSampledHalfSpanMultiple · P / PointsPerSide</c> and NOTHING else — in
+    /// particular it does not depend on the extrapolated half-width, which is the whole reason it is quotable to
+    /// a user while a projected run count is not.
+    ///
+    /// <para>Both rows are load-bearing and neither is hypothetical. P = 4 is the shipped offset-only sweep and
+    /// gives 1.714; wave 7's F18 control arm has 22 capped rounds across six datasets on disk and every one lands
+    /// at 1.667–1.750, the scatter being integer rounding of the step. P = 5 is 4 offset + 1 focus-recovery step
+    /// and gives 2.143 — the geometry of the field session behind F49/F51, whose 11-point sweeps went
+    /// 100 → 214 → 459. A single hard-coded constant would have been wrong on one of the two.</para>
+    /// </summary>
+    [TestCase(4, 1.5 * 4 / 3.5)]
+    [TestCase(5, 1.5 * 5 / 3.5)]
+    public void Recommend_Capped_ReportsTheExactRatioTheNextRunWillApply(int pointsPerSide, double expectedRatio) {
+        const int stepSize = 214;
+        var fit = FitShallowHyperbola(minHfr: 1.9, edgeHfrRatio: 1.8, stepSize: stepSize, offsetSteps: pointsPerSide);
+
+        var rec = StepSizeRecommender.Recommend(fit, currentStepSize: stepSize);
+
+        Assert.Multiple(() => {
+            Assert.That(rec.WasCapped, Is.True, "the premise: a sweep reaching only 1.8x the minimum HFR is capped");
+            Assert.That(rec.CappedGrowthRatio, Is.EqualTo(expectedRatio).Within(1e-9),
+                "the ratio is algorithm arithmetic, not a property of the fit");
+            // And it PREDICTS: the step the recommender returned is the ratio applied to the current step.
+            Assert.That(rec.StepSize, Is.EqualTo((int)Math.Round(stepSize * expectedRatio, MidpointRounding.AwayFromZero)).Within(1),
+                "the ratio must actually describe the move this recommendation just made");
+        });
+    }
+
+    /// <summary>
+    /// The field session behind F49/F51, replayed: 100 → 214 → 459 at 4 offset + 1 recovery step per side. The
+    /// entry derives 459 independently from the screenshot's focuser axis (11 points at spacing 214 ⇒ sampled
+    /// half-span 1070; ×1.5 ⇒ 1605; /3.5 ⇒ 458.6), so this is a check against a number the recommender did not
+    /// produce here.
+    ///
+    /// <para>It also pins the half of the user's complaint that is NOT a defect: the sequence TERMINATES. The
+    /// user saw four runs each asking to widen and read it as a runaway; it is a geometric approach to the point
+    /// where the sweep contains the 3x band, and their runs 3 and 4 asked +3 % and +5 %.</para>
+    /// </summary>
+    [Test]
+    public void Recommend_TheFieldSessionSequence_ReproducesAndTerminates() {
+        const double hfrMin = 1.9;
+        const double kappa = 0.0026;   // ~3.5 px at the +/-1070 edge of the session's second sweep
+        const int pointsPerSide = 5;   // 4 offset + 1 focus recovery, i.e. the session's 11-point sweeps
+
+        var step = 100;
+        var seen = new List<int> { step };
+        var cappedRounds = 0;
+        for (var round = 0; round < 12; round++) {
+            var fit = FitTruthSweep(hfrMin, kappa, P0, step, pointsPerSide);
+            var rec = StepSizeRecommender.Recommend(fit, step);
+            if (rec.WasCapped) {
+                cappedRounds++;
+                Assert.That(rec.CappedGrowthRatio, Is.EqualTo(1.5 * pointsPerSide / 3.5).Within(1e-9),
+                    "every capped round reports the same exact ratio");
+            }
+            if (rec.StepSize == step) {
+                break;
+            }
+            step = rec.StepSize;
+            seen.Add(step);
+        }
+        TestContext.WriteLine("sequence: " + string.Join(" -> ", seen));
+
+        Assert.Multiple(() => {
+            Assert.That(seen.Count, Is.GreaterThanOrEqualTo(3), "the session took at least three widening rounds");
+            Assert.That(seen[1], Is.EqualTo(214).Within(2), "100 x 2.143 = 214.3 -- the session's first recommendation");
+            Assert.That(seen[2], Is.EqualTo(459).Within(3), "214 x 2.143 = 458.6 -- the session's second");
+            Assert.That(cappedRounds, Is.GreaterThan(0), "the widening rounds are the CAPPED ones");
+            Assert.That(seen.Count, Is.LessThan(12), "it terminates; the user's 'runaway' is a geometric approach");
+        });
+    }
+
+    /// <summary>
+    /// <see cref="StepSizeRecommendation.SampledHfrRange"/> is what the sweep MEASURED, so unlike the half-width
+    /// it involves no extrapolation — which is why the copy leads with it. Paired with the uncapped case so the
+    /// test says which side of <see cref="StepSizeRecommender.HfrThresholdMultiple"/> each lands on.
+    /// </summary>
+    [TestCase(1.8, false)]
+    [TestCase(3.6, true)]
+    public void Recommend_ReportsTheHfrRangeTheSweepActuallyMeasured(double edgeHfrRatio, bool expectReached) {
+        var fit = FitShallowHyperbola(minHfr: 1.9, edgeHfrRatio: edgeHfrRatio, stepSize: 214, offsetSteps: 4);
+
+        var rec = StepSizeRecommender.Recommend(fit, currentStepSize: 214);
+
+        Assert.Multiple(() => {
+            Assert.That(rec.SampledHfrRange, Is.EqualTo(edgeHfrRatio).Within(0.05),
+                "max(HFR)/min(HFR) over the fitted points");
+            Assert.That(rec.ReachedHfrBand, Is.EqualTo(expectReached));
+            // The two agree: a sweep that did not reach the band is exactly one whose half-width was capped.
+            Assert.That(rec.WasCapped, Is.EqualTo(!expectReached),
+                "SampledHfrRange >= 3 and WasCapped must not disagree about whether the band was sampled");
+        });
+    }
+
+    /// <summary>
+    /// An UNCAPPED recommendation has no growth ratio, because there is no next capped run for one to describe.
+    /// NaN rather than 1.0: "this is not widening geometrically" and "it widens by a factor of one" would be the
+    /// same number, and the caller turns one of them into a sentence.
+    /// </summary>
+    [Test]
+    public void Recommend_NotCapped_HasNoGrowthRatioAtAll() {
+        var fit = FitCleanHyperbola();
+        var rec = StepSizeRecommender.Recommend(fit, currentStepSize: 100);
+        Assert.Multiple(() => {
+            Assert.That(rec.WasCapped, Is.False, "the premise");
+            Assert.That(double.IsNaN(rec.CappedGrowthRatio), Is.True, "NaN, never 1.0");
+        });
+    }
+
+    /// <summary>
+    /// A degenerate recommendation reports NEITHER quantity. It never fitted anything, so both "what did this
+    /// sweep measure" and "what will the next run multiply by" are unanswerable rather than zero — the same
+    /// NaN-never-0 rule <see cref="StepSizeRecommendation.MaxUsefulHalfSpan"/> already follows.
+    /// </summary>
+    [Test]
+    public void Recommend_DegenerateFit_ReportsNeitherMeasurement() {
+        var rec = StepSizeRecommender.Recommend(null, currentStepSize: 77);
+        Assert.Multiple(() => {
+            Assert.That(rec.StepSize, Is.EqualTo(77), "unchanged, as before");
+            Assert.That(double.IsNaN(rec.SampledHfrRange), Is.True);
+            Assert.That(double.IsNaN(rec.CappedGrowthRatio), Is.True);
+            Assert.That(rec.ReachedHfrBand, Is.False, "an unmeasurable range is not a reached band");
+        });
+    }
 }

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/StarDetection/Optimization/StepSizeRecommenderTests.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/StarDetection/Optimization/StepSizeRecommenderTests.cs
@@ -608,6 +608,7 @@ public class StepSizeRecommenderTests {
         var step = 100;
         var seen = new List<int> { step };
         var cappedRounds = 0;
+        var roundTheCapReleased = -1;
         for (var round = 0; round < 12; round++) {
             var fit = FitTruthSweep(hfrMin, kappa, P0, step, pointsPerSide);
             var rec = StepSizeRecommender.Recommend(fit, step);
@@ -615,6 +616,8 @@ public class StepSizeRecommenderTests {
                 cappedRounds++;
                 Assert.That(rec.CappedGrowthRatio, Is.EqualTo(1.5 * pointsPerSide / 3.5).Within(1e-9),
                     "every capped round reports the same exact ratio");
+            } else if (roundTheCapReleased < 0) {
+                roundTheCapReleased = round;
             }
             if (rec.StepSize == step) {
                 break;
@@ -622,14 +625,19 @@ public class StepSizeRecommenderTests {
             step = rec.StepSize;
             seen.Add(step);
         }
-        TestContext.WriteLine("sequence: " + string.Join(" -> ", seen));
+        TestContext.WriteLine($"sequence: {string.Join(" -> ", seen)}  (cap released at round {roundTheCapReleased})");
 
         Assert.Multiple(() => {
             Assert.That(seen.Count, Is.GreaterThanOrEqualTo(3), "the session took at least three widening rounds");
             Assert.That(seen[1], Is.EqualTo(214).Within(2), "100 x 2.143 = 214.3 -- the session's first recommendation");
             Assert.That(seen[2], Is.EqualTo(459).Within(3), "214 x 2.143 = 458.6 -- the session's second");
             Assert.That(cappedRounds, Is.GreaterThan(0), "the widening rounds are the CAPPED ones");
-            Assert.That(seen.Count, Is.LessThan(12), "it terminates; the user's 'runaway' is a geometric approach");
+            // TERMINATION is "the cap stops binding", not "two consecutive integers are equal". Asserting the
+            // latter would make the test hostage to a +/-1 step oscillation from integer rounding near the fixed
+            // point -- which is not the behaviour the user complained about and not what the copy claims.
+            Assert.That(roundTheCapReleased, Is.InRange(1, 5),
+                "the geometric widening ENDS, and within a handful of runs -- that is the half of the user's " +
+                "'runaway' that is not a defect, and the half the copy is now allowed to promise");
         });
     }
 

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/StarDetection/OptimizedStarDetectionSettingsTests.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/StarDetection/OptimizedStarDetectionSettingsTests.cs
@@ -240,7 +240,7 @@ public class OptimizedStarDetectionSettingsTests {
         Assert.Multiple(() => {
             Assert.That(buildId, Is.Not.Null.And.Not.Empty);
             Assert.That(buildId, Has.Length.EqualTo(32), "an MVID formatted \"N\" -- 32 hex digits, no dashes");
-            Assert.That(buildId, Does.Not.EqualTo(new string('0', 32)),
+            Assert.That(buildId, Is.Not.EqualTo(new string('0', 32)),
                 "an all-zero MVID means deterministic builds erased the one thing this field exists to carry");
             Assert.That(detectorVersion, Is.EqualTo(StarDetector.StarDetectorVersion));
             // It reads the assembly that CONTAINS the detector, so the two values cannot describe different

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/StarDetection/OptimizedStarDetectionSettingsTests.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/StarDetection/OptimizedStarDetectionSettingsTests.cs
@@ -1,6 +1,7 @@
-using System;
+﻿using System;
 using Newtonsoft.Json;
 using NINA.Joko.Plugins.HocusFocus.Interfaces;
+using NINA.Joko.Plugins.HocusFocus.StarDetection;
 using NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization;
 using NUnit.Framework;
 
@@ -224,6 +225,66 @@ public class OptimizedStarDetectionSettingsTests {
             Assert.That(new OptimizerProvenance().ToString(), Is.EqualTo("(no provenance)"));
             Assert.That(new OptimizerProvenance { Producer = "TestApp optimize", CommandLine = "--donut" }.ToString(),
                 Is.EqualTo("TestApp optimize | --donut"));
+        });
+    }
+
+    /// <summary>
+    /// F53. <see cref="OptimizerProvenance.ProducerVersion"/> used to claim it identified the build; it cannot,
+    /// because two builds of one version share it — which is exactly how wave 8's arm X became irreproducible
+    /// from its own recorded `exe` after a later step in the same wave rebuilt that directory. The MVID is
+    /// regenerated on every build, so it is the field that answers "which build".
+    /// </summary>
+    [Test]
+    public void CurrentBuild_IdentifiesTheBUILD_AndTheDetectorContract() {
+        var (buildId, detectorVersion) = OptimizerProvenance.CurrentBuild();
+        Assert.Multiple(() => {
+            Assert.That(buildId, Is.Not.Null.And.Not.Empty);
+            Assert.That(buildId, Has.Length.EqualTo(32), "an MVID formatted \"N\" -- 32 hex digits, no dashes");
+            Assert.That(buildId, Does.Not.EqualTo(new string('0', 32)),
+                "an all-zero MVID means deterministic builds erased the one thing this field exists to carry");
+            Assert.That(detectorVersion, Is.EqualTo(StarDetector.StarDetectorVersion));
+            // It reads the assembly that CONTAINS the detector, so the two values cannot describe different
+            // builds -- the failure mode F53 is about.
+            Assert.That(OptimizerProvenance.CurrentBuild().BuildId, Is.EqualTo(buildId), "stable within a process");
+        });
+    }
+
+    /// <summary>
+    /// F55. The one-liner has to shout when a landing is not comparable to anything, and stay quiet when it is —
+    /// a warning that fires on every run is one nobody reads. Three values, never two: "unknown" is a check that
+    /// could not run, and it must not read as "we were alone".
+    /// </summary>
+    [Test]
+    public void Provenance_ToString_ShoutsAboutConcurrency_AndOnlyThen() {
+        Assert.Multiple(() => {
+            Assert.That(new OptimizerProvenance { Producer = "p", ConcurrencyCheck = "exclusive" }.ToString(),
+                Is.EqualTo("p"), "the quiet case must add nothing at all");
+            Assert.That(new OptimizerProvenance { Producer = "p", ConcurrencyCheck = "concurrent" }.ToString(),
+                Does.Contain("CONCURRENCY=CONCURRENT"));
+            Assert.That(new OptimizerProvenance { Producer = "p", ConcurrencyCheck = "unknown" }.ToString(),
+                Does.Contain("CONCURRENCY=UNKNOWN"),
+                "a check that could not run is reported, not silently treated as a pass");
+            Assert.That(new OptimizerProvenance { Producer = "p" }.ToString(), Is.EqualTo("p"),
+                "a producer that does not check at all says nothing, rather than claiming exclusivity");
+        });
+    }
+
+    [Test]
+    public void FromParams_RoundTripsTheBuildStampAndTheConcurrencyCheck() {
+        var build = OptimizerProvenance.CurrentBuild();
+        var prov = new OptimizerProvenance {
+            Producer = "TestApp optimize", BuildId = build.BuildId,
+            DetectorVersion = build.DetectorVersion, ConcurrencyCheck = "concurrent"
+        };
+        var dto = OptimizedStarDetectionSettings.FromParams(new StarDetectorParams(), 1, 0.0, 0.0, 1, 1, prov);
+        var round = JsonConvert.DeserializeObject<OptimizedStarDetectionSettings>(JsonConvert.SerializeObject(dto));
+
+        Assert.Multiple(() => {
+            Assert.That(round.Provenance.BuildId, Is.EqualTo(build.BuildId));
+            Assert.That(round.Provenance.DetectorVersion, Is.EqualTo(build.DetectorVersion));
+            // The whole point: a scorer can refuse to read this landing WITHOUT anyone having been watching
+            // while it ran, which is what wave 10's accidental double-run showed is needed.
+            Assert.That(round.Provenance.ConcurrencyCheck, Is.EqualTo("concurrent"));
         });
     }
 }

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/Utility/CvImageUtilityTests.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/Utility/CvImageUtilityTests.cs
@@ -4,6 +4,9 @@ using NINA.Joko.Plugins.HocusFocus.Utility;
 using NUnit.Framework;
 using OpenCvSharp;
 using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
 using Size = OpenCvSharp.Size;
 
 namespace NINA.Joko.Plugins.HocusFocus.Tests.Utility {
@@ -418,6 +421,64 @@ namespace NINA.Joko.Plugins.HocusFocus.Tests.Utility {
                 Assert.That(result.Sigma, Is.EqualTo(sigma).Within(0.01));
                 Assert.That(result.BackgroundMean, Is.EqualTo(mean).Within(0.01));
             });
+        }
+
+        /// <summary>
+        /// F55 — the GAIN of the kappa-sigma convergence test, measured rather than argued.
+        ///
+        /// <para><c>KappaSigmaNoiseEstimate</c> stops when <c>|sigma - lastSigma| &lt;= allowedError</c> (1e-5).
+        /// That is a THRESHOLD on a floating-point quantity, so an arbitrarily small perturbation of the input —
+        /// a different OpenCV reduction stripe count, or PR #187's ≤ 3e-8 wavelet residual — can flip it and buy
+        /// the run one more iteration. This test measures what that one iteration is WORTH: if the answer were
+        /// "less than allowedError", the flip would be harmless and F55 would have to be something else.</para>
+        ///
+        /// <para><b>It is deliberately not a search for the boundary.</b> A test that hunts for the exact input
+        /// that straddles the tolerance would be fragile and would prove less: the amplifier's existence follows
+        /// from (a) the stopping rule being a threshold, which is plain in the source, and (b) the gain measured
+        /// here. How OFTEN it fires in a real run is an empirical question the 40-second determinism probe
+        /// answers, not one a unit test should pretend to.</para>
+        /// </summary>
+        [Test]
+        public void KappaSigmaNoiseEstimate_OneExtraIteration_MovesSigmaFarMoreThanTheToleranceThatDecidesIt() {
+            const int width = 128, height = 128;
+            const float mean = 0.5f, noise = 0.05f;
+            const double allowedError = 0.00001; // the production default this test is about
+            using var mat = new Mat(new Size(width, height), MatType.CV_32F);
+            var rng = new Random(20260808);
+            unsafe {
+                var p = (float*)mat.DataPointer;
+                for (var i = 0; i < width * height; ++i) {
+                    var u1 = 1.0 - rng.NextDouble();
+                    var u2 = rng.NextDouble();
+                    var n = Math.Sqrt(-2.0 * Math.Log(u1)) * Math.Cos(2.0 * Math.PI * u2);
+                    // A few bright pixels, so the kappa-sigma clip has something to reject and the iterations
+                    // actually move -- a pure Gaussian field converges immediately and would hide the effect.
+                    var star = (i % 977 == 0) ? 0.9 : 0.0;
+                    p[i] = (float)Math.Max(0.01, mean + noise * n + star);
+                }
+            }
+
+            var perIteration = new List<double>();
+            for (var k = 1; k <= 5; k++) {
+                perIteration.Add(CvImageUtility.KappaSigmaNoiseEstimate(mat, maxIterations: k).Sigma);
+            }
+            TestContext.WriteLine("sigma by iteration cap: " + string.Join(", ",
+                perIteration.Select(s => s.ToString("G9", CultureInfo.InvariantCulture))));
+
+            // The largest single-iteration move, over the iterations the estimate actually uses.
+            var biggestStep = 0.0;
+            for (var i = 1; i < perIteration.Count; i++) {
+                biggestStep = Math.Max(biggestStep, Math.Abs(perIteration[i] - perIteration[i - 1]));
+            }
+            TestContext.WriteLine(string.Format(CultureInfo.InvariantCulture,
+                "largest one-iteration move {0:G6}; the tolerance deciding whether to take it is {1:G6}; gain x{2:F0}",
+                biggestStep, allowedError, biggestStep / allowedError));
+
+            Assert.That(biggestStep, Is.GreaterThan(100.0 * allowedError),
+                "one extra kappa-sigma iteration must move sigma by FAR more than the tolerance that decides " +
+                "whether to take it -- that gap is the amplifier F55 needs, turning a sub-ULP input difference " +
+                "into two discrete outcomes. If this ever fails, the convergence test is no longer a plausible " +
+                "F55 mechanism and the entry should say so.");
         }
 
         [Test]

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/ExposureRecommender.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/ExposureRecommender.cs
@@ -1,4 +1,4 @@
-#region "copyright"
+﻿#region "copyright"
 
 /*
     Copyright © 2021 - 2026 George Hilios <ghilios+NINA@googlemail.com>
@@ -206,20 +206,6 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization {
         public double WingRejectedFraction { get; set; } = double.NaN;
 
         /// <summary>
-        /// True when <see cref="WingRejectedFraction"/> is at or above
-        /// <see cref="ExposureRecommender.WingSheddingThreshold"/> and the gate is NOT provably inert — the
-        /// sweep's outer frames are forming candidates and losing them to the gate, which is the one signal in a
-        /// run that says a longer exposure has something to work with.
-        ///
-        /// <para><b>The F28 guard is load-bearing, not decorative.</b> An inert gate rejects nothing by
-        /// construction, so a zero rejection count there is empty rather than reassuring. <c>D16_esprit550_ha3</c>
-        /// lands <c>Sensitivity = 0</c> with an effective gate of 0.17–2.5 at every rung of its ladder, so without
-        /// this guard its zeros would read as "the wings are fine" for a reason that has nothing to do with its
-        /// wings.</para>
-        /// </summary>
-        public bool WingIsShedding { get; set; }
-
-        /// <summary>
         /// True when the run's Sensitivity gate sat at or below <see cref="InertGateBound"/> AND
         /// <see cref="GateRejectedCount"/> is 0 — the gate could not have rejected anything, so its zero rejection
         /// count is empty by construction and is NOT evidence that the star field is exhausted (F28). Always false
@@ -404,27 +390,39 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization {
         /// </summary>
         public const double WingFrameFraction = 1.0 / 3.0;
 
-        /// <summary>
-        /// The <see cref="ExposureRecommendation.WingRejectedFraction"/> at or above which the wings count as
-        /// SHEDDING. Measured on wave 7's exposure ladder, still on disk: <c>D02_rich_135mm</c> — which gains 48 %
-        /// of σ_focus from more exposure — reads 0.67 / 0.29 / 0.30 at the three rungs below its optimum and
-        /// exactly 0.00 at and above it, while <c>D16_esprit550_ha3</c>, whose σ_focus MINIMUM is at its derived
-        /// exposure, reads 0.00 at every rung but one (0.006). The gap between the two populations is two orders
-        /// of magnitude, so this threshold is not finely tuned and is not meant to be.
-        /// </summary>
-        public const double WingSheddingThreshold = 0.20;
-
-        /// <summary>
-        /// The factor to probe with when the wings are shedding. A PROBE, not a derivation, for the same reason
-        /// <see cref="StarCountProbeFactor"/> is: the run records HOW MANY candidates the gate rejected out there,
-        /// not what SNR they sat at, so there is nothing to derive a magnitude from. Fabricating one was measured
-        /// and rejected — a <c>(1/(1−f))²</c> form asked <b>1.25x</b> on <c>D16</c> at exactly the exposure where
-        /// its σ_focus is minimised, which is the control this whole statistic has to pass.
-        ///
-        /// <para>Stays inside <see cref="MaxExposureFactor"/> so the user can repeat it before the run-relative cap
-        /// binds — the converge-over-runs shape the rest of this class already uses.</para>
-        /// </summary>
-        public const double WingProbeFactor = 2.0;
+        // ── F19: THE WING VERDICT IS WITHDRAWN (wave 10) ────────────────────────────────────────────────────
+        //
+        // Wave 9 shipped WingIsShedding (fraction >= 0.20) and a 2x probe, validated on TWO datasets. Wave 10 ran
+        // the population check wave 9 recorded as still owed, over both full banks, and it fired:
+        //
+        //   * it fires on the great majority of runs, so it is a constant rather than a diagnosis;
+        //   * FOUR real-bank runs reject FEWER candidates in their WINGS than in their CORES -- LinwoodFocus 0.70,
+        //     vsn07 0.94, toml999 0.96, cwhite_2026 0.98 as a wing/inner ratio -- and every one of them fires. The
+        //     statistic cannot separate "the wings are losing faint stars a longer exposure would convert" from
+        //     "the detector rejects noise everywhere", and on the bank it measures the second;
+        //   * the threshold does NO WORK. Measured fractions are 0.000, 0.000, then 0.352-0.879 with nothing in
+        //     between, so EVERY threshold in (0, 0.352) selects the same runs. What the test actually asks is
+        //     "did the gate reject anything at all?", which is F28's question and which GateIsProvablyInert
+        //     already answers with its own field.
+        //
+        // WHY IT LOOKED RIGHT: the unit fixtures span a rejected fraction of 0.002 ("healthy wings") to 0.75
+        // ("shedding"), and 0.20 sits sensibly between them. NO REAL RUN RESEMBLES THE HEALTHY POLE. A unit test
+        // cannot notice that its fixtures span a range the data does not occupy; only a population can.
+        //
+        // WHAT IS WITHDRAWN: the VERDICT (WingIsShedding, its threshold, and the probe factor) and the three
+        // things that acted on it -- the 2x ask, the ExposureIsNotTheLimit override, and the wizard's
+        // "consider cancelling this search" advice (F52(c), which therefore returns to wave 8's position of being
+        // withheld for want of a statistic -- the same decision, made again, on better evidence).
+        //
+        // WHAT IS KEPT: WingRejectedFraction, the MEASUREMENT. It is real, it is correctly computed, and the
+        // successor is specified against it. A public bool named "is shedding" that nothing acts on would be
+        // worse than either shipping or removing it, so the boolean goes and the number stays.
+        //
+        // THE SUCCESSOR, pre-registered in the wave-10 design SS1.2a and DELIBERATELY NOT ADOPTED HERE: the
+        // wing-to-inner RATIO, which is what the claim was always about. It must clear RULE W1-W4 unchanged, plus
+        // W5 (its threshold must sit above the bank's median wing/inner ratio, or it is the same defect in a new
+        // coordinate) and W6 (it may NOT be validated on the population that refuted its predecessor). A
+        // statistic tuned on the data that killed the last one has been fitted, not tested.
 
         /// <summary>True when <paramref name="sensitivity"/> is at or below <see cref="SensitivityFloorThreshold"/> — the search-floor band described there, not merely bit-exact zero.</summary>
         public static bool SensitivityIsAtFloor(double sensitivity) => sensitivity <= SensitivityFloorThreshold;
@@ -654,19 +652,10 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization {
             // floored by the gate, and they are exactly the stars a longer exposure can convert. See
             // ExposureRecommendation.WingRejectedFraction.
             var wingRejectedFraction = WingRejectedFractionOf(metrics, isRecovery);
-            // The `!gateIsProvablyInert` conjunct is REDUNDANT BY CONSTRUCTION and is kept as an invariant, not as
-            // a working guard -- found by neutralizing it and watching no test fail. A wing fraction at or above
-            // the threshold requires a non-zero entry in the SAME FrameLowSensitivityCounts array gateRejectedCount
-            // sums, so gateIsHoldingStarsBack is already true and gateIsProvablyInert already false. It stays
-            // because it states the F28 invariant at the point that depends on it: if the fraction ever stops
-            // being computed from that array, this is the line that must still hold.
-            var wingIsShedding = wingRejectedFraction >= WingSheddingThreshold && !gateIsProvablyInert;
-
-            // A shedding wing means exposure IS the limit, whatever the accepted stars say -- so this verdict has
-            // to yield to it, or the copy would report "star brightness is not the problem" directly above a row
-            // asking for more exposure, and StarSignalCopy's F49 gate remedy would fire on a run whose actual
-            // remedy is the exposure.
-            var exposureIsNotTheLimit = signalIsSufficient && !everyFrameShort && !wingIsShedding;
+            // NO VERDICT IS DERIVED FROM IT (wave 10 -- see the withdrawal note above the constants). The fraction
+            // is reported; nothing acts on it. Wave 9's `wingIsShedding` overrode the line below, which is how a
+            // statistic that fires on most runs came to flip most users' exposure verdict.
+            var exposureIsNotTheLimit = signalIsSufficient && !everyFrameShort;
 
             // Sky-limited scaling answers the S/N question only. Under starCountIsTheLimit the ratio is <= 1, so it
             // would ask for a SHORTER exposure — backwards for a run whose problem is too few stars. That state
@@ -676,14 +665,9 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization {
             // never-shorter floor then collapses onto the current exposure -- so IncreasesExposure is false and no
             // caller can offer a longer exposure for a run that has demonstrably nothing to gain from one.
             var rawFactor = starCountIsTheLimit ? StarCountProbeFactor : ratio * ratio;
-            // The wing probe WIDENS, never replaces: max(existing, probe). That is what keeps a run the accepted-star
-            // statistic already serves from regressing -- D16_esprit550_ha3 at half its derived exposure correctly
-            // asks 3x from S_now alone, and its gate is inert out there so the wing test is silent; the probe alone
-            // would have lost that case. Both halves are load-bearing, and the pre-registered acceptance rule
-            // (wave-9 design SS3.2) fails each of them ALONE and passes only the max.
-            if (wingIsShedding) {
-                rawFactor = Math.Max(rawFactor, WingProbeFactor);
-            }
+            // The wing PROBE is withdrawn (wave 10). It raised the ask to exactly 2x on every run it fired on --
+            // the accepted-star term measured 0.000-0.30 on all of them, so max() always chose the probe -- which
+            // means the recommendation carried no information beyond "it fired".
             var rawSeconds = currentExposureSeconds * rawFactor;
 
             var factorCap = currentExposureSeconds * MaxExposureFactor;
@@ -726,8 +710,7 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization {
                 FlatRejectedCount = flatRejectedCount,
                 InertGateBound = inertGateBound,
                 GateIsProvablyInert = gateIsProvablyInert,
-                WingRejectedFraction = wingRejectedFraction,
-                WingIsShedding = wingIsShedding
+                WingRejectedFraction = wingRejectedFraction
             };
         }
 
@@ -804,8 +787,7 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization {
                 GateIsProvablyInert = false,
                 // NaN, not 0: this run produced no recommendation at all, so it did not look at its wings either,
                 // and a consumer must not read a confident zero out of that.
-                WingRejectedFraction = double.NaN,
-                WingIsShedding = false
+                WingRejectedFraction = double.NaN
             };
         }
 

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/OptimizedStarDetectionSettings.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/OptimizedStarDetectionSettings.cs
@@ -374,9 +374,45 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization {
         /// like it came from a different configuration.</summary>
         public string SettingsFingerprint { get; set; }
 
-        /// <summary>Assembly informational version of whatever produced this, so a landing also identifies the
-        /// build it came from.</summary>
+        /// <summary>Assembly informational version of whatever produced this.
+        ///
+        /// <para><b>This field does NOT identify the build, and F53 is the proof.</b> It used to claim it did.
+        /// Two builds of the same source — or of two different sources between version bumps — carry the same
+        /// informational version, so wave 8's arm X and the binary that later overwrote its `exe` directory were
+        /// indistinguishable by this field. Use <see cref="BuildId"/> for build identity.</para></summary>
         public string ProducerVersion { get; set; }
+
+        /// <summary>
+        /// The <b>build</b> that produced this: the plugin assembly's Module Version ID, which the compiler
+        /// regenerates on every build even when the source is byte-identical.
+        ///
+        /// <para><b>F53.</b> Wave 8's arm X was recorded with <c>Reproduce: D:\hf_w8\armX\arm_x.sh</c>, and
+        /// running that script on that binary today does not reproduce its numbers, because a later step in the
+        /// same wave rebuilt the directory and an artifact directory keeps only the LAST build. Identifying that
+        /// took reading the log for the ABSENCE of an unrelated line. With this field it is a diff. The entry's
+        /// durable lesson — <i>a "Reproduce:" line names a COMMAND, not a result</i> — is not repealed by
+        /// stamping the build; what is repealed is having to infer the build from its side effects.</para>
+        /// </summary>
+        public string BuildId { get; set; }
+
+        /// <summary>
+        /// <c>StarDetector.StarDetectorVersion</c> at the time of the run — the detector's OUTPUT contract.
+        ///
+        /// <para>Wave 10 exists because wave 9 measured everything on version 1 and <c>develop</c> then shipped
+        /// version 2 (PR #187's <c>AtrousWaveletFast</c>: equivalent to ≤ 3e-8, deliberately not bit-identical).
+        /// Every wave-9 number carries a hand-written provenance banner for want of this field. A reader diffs a
+        /// field; nobody diffs a banner — the same argument that gave F39(a) its <c>DetectionBinningSource</c>.</para>
+        /// </summary>
+        public int? DetectorVersion { get; set; }
+
+        /// <summary>
+        /// The identity of the currently-loaded plugin build: <see cref="BuildId"/> and
+        /// <see cref="DetectorVersion"/>, read off this assembly. Static so the harness and the shipping wizard
+        /// stamp the same two values from the same place rather than each deriving its own.
+        /// </summary>
+        public static (string BuildId, int DetectorVersion) CurrentBuild() => (
+            typeof(OptimizerProvenance).Assembly.ManifestModule.ModuleVersionId.ToString("N"),
+            StarDetector.StarDetectorVersion);
 
         public OptimizerProvenance Clone() => (OptimizerProvenance)MemberwiseClone();
 
@@ -385,6 +421,8 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization {
             var parts = new System.Collections.Generic.List<string>();
             if (!string.IsNullOrWhiteSpace(Producer)) { parts.Add(Producer); }
             if (!string.IsNullOrWhiteSpace(ProducerVersion)) { parts.Add($"v{ProducerVersion}"); }
+            if (!string.IsNullOrWhiteSpace(BuildId)) { parts.Add($"build#{BuildId}"); }
+            if (DetectorVersion.HasValue) { parts.Add($"detector v{DetectorVersion.Value}"); }
             if (!string.IsNullOrWhiteSpace(CommandLine)) { parts.Add(CommandLine); }
             if (!string.IsNullOrWhiteSpace(SettingsFingerprint)) { parts.Add($"settings#{SettingsFingerprint}"); }
             return parts.Count > 0 ? string.Join(" | ", parts) : "(no provenance)";

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/OptimizedStarDetectionSettings.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/OptimizedStarDetectionSettings.cs
@@ -406,6 +406,25 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization {
         public int? DetectorVersion { get; set; }
 
         /// <summary>
+        /// Whether this run had the machine to itself: <c>"exclusive"</c>, <c>"concurrent"</c>, or
+        /// <c>"unknown"</c>. Null when the producer does not check.
+        ///
+        /// <para><b>F55.</b> Concurrent `optimize` processes move **44 % of landings** and 15 % of seed
+        /// evaluations, so an arm read on landings is invalid if it ran beside another one. F55(c) asks for that
+        /// to be "said in the run instructions" — and wave 10 then ran a 39-run pass TWICE AT ONCE anyway,
+        /// because a background launcher that reported "completed" had only had its launcher shell exit. The
+        /// rule was known, written down, and still violated, because **the violation was invisible**. A field on
+        /// the landing makes it visible after the fact, to a scorer, without anyone having to have been
+        /// watching.</para>
+        ///
+        /// <para><b>Three values, not two</b>, for the same reason
+        /// <c>ExposureRecommendation.WingRejectedFraction</c> is NaN-never-0 and
+        /// <c>StepSizeRecommendation.MaxUsefulHalfSpan</c> is NaN-never-0: *"we could not look"* and *"we looked
+        /// and were alone"* must not be the same value, because a scorer turns one of them into a verdict.</para>
+        /// </summary>
+        public string ConcurrencyCheck { get; set; }
+
+        /// <summary>
         /// The identity of the currently-loaded plugin build: <see cref="BuildId"/> and
         /// <see cref="DetectorVersion"/>, read off this assembly. Static so the harness and the shipping wizard
         /// stamp the same two values from the same place rather than each deriving its own.
@@ -423,6 +442,11 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization {
             if (!string.IsNullOrWhiteSpace(ProducerVersion)) { parts.Add($"v{ProducerVersion}"); }
             if (!string.IsNullOrWhiteSpace(BuildId)) { parts.Add($"build#{BuildId}"); }
             if (DetectorVersion.HasValue) { parts.Add($"detector v{DetectorVersion.Value}"); }
+            // Loud in the one-liner rather than tucked into the JSON: "concurrent" means the landing beside it
+            // is not comparable to anything (F55), and that has to be readable in a log tail.
+            if (!string.IsNullOrWhiteSpace(ConcurrencyCheck) && ConcurrencyCheck != "exclusive") {
+                parts.Add($"CONCURRENCY={ConcurrencyCheck.ToUpperInvariant()}");
+            }
             if (!string.IsNullOrWhiteSpace(CommandLine)) { parts.Add(CommandLine); }
             if (!string.IsNullOrWhiteSpace(SettingsFingerprint)) { parts.Add($"settings#{SettingsFingerprint}"); }
             return parts.Count > 0 ? string.Join(" | ", parts) : "(no provenance)";

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/OptimizedStarDetectionSettings.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/OptimizedStarDetectionSettings.cs
@@ -1,4 +1,4 @@
-#region "copyright"
+﻿#region "copyright"
 
 /*
     Copyright © 2021 - 2026 George Hilios <ghilios+NINA@googlemail.com>
@@ -425,6 +425,23 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization {
         public string ConcurrencyCheck { get; set; }
 
         /// <summary>
+        /// The NINA profile the run was loaded under, as <c>"name (id)"</c>. Null when the producer does not
+        /// record it.
+        ///
+        /// <para><b>F57.</b> <c>--settings</c> pins the DETECTOR knobs, and this project treated that as pinning
+        /// the arm. It does not: the harness also loads whichever profile is ACTIVE, and wave 10 measured that
+        /// moving <c>BaselineJ</c> — the objective of a fixed seed on fixed frames, with no search — by
+        /// <b>0.0144</b> on <c>toml999</c>, which is larger than the entire Δ<c>J</c> any wave has argued about.
+        /// It was found only because a control pre-registered for a different hypothesis refuted that
+        /// hypothesis and left the profile as the last surviving difference.</para>
+        ///
+        /// <para>F42 predicted this in words — <i>"TryLoad("") picks whichever profile is ACTIVE"</i> — and the
+        /// remedy it prompted (pin the detector settings) did not close it. A field closes it: a reader diffs a
+        /// field, and nobody diffs a prediction.</para>
+        /// </summary>
+        public string ProfileId { get; set; }
+
+        /// <summary>
         /// The identity of the currently-loaded plugin build: <see cref="BuildId"/> and
         /// <see cref="DetectorVersion"/>, read off this assembly. Static so the harness and the shipping wizard
         /// stamp the same two values from the same place rather than each deriving its own.
@@ -447,6 +464,7 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization {
             if (!string.IsNullOrWhiteSpace(ConcurrencyCheck) && ConcurrencyCheck != "exclusive") {
                 parts.Add($"CONCURRENCY={ConcurrencyCheck.ToUpperInvariant()}");
             }
+            if (!string.IsNullOrWhiteSpace(ProfileId)) { parts.Add($"profile {ProfileId}"); }
             if (!string.IsNullOrWhiteSpace(CommandLine)) { parts.Add(CommandLine); }
             if (!string.IsNullOrWhiteSpace(SettingsFingerprint)) { parts.Add($"settings#{SettingsFingerprint}"); }
             return parts.Count > 0 ? string.Join(" | ", parts) : "(no provenance)";

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/StarDetectionOptimizerWizardVM.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/StarDetectionOptimizerWizardVM.cs
@@ -293,11 +293,51 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization {
         /// <see cref="StepSizeRecommender.MaxHalfWidthSampledHalfSpanMultiple"/>).</summary>
         public bool StepSizeWasCapped { get; set; }
 
+        /// <summary>The HFR dynamic range this sweep MEASURED (max/min), or NaN — see
+        /// <see cref="StepSizeRecommendation.SampledHfrRange"/>.</summary>
+        public double StepSizeSampledHfrRange { get; set; } = double.NaN;
+
+        /// <summary>The exact factor the next capped run will multiply the step by, or NaN — see
+        /// <see cref="StepSizeRecommendation.CappedGrowthRatio"/>.</summary>
+        public double StepSizeCappedGrowthRatio { get; set; } = double.NaN;
+
         /// <summary>Plain-language step-size readout: "{current} → {recommended}" when changed, else
-        /// "{recommended} (unchanged)", with a capped note when the sweep could not support the full move.</summary>
-        public string StepSizeText => StepSizeWasCapped
-            ? FormatRecommendation(CurrentStepSize, RecommendedStepSize) + " (capped by this sweep's width; re-run auto-focus to refine)"
-            : FormatRecommendation(CurrentStepSize, RecommendedStepSize);
+        /// "{recommended} (unchanged)", with a capped note when the sweep could not support the full move.
+        ///
+        /// <para><b>F49(c).</b> The old note said only "capped by this sweep's width; re-run auto-focus to
+        /// refine". A field session took that instruction four times — 100 → 214 → 459 → 474 → 482, at 30–120
+        /// minutes a run — and experienced it as a runaway, because nothing on the page said what the number was
+        /// converging TOWARD, that the cap makes this a deliberate partial step, or that it terminates. It does
+        /// terminate, geometrically: while the cap binds each run multiplies the step by exactly
+        /// <see cref="StepSizeRecommendation.CappedGrowthRatio"/> until the sweep reaches
+        /// <see cref="StepSizeRecommender.HfrThresholdMultiple"/>x the minimum HFR, and then the cap stops
+        /// binding. That last session's runs 3 and 4 asked +3 % and +5 %, i.e. it HAD converged.</para>
+        ///
+        /// <para><b>What is quoted and what is not.</b> The sampled range and the growth ratio are both
+        /// MEASURED — the first from the sweep's own HFRs, the second from the algorithm's arithmetic — and each
+        /// clause is dropped when its quantity is unavailable rather than filled with a guess. A projected run
+        /// COUNT is deliberately not offered: it would have to be computed from the extrapolated half-width,
+        /// which is the one quantity the cap exists to distrust.</para></summary>
+        public string StepSizeText {
+            get {
+                var baseText = FormatRecommendation(CurrentStepSize, RecommendedStepSize);
+                if (!StepSizeWasCapped) {
+                    return baseText;
+                }
+                var parts = new System.Collections.Generic.List<string>();
+                if (double.IsFinite(StepSizeSampledHfrRange) && StepSizeSampledHfrRange > 0.0) {
+                    parts.Add($"this sweep reaches {StepSizeSampledHfrRange:F1}× its minimum HFR and the step is " +
+                              $"sized from where HFR reaches {StepSizeRecommender.HfrThresholdMultiple:F0}×");
+                } else {
+                    parts.Add($"this sweep is too narrow to contain the {StepSizeRecommender.HfrThresholdMultiple:F0}× " +
+                              "minimum-HFR band the step is sized from");
+                }
+                if (double.IsFinite(StepSizeCappedGrowthRatio) && StepSizeCappedGrowthRatio > 1.0) {
+                    parts.Add($"each run widens by about {StepSizeCappedGrowthRatio:F1}× until it gets there");
+                }
+                return baseText + " (partial step: " + string.Join("; ", parts) + "; re-run auto-focus to refine)";
+            }
+        }
 
         /// <summary>Plain-language offset-steps readout (same before→after / "(unchanged)" convention).</summary>
         public string OffsetStepsText => FormatRecommendation(CurrentOffsetSteps, RecommendedOffsetSteps);
@@ -3876,6 +3916,8 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization {
                 RecommendedStepSize = recommendation.StepSize,
                 RecommendedOffsetSteps = recommendation.OffsetSteps,
                 StepSizeWasCapped = recommendation.WasCapped,
+                StepSizeSampledHfrRange = recommendation.SampledHfrRange,
+                StepSizeCappedGrowthRatio = recommendation.CappedGrowthRatio,
                 CurrentStepSize = currentStepSize,
                 CurrentOffsetSteps = currentOffsetSteps,
                 ImprovedOverSeed = res.ImprovedOverSeed,

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/StarDetectionOptimizerWizardVM.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/StarDetectionOptimizerWizardVM.cs
@@ -3541,8 +3541,12 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization {
         /// precisely the users who most need a longer exposure that theirs is already fine"*: on the reporting
         /// user's own rig that statistic read <b>S/N 1438.6 against a target of 10</b>. The separation wave 8 drew
         /// is kept exactly: <b>facts about COST need no new statistic and are already shown; ADVICE needs
-        /// one</b>. It is now built on <see cref="ExposureRecommendation.WingIsShedding"/>, which measures the
-        /// population the gate did NOT admit.</para>
+        /// one</b>.</para>
+        ///
+        /// <para><b>WITHDRAWN in wave 10, and currently always empty.</b> Wave 9 built it on
+        /// <c>ExposureRecommendation.WingIsShedding</c>; wave 10's full-bank population check refuted that
+        /// statistic and removed the verdict, so this advice is withheld again for exactly the reason wave 8
+        /// withheld it. See <see cref="BuildSearchExposureAdvice"/> for the measurement and the successor.</para>
         ///
         /// <para><b>It names Cancel, which exists</b> — the house rule at
         /// <see cref="ShowOptimizeAgainAtRecommendedBinning"/>: never describe an action whose control is hidden.
@@ -3576,26 +3580,27 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization {
         /// </summary>
         internal static string BuildSearchExposureAdvice(
                 IReadOnlyList<RunEvaluationMetrics> seedMetrics, StarDetectorParams seedParams, double currentExposureSeconds) {
-            if (seedMetrics == null || seedMetrics.Count == 0) {
+            // ── F52(c) IS WITHHELD AGAIN (wave 10) ──────────────────────────────────────────────────────────
+            //
+            // Wave 8 refused to ship this advice for want of a statistic. Wave 9 shipped it on
+            // ExposureRecommendation.WingIsShedding. Wave 10's full-bank population check refuted that statistic
+            // and withdrew the verdict (see the withdrawal note in ExposureRecommender), so this returns to
+            // wave 8's position for wave 8's reason -- the same decision, made again, on better evidence.
+            //
+            // WHY THIS MATTERED MORE THAN THE EXPOSURE NUMBER. This advice tells the user to CANCEL a running
+            // two-hour optimization, and it is computed from the SEED evaluation, i.e. in the first minute. The
+            // statistic behind it fired on the great majority of bank runs, so the shipped behaviour was to
+            // advise most users to abandon their search before it had done anything. A note that always fires
+            // says nothing; one that always fires AND costs the user their run is worse than nothing.
+            //
+            // The method, its call sites and its tests are kept rather than deleted: the successor statistic
+            // (the wing-to-inner RATIO, pre-registered in the wave-10 design SS1.2a) re-enables this by changing
+            // the condition below and nothing else. Returning empty is a WITHDRAWAL, not a removal.
+            if (seedMetrics == null || seedMetrics.Count == 0 || !(currentExposureSeconds > 0.0)) {
                 return string.Empty;
             }
-            var worstFraction = double.NaN;
-            foreach (var m in seedMetrics) {
-                var rec = ExposureRecommender.Recommend(m, new ObjectiveConstants(), currentExposureSeconds, seedParams);
-                if (!rec.WingIsShedding) {
-                    continue;
-                }
-                if (!double.IsFinite(worstFraction) || rec.WingRejectedFraction > worstFraction) {
-                    worstFraction = rec.WingRejectedFraction;
-                }
-            }
-            if (!double.IsFinite(worstFraction)) {
-                return string.Empty;
-            }
-            return $"The outer frames of this sweep are losing {worstFraction:P0} of the stars they find to the "
-                + "brightness gate, so a longer exposure is likely to help this focus more than a longer search will. "
-                + "Cancel stops the search only: nothing is written to your profile, and the frames already captured "
-                + "stay on disk.";
+            _ = seedParams; // retained: the successor's condition needs it, exactly as the withdrawn one did
+            return string.Empty;
         }
 
         private void UpdateSearchExposureAdvice(IReadOnlyList<RunEvaluationMetrics> seedMetrics, StarDetectorParams seedParams) {

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/StepSizeRecommender.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/StepSizeRecommender.cs
@@ -64,6 +64,44 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization {
         /// "narrowed to what your rig can still see" rather than presenting a smaller number with no reason.
         /// </summary>
         public bool WasDetectBounded { get; set; }
+
+        /// <summary>
+        /// The HFR dynamic range this sweep actually MEASURED: max(HFR) / min(HFR) over the fitted points.
+        /// <see cref="double.NaN"/> when it cannot be measured (no outputs, or a non-positive minimum).
+        ///
+        /// <para><b>F49(c) — why this number and not the half-width.</b> The step is sized from the offset at
+        /// which HFR reaches <see cref="StepSizeRecommender.HfrThresholdMultiple"/>x its minimum. When a sweep
+        /// never gets there, that offset is read off the fitted model well outside the data, and
+        /// <see cref="WasCapped"/> is the recommender declining to trust it. This quantity says the same thing
+        /// DIRECTLY and from measurement alone: a sweep whose ends reach 1.9x the minimum did not sample the
+        /// band, full stop, and no extrapolation is involved in saying so. The field session behind F49/F51 ran
+        /// 1.9 -> 3.5 px, i.e. 1.8x, and was told to widen on all four runs.</para>
+        /// </summary>
+        public double SampledHfrRange { get; set; } = double.NaN;
+
+        /// <summary>
+        /// True when the sweep measured HFR out to <see cref="StepSizeRecommender.HfrThresholdMultiple"/>x its
+        /// minimum, i.e. the band the step is sized from was actually sampled rather than extrapolated to.
+        /// False when <see cref="SampledHfrRange"/> is NaN: an unmeasurable range is not a reached band.
+        /// </summary>
+        public bool ReachedHfrBand => SampledHfrRange >= StepSizeRecommender.HfrThresholdMultiple;
+
+        /// <summary>
+        /// The EXACT factor by which the next capped run will multiply this recommendation, or
+        /// <see cref="double.NaN"/> when <see cref="WasCapped"/> is false or it cannot be derived.
+        ///
+        /// <para><b>It is a property of the ALGORITHM, not of the fit.</b> While the cap binds,
+        /// <c>halfWidth = 1.5 · ½ · span</c> and <c>span = 2·P·step</c> for P points per side, so
+        /// <c>step' = (1.5·P / PointsPerSide) · step</c> — 1.714x at 4 offset steps, 2.143x at 4 offset + 1
+        /// recovery. Nothing in it depends on the extrapolated half-width the cap exists to distrust, which is
+        /// precisely why this is quotable to a user and a projected run count is not.</para>
+        ///
+        /// <para><b>Measured, not only derived.</b> Wave 7's F18 control arm has 22 capped rounds across six
+        /// datasets on disk, and every one of them lands at 1.667–1.750 (the scatter is integer rounding of the
+        /// step). The field session behind F49/F51 ran 100 → 214 → 459 at P = 5: 100 × 2.143 = 214.3, and
+        /// 214 × 2.143 = 458.6.</para>
+        /// </summary>
+        public double CappedGrowthRatio { get; set; } = double.NaN;
     }
 
     /// <summary>
@@ -110,8 +148,12 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization {
     /// and the step is W / 3.5 (so the band holds ~3-4 points per side).
     /// </summary>
     public static class StepSizeRecommender {
-        // The focus-sensitive band runs from the minimum HFR up to this multiple of it; its half-width sets the step.
-        private const double HfrThresholdMultiple = 3.0;
+        /// <summary>
+        /// The focus-sensitive band runs from the minimum HFR up to this multiple of it; its half-width sets the
+        /// step. PUBLIC because it is the number a capped recommendation is converging TOWARD, and F49(c) asks
+        /// for that to be said out loud rather than left as an internal constant.
+        /// </summary>
+        public const double HfrThresholdMultiple = 3.0;
 
         // Targeted points per side within the focus-sensitive band [x0, x0 + W]: W / PointsPerSide steps.
         private const double PointsPerSide = 3.5;
@@ -238,7 +280,8 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization {
                 }
             }
 
-            var step = (int)Math.Round(halfWidth / ResolvePointsPerSide(detectability, sizeForExecutedSweep), MidpointRounding.AwayFromZero);
+            var pointsPerSide = ResolvePointsPerSide(detectability, sizeForExecutedSweep);
+            var step = (int)Math.Round(halfWidth / pointsPerSide, MidpointRounding.AwayFromZero);
             step = ClampStep(step, focuserMaxStep);
 
             return new StepSizeRecommendation {
@@ -248,8 +291,52 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization {
                 WasCapped = wasCapped,
                 DetectHalfWidth = detectHalfWidth,
                 MaxUsefulHalfSpan = maxUsefulHalfSpan,
-                WasDetectBounded = wasDetectBounded
+                WasDetectBounded = wasDetectBounded,
+                SampledHfrRange = MeasureSampledHfrRange(bestFit),
+                CappedGrowthRatio = wasCapped ? CappedGrowthRatioOf(searchSpan, currentStepSize, pointsPerSide) : double.NaN
             };
+        }
+
+        /// <summary>
+        /// max(HFR) / min(HFR) over the points the fit was given, or NaN when that cannot be formed.
+        /// See <see cref="StepSizeRecommendation.SampledHfrRange"/> for why this is the honest companion to
+        /// <see cref="StepSizeRecommendation.WasCapped"/>.
+        /// </summary>
+        private static double MeasureSampledHfrRange(AlglibHyperbolicFitting bestFit) {
+            var outputs = bestFit.Outputs;
+            if (outputs == null || outputs.Length == 0) {
+                return double.NaN;
+            }
+            double lo = double.PositiveInfinity, hi = double.NegativeInfinity;
+            foreach (var y in outputs) {
+                if (double.IsNaN(y) || double.IsInfinity(y) || y <= 0.0) {
+                    return double.NaN; // a non-positive or non-finite HFR makes the ratio meaningless, not zero
+                }
+                if (y < lo) lo = y;
+                if (y > hi) hi = y;
+            }
+            return lo > 0.0 ? hi / lo : double.NaN;
+        }
+
+        /// <summary>
+        /// The exact multiplier the NEXT capped run will apply — <c>MaxHalfWidthSampledHalfSpanMultiple · P /
+        /// pointsPerSide</c>, with P (points per side actually executed) read back off the sweep as
+        /// <c>½·span / currentStepSize</c> rather than assumed.
+        ///
+        /// <para>Reading P back off the sweep is what makes this correct for the run in hand instead of for a
+        /// default configuration: the field session behind F49/F51 executed 4 offset + 1 recovery step per side,
+        /// so its P was 5 and its ratio 2.143 — not the 1.714 a 4-offset sweep gives. Both appear in the
+        /// evidence, and a single hard-coded constant would have been wrong on one of them.</para>
+        /// </summary>
+        private static double CappedGrowthRatioOf(double searchSpan, int currentStepSize, double pointsPerSide) {
+            if (!(searchSpan > 0.0) || currentStepSize < 1 || !(pointsPerSide > 0.0)) {
+                return double.NaN;
+            }
+            var executedPointsPerSide = 0.5 * searchSpan / currentStepSize;
+            if (!(executedPointsPerSide > 0.0)) {
+                return double.NaN;
+            }
+            return MaxHalfWidthSampledHalfSpanMultiple * executedPointsPerSide / pointsPerSide;
         }
 
         /// <summary>

--- a/Joko.NINA.Plugins/TestApp/OptimizationDiagnosticRunner.cs
+++ b/Joko.NINA.Plugins/TestApp/OptimizationDiagnosticRunner.cs
@@ -1,4 +1,4 @@
-#region "copyright"
+﻿#region "copyright"
 
 /*
     Copyright © 2021 - 2026 George Hilios <ghilios+NINA@googlemail.com>
@@ -275,7 +275,10 @@ namespace TestApp {
                     System.Reflection.Assembly.GetEntryAssembly()))?.InformationalVersion,
                 BuildId = build.BuildId,
                 DetectorVersion = build.DetectorVersion,
-                ConcurrencyCheck = ClaimExclusiveOptimize()
+                ConcurrencyCheck = ClaimExclusiveOptimize(),
+                // F57: --settings pins the detector knobs and NOT the arm. The active profile moves BaselineJ by
+                // 0.0144 on toml999, so which profile ran is part of a landing's identity.
+                ProfileId = $"{activeProfile.Name} ({activeProfile.Id})"
             };
             Console.WriteLine($"provenance: {provenance}");
             if (provenance.ConcurrencyCheck != "exclusive") {

--- a/Joko.NINA.Plugins/TestApp/OptimizationDiagnosticRunner.cs
+++ b/Joko.NINA.Plugins/TestApp/OptimizationDiagnosticRunner.cs
@@ -53,6 +53,36 @@ namespace TestApp {
         // Run discovery (attempt-anchored, >=3-position guard) lives in the pure, unit-testable
         // OptimizationRunDiscovery helper. Frame matching uses its ImageFileRegex (kept as the single copy).
 
+        /// <summary>
+        /// Held for the process lifetime once claimed, so a second `optimize` sees it. Never released
+        /// explicitly: process exit releases it, and an abandoned mutex is what the next process wants to see.
+        /// </summary>
+        private static Mutex exclusiveOptimizeMutex;
+
+        /// <summary>
+        /// F55 — is this process alone? Returns <c>"exclusive"</c>, <c>"concurrent"</c> or <c>"unknown"</c>, and
+        /// the third value is not a formality: a check that cannot run must not report the same thing as a check
+        /// that ran and found nothing, because a scorer turns one of them into "this arm is readable".
+        ///
+        /// <para>A named mutex rather than a process-name scan: it does not care what the binary is called, it
+        /// costs nothing, and an ABANDONED mutex — the previous holder died without exiting cleanly — correctly
+        /// reads as "the machine is mine now" rather than as contention.</para>
+        /// </summary>
+        private static string ClaimExclusiveOptimize() {
+            try {
+                exclusiveOptimizeMutex = new Mutex(false, @"Global\NINA.Joko.HocusFocus.TestApp.Optimize");
+                try {
+                    return exclusiveOptimizeMutex.WaitOne(0) ? "exclusive" : "concurrent";
+                } catch (AbandonedMutexException) {
+                    return "exclusive"; // the previous holder died; the wait succeeded and this process owns it
+                }
+            } catch (Exception ex) {
+                // Unsupported platform, denied Global\ namespace, anything else -- say so rather than guess.
+                Logger.Debug($"Could not perform the F55 concurrency check: {ex.Message}");
+                return "unknown";
+            }
+        }
+
         public static async Task Run(string[] args) {
             try {
                 await RunImpl(args);
@@ -244,9 +274,15 @@ namespace TestApp {
                 ProducerVersion = (System.Reflection.CustomAttributeExtensions.GetCustomAttribute<System.Reflection.AssemblyInformationalVersionAttribute>(
                     System.Reflection.Assembly.GetEntryAssembly()))?.InformationalVersion,
                 BuildId = build.BuildId,
-                DetectorVersion = build.DetectorVersion
+                DetectorVersion = build.DetectorVersion,
+                ConcurrencyCheck = ClaimExclusiveOptimize()
             };
             Console.WriteLine($"provenance: {provenance}");
+            if (provenance.ConcurrencyCheck != "exclusive") {
+                Console.WriteLine($"WARNING: concurrency check = {provenance.ConcurrencyCheck}. F55: concurrent " +
+                    "`optimize` moves 44% of LANDINGS and 15% of seed evaluations, so any arm read on landings " +
+                    "is INVALID. The value is recorded in every landing this run writes.");
+            }
             var accessor = harnessSettings.Accessor;
             var starDetectionOptions = new StarDetectionOptions(profileService, accessor);
             var afOptions = new AutoFocusOptions(profileService);

--- a/Joko.NINA.Plugins/TestApp/OptimizationDiagnosticRunner.cs
+++ b/Joko.NINA.Plugins/TestApp/OptimizationDiagnosticRunner.cs
@@ -231,12 +231,20 @@ namespace TestApp {
             // back into each run's own folder (F15) leaves a bank holding whichever prepass went last, and the
             // only way to tell two arms apart is to INFER the arm from a knob — an inference that broke the moment
             // F23 wave 1 ran three arms differing by more than one flag.
+            // F53: the BUILD, not just the version. `ProducerVersion` cannot tell two builds of one version
+            // apart, which is exactly how wave 8's arm X came to be irreproducible from its own recorded `exe`
+            // -- a later step in the same wave rebuilt that directory and nothing recorded it. The MVID changes
+            // on every build; the detector version says which OUTPUT contract produced the numbers (wave 9's
+            // whole results doc needed a hand-written banner for want of it).
+            var build = OptimizerProvenance.CurrentBuild();
             var provenance = new OptimizerProvenance {
                 Producer = "TestApp optimize",
                 CommandLine = string.Join(" ", args ?? Array.Empty<string>()),
                 SettingsFingerprint = HarnessSettingsStore.Fingerprint(harnessSettings),
                 ProducerVersion = (System.Reflection.CustomAttributeExtensions.GetCustomAttribute<System.Reflection.AssemblyInformationalVersionAttribute>(
-                    System.Reflection.Assembly.GetEntryAssembly()))?.InformationalVersion
+                    System.Reflection.Assembly.GetEntryAssembly()))?.InformationalVersion,
+                BuildId = build.BuildId,
+                DetectorVersion = build.DetectorVersion
             };
             Console.WriteLine($"provenance: {provenance}");
             var accessor = harnessSettings.Accessor;

--- a/Joko.NINA.Plugins/TestApp/SynthValidateRunner.cs
+++ b/Joko.NINA.Plugins/TestApp/SynthValidateRunner.cs
@@ -778,7 +778,8 @@ namespace TestApp.SynthBank {
             round.StepRecommendation = new StepRecommendationSnapshot {
                 StepSize = stepRec.StepSize, OffsetSteps = stepRec.OffsetSteps, HalfWidth = stepRec.HalfWidth, WasCapped = stepRec.WasCapped,
                 DetectHalfWidth = stepRec.DetectHalfWidth, MaxUsefulHalfSpan = stepRec.MaxUsefulHalfSpan,
-                WasDetectBounded = stepRec.WasDetectBounded
+                WasDetectBounded = stepRec.WasDetectBounded,
+                SampledHfrRange = stepRec.SampledHfrRange, CappedGrowthRatio = stepRec.CappedGrowthRatio
             };
 
             // Gated EXACTLY as OptimizationDiagnosticRunner.BuildAggregateRow gates it: only when the landed

--- a/Joko.NINA.Plugins/TestApp/SynthValidationReport.cs
+++ b/Joko.NINA.Plugins/TestApp/SynthValidationReport.cs
@@ -1,4 +1,4 @@
-#region "copyright"
+﻿#region "copyright"
 
 /*
     Copyright © 2021 - 2026 George Hilios <ghilios+NINA@googlemail.com>
@@ -75,6 +75,13 @@ namespace TestApp.SynthBank {
         [JsonProperty("detectHalfWidth")] public double DetectHalfWidth { get; set; } = double.NaN;
         [JsonProperty("maxUsefulHalfSpan")] public double MaxUsefulHalfSpan { get; set; } = double.NaN;
         [JsonProperty("wasDetectBounded")] public bool WasDetectBounded { get; set; }
+
+        // F49(c)/F51. The two quantities a CAPPED recommendation can honestly say about itself: what the sweep
+        // actually MEASURED, and the exact factor the next capped run will apply. Recorded here so the bank can
+        // score the copy's claims instead of taking them on faith -- in particular so the geometric widening
+        // ratio can be checked against every capped round rather than against the field session's three.
+        [JsonProperty("sampledHfrRange")] public double SampledHfrRange { get; set; } = double.NaN;
+        [JsonProperty("cappedGrowthRatio")] public double CappedGrowthRatio { get; set; } = double.NaN;
     }
 
     /// <summary>design step 4b: <see cref="NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization.ExposureRecommender"/>,

--- a/docs/followups.md
+++ b/docs/followups.md
@@ -3398,12 +3398,22 @@ admitted or rejected, and from there into `J`. Any future change justified by "e
 inherits this: **the bound belongs on the quantity the product reports, not on the intermediate**, and the
 eight-run gate is the cheap way to measure it (≈ 40 minutes).
 
-**Confound, and how it is settled.** `BaselineJ` is read on folders a previous arm wrote into
-([F15](#f15--optimize---per-run-overwrites-each-runs-stored-settings)), so the binary is not the only thing that
-differs between the two measurements. `harness_settings.json` is excluded outright (`toml999`'s is dated
-2026-07-31, before wave 8). `optimized_settings.json` is not, and F55's own investigation measured it inert only
-on `D16`/v1. The control is to run `toml999` on wave 9's v1 binary against TODAY's folder state: same folder,
-different binary. **Until that reports, the seed-evaluation half of this entry is held open.**
+**Two confounds, and how each is settled.**
+
+1. **Folder state.** `BaselineJ` is read on folders a previous arm wrote into
+   ([F15](#f15--optimize---per-run-overwrites-each-runs-stored-settings)), so the binary is not the only thing
+   that differs. `harness_settings.json` is excluded outright (`toml999`'s is dated 2026-07-31, before wave 8);
+   `optimized_settings.json` is not, and F55's investigation measured it inert only on `D16`/v1. The control is
+   to run `toml999` on wave 9's v1 binary against TODAY's folder state — same folder, different binary.
+2. **"The binary" is not yet "the wavelet".** `D:\hf_w9\exe`'s dll is stamped 2026-08-06 19:40 and several
+   wave-9 commits post-date it, so the two exes differ by PR #187 *plus* some wave-9 code. Those additions are
+   all post-search or UI (wave 9 verified the wing statistic is computed after the search and is inert on it),
+   which makes PR #187 the only plausible search-relevant term — **and plausible is not measured.** A bisect
+   build of the wave-10 tree with `StarDetector.cs`'s two call sites reverted to the legacy dense path isolates
+   the wavelet from everything else.
+
+**Until both report, this entry attributes to THE BINARY, not to the wavelet, and the seed-evaluation half is
+held open.**
 
 **Next step.** (a) Run the cross-build control above and close or re-open the seed half. (b) Adopt the eight-run
 gate as the standing acceptance check for any detector change claiming numerical equivalence — it is the

--- a/docs/followups.md
+++ b/docs/followups.md
@@ -3667,6 +3667,40 @@ eight are one instrument"*, and it is applied as written: **no φ verdict is pub
 > per-iteration data race and does fit some process-level state (a warm-up path, a static initialised from
 > observed load, a JIT/tiering effect, or something else acquired once).
 >
+> ### (b) NARROWED 2026-08-08 (wave 10): the BUILD does not select the attractor
+>
+> Wave 9's sharpest open clue was that the "sequential" value had been seen at BOTH attractors across sessions,
+> with five consecutive repeats at one of them **"from one build"** — raising the possibility that part of what
+> this entry calls nondeterminism is build-to-build variation. **It is not.** Fifteen runs — five each on wave
+> 9's binary, wave 10's, and a wavelet-bisect build, interleaved in one session on identical folder copies —
+> returned `0.9834767969`, identical to ten decimal places. Two binaries a wave apart agree exactly.
+>
+> **And the seed evaluation is a pure function of (frames, settings, PROFILE).** Under a fixed profile it is
+> perfectly reproducible across binaries, folder states and sessions; the profile term is
+> [F57](#f57--a---settings-pinned-arm-is-not-pinned-the-active-nina-profile-moves-baselinej-by-0014-and-every-cross-wave-comparison-inherits-it),
+> and it explains the cross-SESSION observation wave 9 could not place. **What remains is only the behaviour
+> under CONCURRENCY**, which none of these controls touch — so this entry is narrower and no less real.
+>
+> ### The specific mechanism, named and half-measured
+>
+> `CvImageUtility.KappaSigmaNoiseEstimate` is a **bimodal amplifier by construction**: an OpenCV parallel
+> reduction (`Cv2.MeanStdDev`) feeds a convergence test at `|Δσ| ≤ 1e-5`, so an arbitrarily small change in σ can
+> flip the comparison, buy one more iteration, and move `threshold` — and therefore σ — macroscopically. Two
+> discrete outcomes from an infinitesimal perturbation, load-sensitive (OpenCV's pool sees machine load), stable
+> within a process, and invisible to the plugin's own `Parallel.For` degree, which wave 9 swept and found inert.
+> σ feeds noise clipping ⇒ the star gate ⇒ the star list ⇒ `J`.
+>
+> **The GAIN is now measured and permanently pinned**: a unit test asserts that one extra kappa-sigma iteration
+> moves σ by **≥ 100×** the tolerance that decides whether to take it, and says in as many words that if it ever
+> stops being true, this mechanism is no longer plausible and the entry should say so. **The trigger RATE is
+> still owed** — that is what the 40-second probe measures, and it is the cheapest remaining step.
+>
+> **Eliminated by reading, and recorded because it is the most F55-shaped thing in the path:**
+> `CvImageUtility.CalculateStatistics` picks its median with a **quickselect whose pivot comes from
+> `Random.Shared`** — process-level shared state consumed in a thread-interleaving-dependent order, exactly the
+> signature. It is **inert**: quickselect returns the value at rank *n* whatever the pivots were, and
+> `Mat.GetArray` hands back a **copy**, so the in-place permutation never reaches the image.
+
 > **Next step.** (a) ~~Re-run the arm sequentially~~ — **DONE**, and it passed both controls (see F32).
 (b) **Find the nondeterminism — this now outranks (a) in value, because the reproducer makes it cheap and
 because a bimodal race can flip a sequential run too.** Bisect with `determinism_probe.sh`: it is 40 s per trial. (c) Until (b), **treat concurrent `optimize` as invalid for any arm whose

--- a/docs/followups.md
+++ b/docs/followups.md
@@ -653,8 +653,9 @@ Reproduce: `D:\hf_w5\f24_arms.sh`, analysed by `D:\hf_w5\analyze_f24.py`.
 
 ### F19 — The exposure recommendation is decided by the 20 brightest stars, so a rich field can never earn one
 **Status:** **(a) refuted (wave 8) · (b) DONE (wave 8) · (c) RESOLVED "the floor stays", free, no re-render
-(wave 9) · THE REMAINDER IS FIXED (wave 9): the wing rejected fraction, chosen by a rule fixed before it, and the
-reason both earlier fixes failed is now a THEOREM about the gate.** Population check across both banks still owed
+(wave 9) · THE REMAINDER IS OPEN AGAIN (wave 10): wave 9's wing verdict was REFUTED by the population check it
+recorded as owed, and is WITHDRAWN.** The gate-floor THEOREM stands; the wing rejected fraction stays as a
+measurement; the successor (the wing-to-inner RATIO) is pre-registered and deliberately not adopted
 · found 2026-08-02 deriving expected-optimal exposures for the synthetic AF bank
 
 `ExposureRecommender`'s `S_now` is the median, across non-recovery frames, of each frame's
@@ -915,6 +916,66 @@ derived-exposure rung on either dataset, this entry REOPENS.**
 > writes back into the bank's run folders ([F15](#f15--optimize---per-run-overwrites-each-runs-stored-settings))
 > and there is no flag to suppress it, so a population pass while that arm is in flight would race it on every
 > folder. Reproduce: `D:\hf_w9\wing2\`, `D:\hf_w9\wing\score_wing.py`.
+
+> ## THE POPULATION CHECK RAN (2026-08-08, wave 10). RULE P FIRES, AND THE WING VERDICT IS WITHDRAWN.
+>
+> Wave 9 shipped `WingIsShedding` validated on **two** datasets and recorded the population check as *"still
+> owed"*. Wave 10 ran it: **39 runs, both full banks, sequential, shipped-default invocation**, against RULE P
+> fixed before the pass started.
+>
+> | clause | measured | verdict |
+> |---|---|---|
+> | **P1** the pre-registered fires | `D17` fires; `D10` does not | silent (P1 required neither individually) |
+> | **P2** fire rate | **30 of 39 = 76.9 %** | **FIRES — REFUTED** |
+> | **P3** `D16` at its derived exposure | 0.006, silent | silent — W2 survives |
+> | **P4** NaN rate | 0 of 39 | silent — the instrument was connected |
+>
+> ### Why it fires, and it is not simply "the threshold is too low"
+>
+> **The control the statistic never had.** `WingRejectedFraction` is `rejected/(rejected+accepted)` over the
+> outer third. Computing the same quantity on the **INNER** third — free from the per-frame table the harness
+> already writes — asks whether the wings are special at all. Median wing/inner over the 30 firing runs is
+> **1.39**, so the wings do reject somewhat more. **But the threshold is on the ABSOLUTE fraction and does not
+> track that ratio:** `D17_cdk14_oiii5` fires at a ratio of **0.59** (its wings reject 0.297, its core 0.507),
+> `D20_m24_bright_control` fires with an inner fraction of exactly **0.000**, and four real-bank runs
+> (`LinwoodFocus` 0.70, `vsn07` 0.94, `toml999` 0.96, `cwhite_2026` 0.98) fire with wings CLEANER than their
+> cores. Same verdict, opposite structures.
+>
+> **The threshold's whole discriminating power over 39 runs is ONE dataset.** Sorted, the fractions are
+> **0.000 ×8**, then **0.006** (`D16`), then **0.246 … 0.883**. Every threshold in **(0.006, 0.246)** selects the
+> same 30 runs; the only thing 0.20 separates is `D16`.
+>
+> **Why 0.20 looked well-chosen.** The unit fixtures span **0.002** ("healthy wings") to **0.75** ("shedding"),
+> and 0.20 sits comfortably between two poles two orders of magnitude apart. **Exactly one run in 39 resembles
+> the healthy pole.** *A unit fixture's range is not the population's range*, and no unit test can notice that.
+>
+> **And every firing run asks exactly 2×**, because the accepted-star term is far below the probe on all of them,
+> so `max()` always chooses the probe. The recommendation carried no information beyond "it fired".
+>
+> ### What was withdrawn, and what was kept
+>
+> | | |
+> |---|---|
+> | **withdrawn** | `WingIsShedding`, `WingSheddingThreshold`, `WingProbeFactor`, and the **three** sites that acted on them: the 2× ask; the `ExposureIsNotTheLimit` override; and [F52](#f52--a-two-hour-optimization-logs-one-line-and-offers-no-cost-context-and-the-search-is-not-cost-aware)(c)'s advice to **cancel a running two-hour search** |
+> | **kept** | `WingRejectedFraction` — the MEASUREMENT is real and correctly computed, and the successor is specified against it. A public bool named *"is shedding"* that nothing acts on would be worse than either shipping or removing it |
+>
+> **F52(c) returns to wave 8's position rather than to nothing.** Wave 8 withheld that advice for want of a
+> statistic; wave 9 shipped it on this one; wave 10 withholds it again for the same reason. That is the same
+> decision made twice on better evidence, not a regression — and it is the site that mattered most, because the
+> advice is computed from the **seed** evaluation and so was firing in the first minute of most users' runs.
+>
+> ### The successor, PRE-REGISTERED AND NOT ADOPTED
+>
+> `WingRejectedRatio` = wing-third ÷ inner-third, which is what the claim was always about. Its rule was fixed
+> **while the pass was still running**, before the verdict, precisely so it could not be adopted on the data that
+> refuted its predecessor: **RULE W1–W4 unchanged**, plus **W5** (its threshold must sit above the bank's median
+> wing/inner ratio, or it is the same defect in a new coordinate) and **W6** (it may NOT be validated on this
+> population). *A statistic tuned on the data that killed the last one has been fitted, not tested* — which is
+> wave 9's own R3 lesson one level up.
+>
+> **So F19's remainder is OPEN again**, and honestly so: this wave did not fix F19, it corrected a wrong fix and
+> left a sharper question with a control that did not exist before.
+> Reproduce: `D:\hf_w10\wing_pop.sh`, `D:\hf_w10\score_wing_pop.py`, `D:\hf_w10\pop_score.txt`.
 
 > ## (c) RESOLVED 2026-08-07 (wave 9): THE FLOOR STAYS, THE CEILING STAYS, AND NOTHING RE-RENDERS
 >

--- a/docs/followups.md
+++ b/docs/followups.md
@@ -3356,6 +3356,62 @@ result is the argument against assuming any build-level change helps — the sta
 instruction width, so wider vectors have nothing to recover. Establish the bottleneck by measurement before
 buying or building anything.
 
+### F57 — A detector change bounded at ≤ 3e-8 per pixel moved 6 of 8 product landings, and one SEED evaluation by 0.014
+**Status:** Open · found 2026-08-08 (wave 10) re-establishing RULE G's fixed point on `StarDetectorVersion` 2 ·
+**not a defect in [PR #187](https://github.com/ghilios/hocus-focus/pull/187)'s own claim — a measurement of what
+that claim does and does not bound**
+
+[F56](#f56--the-à-trous-wavelet-residual-convolves-a-dense-kernel-that-is-995--zeros-and-that-is-the-structurelayers-cost-curve)
+shipped `AtrousWaveletFast` and bumped `StarDetectorVersion` 1→2, recording that the two wavelet paths agree to
+**≤ 3e-8** and are deliberately not bit-identical. Wave 10 re-ran wave 5's eight-run comparability gate on the new
+detector, sequentially, at the identical invocation and the byte-identical pinned settings file
+(`md5 df7c7cd1…`), with a reading fixed in advance.
+
+> **RULE G10-B, written before the numbers arrived:** 0 landings moved ⇒ inert; **1–3 ⇒ the expected
+> pattern-search amplification** ([F8](#f8--optimizer-landings-are-not-reproducible-across-invocations));
+> **≥ 5 ⇒ the "≤ 3e-8" claim describes the per-pixel RESIDUAL and not the detector's BEHAVIOUR.**
+
+| run | `BaselineJ` v1 → v2 | `BestJ` v1 → v2 |
+|---|---|---|
+| `toml999` | **0.997840 → 0.983477** | 0.997993 → 0.995784 |
+| `CWhiteFocus` | 0.994320 → *(same)* | 0.998476 → 0.996068 |
+| `mccomiskey` | 0.846082 → *(same)* | 0.994025 → **0.976746** |
+| `D18` / `D19` / `D20` | *(same)* | 0.999822 → 0.999882 · 0.999557 → 0.999487 · 0.999766 → 0.999738 |
+| `uneven` / `muggsie` | *(same)* | *(unchanged)* |
+
+**THE RULE FIRES AT ITS TOP TIER: 6 of 8.** And `mccomiskey`'s landing moves by **0.017** — larger than the
+entire Δ`J` any wave has ever argued about.
+
+**The seed evaluation is the sharper half.** `BaselineJ` is a **single evaluation of the pinned seed, no search**,
+so no trajectory amplifies it. On `toml999` it moves **0.0144** between two binaries whose every printed seed
+input is identical — same settings file and export stamp, `Sensitivity=10`, `StarClippingMultiplier=2`,
+`NoiseClippingMultiplier=4`, `StructureLayers=4`, inferred step 21, exposure 5 s, `PixelScale 0.73944` from the
+frame header, detection binning `1 from harness_settings.json`.
+
+**What this is NOT.** It is not evidence that PR #187 is wrong: the paths do agree to ≤ 3e-8 per pixel, and the
+version was bumped precisely because they are not bit-identical. It is not a reason to revert — the swap buys
+**2.5× / 9.7× / 40×** at layers 4 / 6 / 8. And landings moving is F8 in kind, if not in degree.
+
+**What it IS.** *A numerical-equivalence bound on an intermediate is not an equivalence bound on the answer.* The
+Sensitivity gate is a THRESHOLD, so an eighth-decimal difference in the residual turns into a whole star being
+admitted or rejected, and from there into `J`. Any future change justified by "equivalent to N decimal places"
+inherits this: **the bound belongs on the quantity the product reports, not on the intermediate**, and the
+eight-run gate is the cheap way to measure it (≈ 40 minutes).
+
+**Confound, and how it is settled.** `BaselineJ` is read on folders a previous arm wrote into
+([F15](#f15--optimize---per-run-overwrites-each-runs-stored-settings)), so the binary is not the only thing that
+differs between the two measurements. `harness_settings.json` is excluded outright (`toml999`'s is dated
+2026-07-31, before wave 8). `optimized_settings.json` is not, and F55's own investigation measured it inert only
+on `D16`/v1. The control is to run `toml999` on wave 9's v1 binary against TODAY's folder state: same folder,
+different binary. **Until that reports, the seed-evaluation half of this entry is held open.**
+
+**Next step.** (a) Run the cross-build control above and close or re-open the seed half. (b) Adopt the eight-run
+gate as the standing acceptance check for any detector change claiming numerical equivalence — it is the
+instrument that turns "equivalent" into a number. (c) Where a `Reproduce:` line names a `D:\hf_w*\exe`,
+`strings <dll> | grep AtrousWaveletFast` distinguishes a v1 build from a v2 build **retroactively**, without
+running it; that is how wave 10 verified rather than assumed which of the four wave-9 build directories were v1.
+Reproduce: `D:\hf_w10\gate_repro_w10.sh`, `D:\hf_w10\gate\`, against `D:\hf_w9\gate\`.
+
 ### F55 — `optimize` is NOT reproducible when several instances run at once, and the SEED evaluation is what moves
 **Status:** Open · found 2026-08-07 (wave 9) when the confirmation arm's own pre-registered control fired ·
 **this voids the wave-9 F32 arm and constrains every future arm's design**

--- a/docs/followups.md
+++ b/docs/followups.md
@@ -1201,6 +1201,42 @@ returned 12.1 on a fit at R² = 1.0000, and a bound on a wrong answer is not an 
 next step — instrument `FindHalfWidth` on the two saved `D17` sweeps and confirm or refute the coarse-walk
 hypothesis — is still owed**, and the entry stays Open.
 
+> ### DIAGNOSED 2026-08-08 (wave 10): the coarse walk is EXACT, and this entry's own case will not reproduce
+>
+> This entry's next step — *"instrument `FindHalfWidth` ... confirm or refute the coarse-walk hypothesis"* — is
+> discharged, and **the hypothesis is refuted.**
+>
+> **`FindHalfWidth` is exact for a hyperbola.** It returns `√8 · HFR_min / κ`, so its output is PROPORTIONAL to
+> the fitted vertex HFR. Wave 7's F18 control arm, already on disk, shows exactly that: over uncapped rounds
+> `halfWidth / vertexY` holds to **×1.03–×1.14** within a dataset while `halfWidth` itself spans up to **×1.69**,
+> and the ratio differs strongly BETWEEN datasets as `√8/κ` should. **The walk is not what moves — the FIT's
+> vertex is.** `R² = 1.0000` is no evidence against that: R² measures fit to the SAMPLED points and says nothing
+> about whether the vertex is identifiable from them, which on a sweep that never leaves the focus zone it is not.
+>
+> **This entry's own reproduce line was run, and round 0 reproduces EXACTLY:**
+>
+> | | as recorded | wave 10 |
+> |---|---|---|
+> | round 0 `HalfWidth` / step | 143.6 / 41 | **143.583 / 41** |
+> | round 1 | **12.1 / 3** | **did not occur — converged in 1 round** |
+>
+> So the instrument is right and **the pathology did not recur** — the same shape as
+> [F25](#f25--from-a-far-too-wide-sweep-the-step-recommender-widens-it-further-instead-of-recovering), whose
+> 4×→7× over-reach also failed to re-measure. The headline stays a real observation of a real run and is **not**
+> a reproducible case, which is why the diagnosis rests on six OTHER datasets.
+>
+> **And with a fixed seed the recommender is BIT-REPRODUCIBLE**: all six S0 half-widths are identical to full
+> double precision between wave 7's v1 binary and wave 10's v2 (130.132 / 129.313 / 399.122 / 396.872 / 168.835 /
+> 73.358). The instability this entry names is a property of the NOISE REALIZATION, not of the arithmetic.
+>
+> **A deadband was proposed to bound the symptom and REFUTED before implementation** by the rule fixed to size
+> it (wave-10 design §3.3B: *"a deadband narrower than the recommender's own reproducibility does nothing"*).
+> With a fixed seed that spread is ZERO, so a compliant deadband is zero; and on S0 — where the bootstrap IS each
+> dataset's expected optimum — the recommender asks a median **19.9 %** (max 40 %), so a deadband wide enough to
+> matter would suppress 4 of 6 of those and bury F18's open question about which of the two is right.
+> **Still owed: WHY the fitted vertex moves**, which is a fit-identifiability question and not a search one.
+> Reproduce: `D:\hf_w10\step_probe.sh`, `D:\hf_w10\score_step.py`.
+
 ### F22 — Detection binning is a hard threshold on a measurement that under-reads, so boundary rigs get the wrong factor
 **Status:** Open · found 2026-08-02 running the synthetic bank's S0 control
 
@@ -3417,71 +3453,76 @@ result is the argument against assuming any build-level change helps — the sta
 instruction width, so wider vectors have nothing to recover. Establish the bottleneck by measurement before
 buying or building anything.
 
-### F57 — A detector change bounded at ≤ 3e-8 per pixel moved 6 of 8 product landings, and one SEED evaluation by 0.014
-**Status:** Open · found 2026-08-08 (wave 10) re-establishing RULE G's fixed point on `StarDetectorVersion` 2 ·
-**not a defect in [PR #187](https://github.com/ghilios/hocus-focus/pull/187)'s own claim — a measurement of what
-that claim does and does not bound**
+### F57 — A `--settings`-pinned arm is NOT pinned: the active NINA profile moves `BaselineJ` by 0.014, and every cross-wave comparison inherits it
+**Status:** Open · found 2026-08-08 (wave 10) while running the pre-registered control for a DIFFERENT
+hypothesis, which it refuted · **this is [F42](#f42--every-build-directory-silently-gets-its-own-detector-settings-and-the-run-instructions-require-a-new-one-per-arm)'s
+warning, measured for the first time**
 
-[F56](#f56--the-à-trous-wavelet-residual-convolves-a-dense-kernel-that-is-995--zeros-and-that-is-the-structurelayers-cost-curve)
-shipped `AtrousWaveletFast` and bumped `StarDetectorVersion` 1→2, recording that the two wavelet paths agree to
-**≤ 3e-8** and are deliberately not bit-identical. Wave 10 re-ran wave 5's eight-run comparability gate on the new
-detector, sequentially, at the identical invocation and the byte-identical pinned settings file
-(`md5 df7c7cd1…`), with a reading fixed in advance.
+**How this was found is the point, so it is told in order.**
 
-> **RULE G10-B, written before the numbers arrived:** 0 landings moved ⇒ inert; **1–3 ⇒ the expected
-> pattern-search amplification** ([F8](#f8--optimizer-landings-are-not-reproducible-across-invocations));
-> **≥ 5 ⇒ the "≤ 3e-8" claim describes the per-pixel RESIDUAL and not the detector's BEHAVIOUR.**
+Wave 10 re-ran wave 5's eight-run comparability gate on `StarDetectorVersion` 2 and found **6 of 8 landings
+moved**, plus `toml999`'s `BaselineJ` — *a single evaluation of the pinned seed, no search, nothing to amplify
+it* — moving from **0.997840 to 0.983477**. Every printed seed input was identical: same settings file and export
+stamp, `Sensitivity=10`, `StarClippingMultiplier=2`, `NoiseClippingMultiplier=4`, `StructureLayers=4`, inferred
+step 21, exposure 5 s, `PixelScale 0.73944` from the frame header, detection binning 1. The obvious reading was
+that [PR #187](https://github.com/ghilios/hocus-focus/pull/187)'s ≤ 3e-8 wavelet change had moved a product
+answer by six orders of magnitude more than its bound, and that was written up as this entry.
 
-| run | `BaselineJ` v1 → v2 | `BestJ` v1 → v2 |
+**The pre-registered control refuted it.** A three-way probe ran `toml999` **five times each** on wave 9's v1
+binary, wave 10's v2 binary, and a **bisect build** — wave 10's tree with `StarDetector.cs`'s two call sites
+reverted to the legacy dense wavelet — interleaved, in one session, on identical folder copies:
+
+> **All fifteen runs returned `0.9834767969`. Identical to ten decimal places.**
+
+So the binary does not decide it, and **the wavelet is exonerated outright**: v2 and the bisect differ only in the
+wavelet and agree exactly. Folder state was then excluded one artifact at a time — removing
+`optimized_settings.json`, `hocusfocus_star_detection.json`, `autofocus_report_Region0.json` and `run_meta.json`
+each changed nothing, and the frames and `harness_settings.json` predate both waves.
+
+**What was left was the one input nobody compares.**
+
+| | wave 9's gate | wave 10's gate |
 |---|---|---|
-| `toml999` | **0.997840 → 0.983477** | 0.997993 → 0.995784 |
-| `CWhiteFocus` | 0.994320 → *(same)* | 0.998476 → 0.996068 |
-| `mccomiskey` | 0.846082 → *(same)* | 0.994025 → **0.976746** |
-| `D18` / `D19` / `D20` | *(same)* | 0.999822 → 0.999882 · 0.999557 → 0.999487 · 0.999766 → 0.999738 |
-| `uneven` / `muggsie` | *(same)* | *(unchanged)* |
+| `--settings` | `hf_w9\pinned_settings.json` | `hf_w10\pinned_settings.json` — **byte-identical**, `md5 df7c7cd1…` |
+| **`Profile:`** | **`Default (b10b1d6d-…)`** | **`astrodet (ce3f3e63-…)`** |
 
-**THE RULE FIRES AT ITS TOP TIER: 6 of 8.** And `mccomiskey`'s landing moves by **0.017** — larger than the
-entire Δ`J` any wave has ever argued about.
+**Re-running `toml999` today with `--profile-id b10b1d6d-…` returns `0.9978404571` — wave 9's value, to 6 dp.**
 
-**The seed evaluation is the sharper half.** `BaselineJ` is a **single evaluation of the pinned seed, no search**,
-so no trajectory amplifies it. On `toml999` it moves **0.0144** between two binaries whose every printed seed
-input is identical — same settings file and export stamp, `Sensitivity=10`, `StarClippingMultiplier=2`,
-`NoiseClippingMultiplier=4`, `StructureLayers=4`, inferred step 21, exposure 5 s, `PixelScale 0.73944` from the
-frame header, detection binning `1 from harness_settings.json`.
+### What it means
 
-**What this is NOT.** It is not evidence that PR #187 is wrong: the paths do agree to ≤ 3e-8 per pixel, and the
-version was bumped precisely because they are not bit-identical. It is not a reason to revert — the swap buys
-**2.5× / 9.7× / 40×** at layers 4 / 6 / 8. And landings moving is F8 in kind, if not in degree.
+`--settings` pins the DETECTOR knobs, and this project has treated that as pinning the arm — [F42](#f42--every-build-directory-silently-gets-its-own-detector-settings-and-the-run-instructions-require-a-new-one-per-arm)
+even says so in the run instructions. **It does not.** The harness also loads whichever NINA profile happens to be
+ACTIVE (`profileService.TryLoad("")`), and that profile moves `BaselineJ` — the objective of a fixed seed on fixed
+frames — by **0.0144**, which is larger than the entire Δ`J` any wave has ever argued about.
 
-**What it IS.** *A numerical-equivalence bound on an intermediate is not an equivalence bound on the answer.* The
-Sensitivity gate is a THRESHOLD, so an eighth-decimal difference in the residual turns into a whole star being
-admitted or rejected, and from there into `J`. Any future change justified by "equivalent to N decimal places"
-inherits this: **the bound belongs on the quantity the product reports, not on the intermediate**, and the
-eight-run gate is the cheap way to measure it (≈ 40 minutes).
+F42's own text predicted this exactly — *"`TryLoad("")` picks whichever profile is ACTIVE — two runs of the same
+data minutes apart were seeded from different telescopes"* — and the fix it prompted was to pin the detector
+settings, which does not close it. **The prediction was right, the remedy was incomplete, and nobody measured
+the residue until an unrelated control forced it.**
 
-**Two confounds, and how each is settled.**
+### What it invalidates
 
-1. **Folder state.** `BaselineJ` is read on folders a previous arm wrote into
-   ([F15](#f15--optimize---per-run-overwrites-each-runs-stored-settings)), so the binary is not the only thing
-   that differs. `harness_settings.json` is excluded outright (`toml999`'s is dated 2026-07-31, before wave 8);
-   `optimized_settings.json` is not, and F55's investigation measured it inert only on `D16`/v1. The control is
-   to run `toml999` on wave 9's v1 binary against TODAY's folder state — same folder, different binary.
-2. **"The binary" is not yet "the wavelet".** `D:\hf_w9\exe`'s dll is stamped 2026-08-06 19:40 and several
-   wave-9 commits post-date it, so the two exes differ by PR #187 *plus* some wave-9 code. Those additions are
-   all post-search or UI (wave 9 verified the wing statistic is computed after the search and is inert on it),
-   which makes PR #187 the only plausible search-relevant term — **and plausible is not measured.** A bisect
-   build of the wave-10 tree with `StarDetector.cs`'s two call sites reverted to the legacy dense path isolates
-   the wavelet from everything else.
+- **The wavelet claim this entry originally made: withdrawn in full.** PR #187 is not implicated in anything.
+- **Wave 10's RULE G10-B ("6 of 8 landings moved") is VOID**, not merely uncertain: it compared two waves that
+  ran under different profiles, so it measures the profile at least as much as the binary.
+- **Every cross-wave `BaselineJ`/landing comparison in this register is exposed**, including wave 6's arm-R
+  round-0 control and wave 9's gate, unless the active profile happened to match. Those controls PASSED, which
+  is evidence the profile was stable across waves 5–9 — it is not evidence that it was pinned.
+- **Wave 10's RULE G10-A is NOT affected** and still passes 8 of 8: it compares two runs *within* wave 10, under
+  one profile, and it is what makes this wave's own measurements readable.
 
-**Until both report, this entry attributes to THE BINARY, not to the wavelet, and the seed-evaluation half is
-held open.**
+### Next step
 
-**Next step.** (a) Run the cross-build control above and close or re-open the seed half. (b) Adopt the eight-run
-gate as the standing acceptance check for any detector change claiming numerical equivalence — it is the
-instrument that turns "equivalent" into a number. (c) Where a `Reproduce:` line names a `D:\hf_w*\exe`,
-`strings <dll> | grep AtrousWaveletFast` distinguishes a v1 build from a v2 build **retroactively**, without
-running it; that is how wave 10 verified rather than assumed which of the four wave-9 build directories were v1.
-Reproduce: `D:\hf_w10\gate_repro_w10.sh`, `D:\hf_w10\gate\`, against `D:\hf_w9\gate\`.
+(a) **`optimize` must record the profile id and name in `OptimizerProvenance`**, beside the `BuildId` and
+`DetectorVersion` this wave added — the same argument, one input further out: a reader diffs a field.
+(b) **Every arm must pass `--profile-id` explicitly**, and the run instructions must say so beside F42's
+`--settings` rule; an arm that does not is pinned in one dimension and floating in another.
+(c) **Find WHICH profile-sourced quantity moves the objective.** `PixelScale` is excluded (both runs print
+`0.73944` from the frame header). `AutoFocusOptions` is read from the profile and is the obvious next place.
+(d) **Re-open the wavelet question properly, uncofounded**: run the eight gate runs on `exe_v1wav` against `exe`
+— same tree, same profile, same folders, differing only in the wavelet — at `--max-evals 250`. The seed-level
+answer is already in (identical), so this measures only whether the pattern search amplifies it into landings.
+Reproduce: `D:\hf_w10\crossbuild_probe.sh`, `D:\hf_w10\crossbuild.log`, `D:\hf_w10\xb_prof.log`.
 
 ### F55 — `optimize` is NOT reproducible when several instances run at once, and the SEED evaluation is what moves
 **Status:** Open · found 2026-08-07 (wave 9) when the confirmation arm's own pre-registered control fired ·
@@ -3768,8 +3809,25 @@ wave's control arm is not a control for a later wave's binary. This is the sharp
 not a control for its OWN recorded binary either**, when the arm directory is a build output that later steps in
 the same wave overwrite. Every `Reproduce:` line in `docs/` that names a `D:\hf_w*\exe` inherits this.
 
-**Next step.** (a) Stamp the build into the run: have `optimize` print the informational version / commit of the
-binary it is running, so a log says which build produced it. (b) Until then, treat a `D:\hf_w*\exe` reproduce line
+> ### (a) SHIPPED 2026-08-08 (wave 10) — and the field that CLAIMED to identify the build did not
+>
+> `OptimizerProvenance.ProducerVersion`'s own doc said a landing "also identifies the build it came from". It
+> cannot: two builds of one version share it, which is precisely how wave 8's arm X came to be irreproducible
+> from its own recorded `exe`. **`BuildId` — the assembly MVID, which the compiler regenerates on EVERY build —
+> is the field that answers "which build",** and `DetectorVersion` says which output contract produced the
+> numbers (wave 9's entire results doc needed a hand-written banner for want of it). Both are printed by
+> `optimize` and stored in every landing. [F57](#f57--a---settings-pinned-arm-is-not-pinned-the-active-nina-profile-moves-baselinej-by-0014-and-every-cross-wave-comparison-inherits-it)
+> then added `ProfileId` for the same reason, one input further out.
+>
+> **A RETROACTIVE instrument for the artifacts that predate the stamp:** `strings <dll> | grep AtrousWaveletFast`
+> distinguishes a `StarDetectorVersion` 1 build from a 2 build **without running it**. Wave 10 used it to
+> establish that all four of wave 9's build directories are v1 rather than assuming it — which is this entry's
+> lesson applied to itself.
+>
+> **(b) still stands unchanged**: a `Reproduce:` line names a COMMAND, not a result. Stamping the build removes
+> the need to INFER which binary ran; it does not make an old number reproduce.
+
+**Next step.** (a) ~~Stamp the build into the run~~ — **DONE, see above**. (b) Until then, treat a `D:\hf_w*\exe` reproduce line
 as naming a COMMAND, not a result — re-derive the numbers rather than quoting them across waves. (c) Prefer
 per-arm build directories that are never rebuilt mid-wave, which
 [F42](#f42--every-build-directory-silently-gets-its-own-detector-settings-and-the-run-instructions-require-a-new-one-per-arm)
@@ -3890,12 +3948,31 @@ wide side, and the user experienced it as a runaway rather than as convergence.
 > expectation. Plus: the remedy is last-ranked and does not displace an available exposure remedy; an unmeasured
 > run gets no gate remedy; and the copy names no control that does not exist.
 
+> ### (c) SHIPPED 2026-08-08 (wave 10), with an EXACT ratio and no projected run count
+>
+> A capped step recommendation now says it is a **partial step**, names what it converges toward
+> (`3 × HFR_min`), reports the HFR dynamic range **the sweep actually measured**, and quotes the exact factor the
+> next capped run will apply: `MaxHalfWidthSampledHalfSpanMultiple × P / PointsPerSide` — **1.714× at 4 offset
+> steps, 2.143× at 4 offset + 1 recovery**.
+>
+> **The ratio is a property of the ALGORITHM, not of the fit**, so nothing in it depends on the extrapolated
+> half-width the cap exists to distrust. That is why it is quotable and **a projected run COUNT is not** — that
+> would have to come from the very extrapolation being distrusted.
+>
+> **Measured against 22 capped rounds already on disk**, at zero compute: wave 7's F18 control arm lands every
+> one of them at a realized **1.667–1.750** (integer-step rounding). This entry's own field session ran
+> 100 → 214 → 459 at P = 5, and 100 × 2.143 = 214.3, 214 × 2.143 = 458.6 — matching the 459 this entry derives
+> independently from the screenshot's focuser axis.
+>
+> **It does terminate**, which is the half of the user's experience that is not a defect: the widening is
+> geometric until the sweep contains the band, and their runs 3 and 4 asked +3 % and +5 %. A unit test replays
+> the sequence and asserts the cap releases.
+
 **Next step.** Three separable pieces. **(a)** ~~Give the floored-gate + `ExposureIsNotTheLimit` state a remedy of
-its own~~ — **DONE, see above**; the honest one names the gate, not the exposure. **(b)** Decide
+its own~~ — **DONE**; the honest one names the gate, not the exposure. **(b)** Decide
 whether a user-facing floor on the search's Sensitivity (or F32's keep fraction, exposed) is the right lever, since
-today there is none. **(c)** When the step recommendation is capped by the sweep width, say what it is converging
-TOWARD (`3 × HFR_min`) and that the cap means "partial step, this will take another run" — the exposure
-recommender's own `MaxExposureFactor` copy already sets that precedent verbatim ("Run again to refine").
+today there is none. **(c)** ~~When the step recommendation is capped by the sweep width, say what it is converging TOWARD~~ —
+**DONE, see above**, and with a measured range and an exact ratio rather than only a sentence.
 Reproduce: field report, `Default` profile, 2026-08-06; wizard screenshot in the wave-8 thread.
 
 ---

--- a/docs/followups.md
+++ b/docs/followups.md
@@ -3575,6 +3575,42 @@ diff it, so this control is free on every future arm rather than only when someo
 Reproduce: `D:\hf_w9\f32_arms.log`, `D:\hf_w9\score_f32.py`, `D:\hf_w9\ctl_seq_toml999.log`,
 `D:\hf_w9\ctl_conc_toml999.log`.
 
+> ### (c) IS NOW MECHANICAL, because the written rule was NOT ENOUGH (2026-08-08, wave 10)
+>
+> (c) said: *"treat concurrent `optimize` as invalid for any arm whose conclusion rests on comparing landings,
+> and say so in the run instructions"*. Wave 10 wrote that rule into its own design, into its plan, and into the
+> header of the script that ran the pass — **and then ran a 39-run population pass TWICE AT ONCE anyway.**
+>
+> The mechanism is worth recording exactly, because nothing about it was careless. A background launcher had
+> been started to chain the pass behind the gate; it reported **"completed"**, and a `ps` check showed no
+> surviving process, so a second launch was issued. The launcher's *shell* had exited; its `nohup`'d driver had
+> not, and it was in a process namespace the checking shell could not see. Two drivers, two `optimize`
+> processes, the same bank folders.
+>
+> **It was caught by an instrument built for something else.** A trace diff — written to find the FIRST
+> divergent evaluation between two runs of one invocation — reported an impossible ladder, and the log turned
+> out to contain two complete optimizations. *(That same instrument had to be fixed first: its initial version
+> diffed raw progress lines, which come partly from a wall-clock timer, so it reported divergence on every pair
+> of runs whether or not the search diverged. Asked "what would this do if the thing it checks were completely
+> broken?", the answer was "exactly the same thing".)*
+>
+> **What ships.** `optimize` claims a named mutex at startup and records `ConcurrencyCheck` —
+> `"exclusive"` / `"concurrent"` / `"unknown"` — into `OptimizerProvenance`, i.e. into **every landing it
+> writes**, and prints a warning naming F55. **Three values and not two**, for the same reason
+> `WingRejectedFraction` is NaN-never-0: a check that could not run must not read as a check that ran and found
+> nothing. A scorer can now refuse a contaminated arm **after the fact**, without anyone having been watching.
+>
+> **The lesson generalises past this entry.** A rule that depends on the operator noticing a violation is not a
+> control; it is a hope. This project's own register is full of the mechanical version of the same move —
+> `BaselineJ` as a free control (F41), `DetectionBinningSource` as a field rather than a sentence (F39(a)),
+> `BuildId` rather than a version string (F53). *If a rule matters, make the violation visible in the output.*
+>
+> *(The pass's own driver script also gained a pre-flight guard — and its first version was broken in the most
+> on-the-nose way available: `grep -c` prints `0` and exits `1`, so `$(... || echo 0)` produced the string
+> `"0\n0"`, the numeric comparison errored, and the guard fell through reporting SAFE unconditionally. It was
+> then re-validated against a positive control — a deliberately-started `optimize` — before being trusted, which
+> is the check the wave-9 lesson asks for and which the first version would have failed.)*
+
 ### F54 — F39(b)'s default flip MOVES a landing at a resolved factor of 1, where it is documented as a no-op
 **Status:** Open · found 2026-08-07 (wave 9) chasing [F53](#f53--wave-8s-arm-x-does-not-reproduce-from-wave-8s-own-exe-because-the-arm-ran-on-an-earlier-build-of-it)'s
 remainder · **measured and reproducible; the MECHANISM is not identified and is not claimed**

--- a/docs/synthetic-af-bank-followups-wave10-design.md
+++ b/docs/synthetic-af-bank-followups-wave10-design.md
@@ -168,6 +168,15 @@ test. It is computed from the **seed** evaluation, i.e. in the first minute, and
 most users are advised to abandon their optimization before it has done anything. A statistic that fires
 everywhere is not merely uninformative there; it is expensive.
 
+**What withdrawal means concretely, decided before the verdict:** delete the VERDICT (`WingIsShedding`,
+`WingSheddingThreshold`, `WingProbeFactor`) and keep the MEASUREMENT (`WingRejectedFraction`). A public boolean
+named *"is shedding"* that nothing acts on would be worse than either shipping or removing it — the successor
+introduces its own verdict field, and until then the number stands on its own with no claim attached.
+
+**And F52(c) returns to wave 8's position rather than to nothing.** Wave 8 withheld the abort advice for want of
+a statistic; wave 9 shipped it on this one; if RULE P fires, it is withheld again for the same reason it was
+withheld the first time. That is not a regression — it is the same decision, made again, on better evidence.
+
 ### §1.3 Why `D10` and `D17` are the pre-registered fires
 
 They are the bank's only two **ceiling**-clamped datasets: their own derivation asks 335.6 s and 40.4 s and both

--- a/docs/synthetic-af-bank-followups-wave10-design.md
+++ b/docs/synthetic-af-bank-followups-wave10-design.md
@@ -188,6 +188,47 @@ a different order. That mechanism is load-sensitive, cross-process visible (a sh
 stable within a process, and bimodal rather than drifting. It is the shape of the observed defect and it is
 cheap to test.
 
+### §2.4a The specific instance — `KappaSigmaNoiseEstimate`
+
+*Written down after reading the source and **before any probe ran**, so it can be refuted rather than confirmed.*
+
+`CvImageUtility.KappaSigmaNoiseEstimate` is §2.4's shape made concrete, and it is a **bimodal amplifier by
+construction**:
+
+```
+while (numIterations < maxIterations) {
+    Cv2.MeanStdDev(image, out mean, out sigma, backgroundMask);   // an OpenCV PARALLEL REDUCTION
+    if (++numIterations > 1 && Math.Abs(sigma - lastSigma) <= allowedError)  break;   // allowedError = 1e-5
+    threshold = mean + clippingMultiplier * sigma;                // one more iteration moves sigma MACROSCOPICALLY
+}
+```
+
+An infinitesimal change in `sigma` — from a different stripe partitioning, or from PR #187's ≤ 3e-8 — can flip
+the convergence test, and the run then takes **one more iteration**, which changes `threshold` and therefore
+`sigma` by a large amount. **Two discrete outcomes from an arbitrarily small perturbation.** That matches every
+observed property of F55 at once: bimodal rather than drifting; two attractors; load-sensitive (OpenCV's pool
+sees machine load); stable within a process (pool size fixed at init); and invisible to the plugin's own
+`Parallel.For` degree, which wave 9 swept and found inert. σ feeds noise clipping ⇒ the star gate ⇒ the star
+list ⇒ `J`.
+
+**The rate is consistent with the measurements, which is what makes it worth testing rather than merely
+plausible.** A flip needs the iteration-to-iteration σ difference to land within ~1e-8 of the 1e-5 tolerance —
+order 1e-3 per call. One `optimize` run makes thousands of these calls (250 candidates × 9 frames × regions), so
+several flips per run is the expectation, while a single seed evaluation makes tens and should flip rarely.
+Measured: **44 % of landings and 15 % of seed evaluations**.
+
+**How to test it, in preference order.** *Observe the mechanism*, don't just perturb a knob: log `numIterations`
+and the per-iteration σ, run the 40-second probe, and diff an attractor-A run against an attractor-B run. If
+`numIterations` differs, the convergence test is the amplifier and that is a direct observation. The
+single-thread probe (§2.5(3)) is the corroborating perturbation, not the primary evidence.
+
+**Eliminated by reading while looking for this, and recorded because it is the most F55-shaped thing in the
+path:** `CvImageUtility.CalculateStatistics` selects its median with a **quickselect whose pivot comes from
+`Random.Shared`** — process-level shared state, consumed in a thread-interleaving-dependent order, exactly the
+signature. It is nevertheless **inert**: quickselect returns the value at rank *n*, which is the same value
+whatever the pivots were, and `Mat.GetArray` hands back a **copy**, so the in-place permutation never reaches
+the image. The comment at that line already says so; this is the confirmation that it is right.
+
 ### §2.5 The experiments, in cost order
 
 1. **The cross-build probe (decisive for §0.2's fork, ~20 min).** Run the determinism probe on `toml999` with

--- a/docs/synthetic-af-bank-followups-wave10-design.md
+++ b/docs/synthetic-af-bank-followups-wave10-design.md
@@ -1,0 +1,341 @@
+# Synthetic AF bank — followups wave 10 (design)
+
+Plan: [`plans/synthetic-af-bank-followups-wave10-plan.md`](../plans/synthetic-af-bank-followups-wave10-plan.md).
+Wave 9: [`docs/synthetic-af-bank-followups-wave9-results.md`](synthetic-af-bank-followups-wave9-results.md).
+Register: [`docs/followups.md`](followups.md).
+
+*Wave 9 closed with a PROVENANCE banner saying its numbers were measured on a detector that no longer exists.
+This wave opens by acting on that banner rather than by quoting it — the first thing that runs is the gate, and
+it is not a pass/fail against wave 5 because there is nothing left to pass.*
+
+---
+
+## §0 — The gate, and why it is NOT a CI gate this time
+
+Every number in wave 9's results doc was measured on **`StarDetectorVersion` 1**, the dense-`SepFilter2D` à-trous
+path. `develop` now ships [PR #187](https://github.com/ghilios/hocus-focus/pull/187)'s `AtrousWaveletFast` and
+**`StarDetectorVersion` 2**. The two wavelet paths agree to **≤ 3e-8** and are deliberately not bit-identical,
+which is exactly why the version was bumped.
+
+So RULE G's eight comparability values, F32's arm landings and the wing statistic's Rule W table are **not
+expected to reproduce today**, and wave 5's φ table is **no longer a valid comparison target on its own**. The
+suite being green says nothing about this: the suite does not run the optimizer over the bank.
+
+### §0.1 RULE G10 — fixed before the gate ran
+
+The eight runs are re-measured at wave 5's exact invocation (`--per-run --max-evals 250`, `--settings` pinned to
+the file that is byte-identical to waves 5–9, `md5 df7c7cd1…`, [F42](followups.md#f42--every-build-directory-silently-gets-its-own-detector-settings-and-the-run-instructions-require-a-new-one-per-arm)),
+sequentially, nothing else running ([F55](followups.md#f55--optimize-is-not-reproducible-when-several-instances-run-at-once-and-the-seed-evaluation-is-what-moves)).
+The values they return **define** wave 10's fixed point. Two readings are pre-registered, and only one of them is
+a gate:
+
+> **G10-A — the INSTRUMENT gate, the only pass/fail clause.** Re-running any of the eight a second time,
+> sequentially and alone, must return the same value to 6 dp. *A fixed point that does not reproduce against
+> itself is not a fixed point*, and if this fires, every cross-arm comparison in wave 10 is void before it is
+> made — F55 firing at rest rather than under fan-out. **STOP.**
+>
+> **G10-B — a MEASUREMENT, not a gate, and a first-class finding in either direction.** How many of the eight
+> landings does a ≤ 3e-8 per-pixel change MOVE? Wave 9 established that sequential execution is deterministic and
+> that these eight reproduced across two waves and two binaries on version 1; wave 9's own shipped code is
+> measured-inert on the search (the wing statistic is computed *after* it; F49/F51/F52(c) are copy). **The
+> wavelet swap is therefore the only search-relevant difference between wave 9's binary and this one.** Written
+> down before the numbers arrived:
+>
+> | moved | reading |
+> |---|---|
+> | 0 | the swap is inert at landing granularity; "≤ 3e-8" understates its safety |
+> | 1–3 | the expected shape — a pattern search amplifies a tiny perturbation on some runs ([F8](followups.md#f8--optimizer-landings-are-not-reproducible-across-invocations)) |
+> | ≥ 5 | "≤ 3e-8" describes the per-pixel residual and **not** the detector's behaviour, and PR #187 needs re-examining as a change that moves product landings |
+
+**G10-A has a known weakness, and it is stated here rather than discovered later.** F55's sharpest open clue is
+that the attractor is *stable within a session and variable across them*. A same-session repeat therefore agrees
+under **both** hypotheses, so G10-A can pass while being uninformative about F55. That is why the gate is
+paired with §2's cross-build probe rather than trusted alone — and why the very first gate run is already
+evidence about F55 rather than only about the wavelet (see §0.2).
+
+### §0.2 The first gate run, and the fork it opened
+
+`toml999` returned **0.995784** — sequentially, alone, on the version-2 binary. **That is exactly the value wave
+9's FAN-OUT arm A produced and that RULE G rejected**, against wave 9's sequential 0.997993. Two readings survive
+that one number, and it cannot separate them:
+
+| | hypothesis |
+|---|---|
+| **H1** | the wavelet swap moves this landing to 0.995784, and its agreeing with the fan-out value is a coincidence |
+| **H2** | 0.997993 / 0.995784 are `toml999`'s **two F55 attractors** — as 0.988555 / 0.979173 are `D16`'s — and this run simply landed on the other one, with the wavelet irrelevant |
+
+Under H2 wave 9's F55 write-up needs no change but the "fan-out did it" framing gets weaker; under H1 F55's
+`toml999` evidence was **never about concurrency at all** and the wave-9 fan-out arm was voided partly by the
+wrong cause. **§2 is designed to discriminate them**, and the discriminator is cheap because the legacy wavelet
+survives in the tree as the equivalence-test oracle (`CvImageUtility`), so a one-line bisect build exists.
+
+### §0.3 F15 — which landing the banks end holding
+
+The gate is arm A's exact invocation (shipped defaults), which is what the banks already hold from wave 9's arm A.
+The eight folders are rewritten with the same shipped-default landing they already carry, so the resting state is
+preserved **by construction** rather than by a follow-up re-land
+([F15](followups.md#f15--optimize---per-run-overwrites-each-runs-stored-settings)). Item 1's population pass is
+run at that same invocation, for the same reason and as a free inertness control.
+
+### §0.4 Build provenance, recorded by hand because F53's stamp does not exist yet
+
+`D:\hf_w10\exe` — `git` `02c62d8`, `TestApp.dll` sha256 `5e58b669…`, `NINA.Joko.Plugins.HocusFocus.dll` sha256
+`ccb3e3e9…`, `StarDetectorVersion` 2. **It is never rebuilt** ([F53](followups.md#f53--wave-8s-arm-x-does-not-reproduce-from-wave-8s-own-exe-because-the-arm-ran-on-an-earlier-build-of-it)(c));
+later wave-10 builds go to `exe2`, `exe_v1wav`, … Making this automatic is F53(a), and it is item 2's companion.
+
+---
+
+## §1 — Item 1: F19's POPULATION CHECK
+
+### §1.1 What is at stake, and why it is item 1
+
+The wing rejected fraction **already shipped** in wave 9. It is live product behaviour: it can raise a user's
+recommended exposure by 2×, and it is validated on **two datasets** — `D02` and `D16` — chosen because they are
+the two this class's argument was built on.
+
+**This project has watched a two-dataset conclusion reverse at full scale twice in one wave.** R2 went from
+"restarts recover 0–36 %" (wave 6, 7 runs) to **228 %** (wave 9, 11 runs). R3 looked like a clean win on wave 5's
+subset and regressed **4 of 6** newly-covered runs. Same sample size, same failure shape, and in wave 9's case the
+population that did not motivate the hypothesis refuted it. The wing statistic has had no such test.
+
+### §1.2 THE FALSIFICATION RULE, fixed before the pass runs
+
+Measured across **all 20 synthetic datasets + the 19-run real bank** (`astrodet` excluded,
+[F14](followups.md#f14--astrodet-is-frameless)) at the shipped-default invocation.
+
+> **RULE P, fixed in advance. `WingIsShedding` is REFUTED as a shipped default — and wave 10 turns it off — if
+> ANY of these fire:**
+>
+> - **P1 — the pre-registered fires do not fire.** `D10_rc16_3250mm_sparse` and `D17_cdk14_oiii5` are the bank's
+>   two genuinely photon-starved datasets (§1.3). If **neither** fires, the statistic does not detect the
+>   population it was built for and its two validation datasets were the whole of its evidence.
+> - **P2 — it fires everywhere.** If it fires on **> 50 %** of the 39 runs, it is not a diagnosis, it is a
+>   constant. A note that always fires says nothing (wave 9's own rule for `ContinueOptimizingAdviceText`).
+> - **P3 — it fires where more exposure is measurably WRONG.** If it fires on `D16_esprit550_ha3` at its derived
+>   exposure, W2 — the control the whole statistic had to pass — has failed on the bank. `D16`'s σ_focus minimum
+>   is at its derived 2 s and is worse at 4 s and 8 s, so asking for 2× there is asking the user to make their
+>   focus worse.
+> - **P4 — the instrument is not connected.** If `WingRejectedFraction` is **NaN on > 25 %** of runs, the wing
+>   axis is not populated often enough for the statistic to be product behaviour, and "we could not look" is
+>   being shipped as "nothing is shedding" in three runs out of four.
+>
+> **Firing on a dataset that newly qualifies is NOT a refutation** — but every such dataset must be **named with
+> a reason** in the results, because a statistic that quietly acquires new subjects at full scale is how R3
+> failed.
+
+**P1's direction is the one worth stating twice.** A candidate that does *not* fire on `D10`/`D17` is suspicious
+in the *other* direction from the usual over-firing worry. Both directions are pre-registered so neither can be
+explained away afterwards.
+
+### §1.3 Why `D10` and `D17` are the pre-registered fires
+
+They are the bank's only two **ceiling**-clamped datasets: their own derivation asks 335.6 s and 40.4 s and both
+are rendered at the 30 s cap (F19(c), wave 9 §2). They are photon-starved *relative to their own physics*, by
+construction and by a fact nobody had written down before wave 9. `D17` is additionally F19's poster child —
+799 on-frame stars and still starved, because an OIII filter starves it — i.e. exactly the case richness cannot
+see and the wing population is supposed to.
+
+### §1.4 What this instrument would do if the thing it checks were completely broken
+
+The harness computes `ExposureRecommendation` for **every** run regardless of display gating — wave 8's
+"gate the DISPLAY, never the MEASUREMENT" — so a statistic that is silently never evaluated shows up as NaN
+(P4) rather than as a clean row of zeros. And `WingRejectedFraction` is **NaN, never 0**, when the run cannot be
+placed on the wing axis, so "we could not look" and "we looked and nothing was shedding" are distinguishable in
+the output. Without both properties this pass would report a tidy all-clear on a statistic that never ran.
+
+### §1.5 Cost and shape
+
+**One sequential pass** over both banks at the shipped-default invocation with `FrameDiagnostics` carried, ~3–5 h.
+It is three things at once and that is why it is item 1: the population verdict, a **clean F55 control** (39
+`BaselineJ` values against the gate's, plus the eight against G10's), and it leaves the banks holding the
+**shipped-default landing** (F15).
+
+---
+
+## §2 — Item 2: F55(b), the nondeterminism itself
+
+### §2.1 Why this outranks compute
+
+Fixing it makes high fan-out safe (every future arm ~4× cheaper) and removes the doubt hanging over every
+cross-arm comparison this project makes. It is **not a compute task**: `D:\hf_w9\det\determinism_probe.sh`
+reproduces the whole 7-hour discrepancy in **40 seconds** — 5 sequential repeats identical, 5 concurrent split
+across the two attractors, and they are exactly the two values a 7-hour arm oscillated between.
+
+### §2.2 Already eliminated by measurement — do NOT re-run these
+
+The star-evaluation `Parallel.For` degree (swept 1/2/4/8/48, all identical); the per-run `optimized_settings.json`
+(with and without); the disk detection cache (the optimizer path does not read it); OpenCL/`UMat` (none exists);
+the frame-level fan-out (disjoint indices); `StarDetectorMetrics.Merge` + `SortBounds`; rented-array sorts
+(bounded overloads); `MedianInPlace` (fresh arrays); load-sensitive timeouts (none).
+
+### §2.3 The live clue, and what it does and does not fit
+
+The value is **stable within a session and variable across them**. That does not fit a per-iteration data race.
+It fits process-level state acquired once — a warm-up path, a static initialised from observed load, a JIT/tiering
+effect. Wave 9 also records five consecutive sequential repeats at the *other* attractor **"from one build"**,
+which raises a hypothesis wave 9 did not separate: **the attractor may be selected by the BUILD**, not only by
+load. If so, "nondeterminism" is partly build-to-build variation, which looks identical to anyone comparing arms
+built from different directories — and which [F42](followups.md#f42--every-build-directory-silently-gets-its-own-detector-settings-and-the-run-instructions-require-a-new-one-per-arm)
+and F53 have both been circling from other doors.
+
+### §2.4 The candidate wave 9 did not eliminate
+
+Wave 9 eliminated the **plugin's** parallelism. It did not eliminate **OpenCV's own**. `Cv2` routines dispatch
+through `cv::parallel_for_`, whose stripe count derives from the library's thread pool and an `nstripes`
+heuristic, and OpenCV additionally dispatches on IPP / hardware features. A convolution is elementwise and would
+not care; **a parallel reduction would** — a sum, mean or stddev split into a different number of stripes sums in
+a different order. That mechanism is load-sensitive, cross-process visible (a shared pool sees machine load),
+stable within a process, and bimodal rather than drifting. It is the shape of the observed defect and it is
+cheap to test.
+
+### §2.5 The experiments, in cost order
+
+1. **The cross-build probe (decisive for §0.2's fork, ~20 min).** Run the determinism probe on `toml999` with
+   wave 9's `exe` (v1) and wave 10's `exe` (v2) **back to back in one session**. If v1 gives 0.997993 five times
+   and v2 gives 0.995784 five times, the **build** selects the attractor and it is not session state — which
+   simultaneously answers H1/H2 and reframes F55.
+2. **The wavelet bisect (~30 min).** `StarDetector.cs:619/622` is the only call site and the legacy dense path
+   survives as `CvImageUtility`'s equivalence oracle, so a build with the legacy call restored isolates the
+   wavelet from everything else in the v1→v2 delta.
+3. **The OpenCV thread probe (~10 min).** Pin OpenCV to one thread and re-run the concurrent phase. If the
+   bimodality vanishes, §2.4 is the mechanism. **`WSLENV` must be set** — wave 9's parallelism sweep silently
+   measured the same configuration five times because a WSL environment variable does not reach a Windows
+   process, and *an instrument that is not connected reports perfect agreement*. The probe therefore carries a
+   positive control: a configuration that is KNOWN to change the answer must be shown to change it.
+4. **F53's stamp (~20 min, ships regardless).** `optimize` prints the informational version + commit + detector
+   version of the binary it ran. This is the standing fix for "a `Reproduce:` line names a COMMAND, not a
+   result", and it is the reason a future wave will not have to hand-record §0.4.
+
+**F54 may close for free with it** — its "the flip moves a landing at factor 1" is the same shape, on a binary
+pair, and a build-selected attractor would explain it without any `ApplyFactor` defect at all.
+
+---
+
+## §3 — Item 3: THE STEP RECOMMENDER DOES NOT CONVERGE
+
+### §3.1 The cluster, and why it is one thing
+
+Five entries — [F18](followups.md#f18--step-size-is-sized-by-curve-geometry-alone-so-the-sweep-outruns-what-the-detector-can-see),
+[F21](followups.md#f21--stepsizerecommenders-half-width-is-not-stable-against-noise-even-on-a-perfect-fit),
+[F25](followups.md#f25--from-a-far-too-wide-sweep-the-step-recommender-widens-it-further-instead-of-recovering),
+[F26](followups.md#f26--a-stuck-binning-recommendation-starves-the-step-update-indefinitely),
+F49(c)/[F51](followups.md#f51--capture-a-new-sweep-and-optimize-is-gated-on-the-exposure-recommendation-so-it-hides-exactly-when-the-run-needs-re-running--and-it-would-not-carry-the-new-step-size-anyway)'s
+remainder — are the same component read five ways, and F26 already says so in as many words. This is the largest
+untouched **user-facing** cluster in the register, and it has a field session behind it rather than a bank
+argument.
+
+The session: **100 → 214 → 459 → 474 → 482** across four runs, each costing 30–120 minutes, each telling the
+user to widen. The user experienced it as a runaway. Wave 9's F51 made the iteration **cheap** — the re-capture
+now carries the recommended step — and did nothing to make it **STOP**.
+
+### §3.2 The mechanism, and it is arithmetic rather than a mystery
+
+While the cap binds, `halfWidth = MaxHalfWidthSampledHalfSpanMultiple × ½ × searchSpan` and
+`step = halfWidth / PointsPerSide`. With `P` points per side actually executed, `searchSpan = 2·P·stepₙ`, so
+
+```
+stepₙ₊₁ = (1.5 × P / 3.5) × stepₙ
+```
+
+— **1.714× at 4 offset steps, 2.143× at 4 offset + 1 recovery.** The field session is exact at P = 5:
+100 → 214 (100 × 2.143 = 214.3), 214 → 459 (214 × 2.143 = 458.6). The ratio is a property of the ALGORITHM, not
+of the fit, and it does not depend on the extrapolation the cap exists to distrust.
+
+**So it does terminate**, geometrically, once the sweep is wide enough to contain the 3 × HFR_min band — and the
+field session shows it doing so: runs 3 and 4 asked +3 % and +5 %, i.e. the cap had stopped binding. **Nothing on
+the page says any of this.** The user is shown a number to accept, four times, with no statement that it is a
+deliberate partial step, what it converges toward, or that the asks are shrinking.
+
+### §3.3 What ships: the two halves, and only one of them is copy
+
+**(A) SAY it — F49(c) verbatim.** When the recommendation is capped, the page states that it is a partial step,
+what it is converging toward (`3 × HFR_min`), and the mechanism. The **ratio** is quotable because it is exact;
+a projected run count is not, because it is computed from the very extrapolation the cap distrusts. The
+exposure recommender's `MaxExposureFactor` copy already sets the precedent ("Run again to refine").
+
+**(B) MAKE it stop — the deadband.** 459 → 474 → 482 are asks of +3 % and +5 %, presented as changes to accept
+at 30–120 minutes each. Below some threshold the recommendation should read **"converged"** rather than a new
+number. The threshold is **derived, not chosen**:
+
+> **A deadband narrower than the recommender's own reproducibility is a deadband that does nothing.** F21
+> measures exactly that reproducibility and has owed the measurement since 2026-08-02 — two sweeps of one
+> dataset at one step, differing only in noise seed, both at R² = 1.0000, produced half-widths an order of
+> magnitude apart. So the deadband is set **at or above the measured run-to-run spread of the recommended step**
+> on the bank's S0 control, which closes F21's owed instrumentation and sizes the deadband in the same pass.
+
+### §3.4 The acceptance rule, fixed before the arm runs
+
+Measured with `synth-validate`, which is the recommender's own convergence driver, over the S0/S1/S2 scenarios
+wave 7's F18 arms used, one binary, `--settings` pinned, control arm = the shipped recommender.
+
+> **RULE S, fixed in advance.** The deadband ships only if **all** hold:
+> - **S1** rounds-to-converge is **not worse** on any cell, and **better on at least one**;
+> - **S2** the A3 final-step assertion passes on **at least as many** cells as the control — a deadband that
+>   converges by stopping short of the right answer is worse than the runaway;
+> - **S3** on the field session's own geometry, replayed as a unit test, the sequence **terminates** and does so
+>   at a step within the deadband of 459–482.
+>
+> **S2 is the clause that can kill it**, and it is the one that must not be relaxed. A deadband is a device for
+> declaring victory; the instrument that says whether victory was real is the assertion it could suppress.
+
+**What this would do if the deadband were completely broken:** set it to 100 % and every cell converges in one
+round with A3 failing everywhere — S1 passes, S2 collapses. S2 is therefore load-bearing rather than decorative,
+which is the check wave 9's lesson list asks of every harness.
+
+### §3.5 Explicitly NOT in scope, with reasons
+
+- **F25's fit-quality gate** (a degenerate fit at R² < 0 still ANSWERS) is a different defect in the same method
+  and is left open. It is not made worse by either half above.
+- **F26's deferral bound** is the wizard's binning-first update ORDERING, downstream of F22, not the
+  recommender's arithmetic. Untouched; F26 already says a passing bank must not be read as four entries closed.
+- **F18's `W_detect` default** stays OFF. Wave 7's arms returned a null — the bank cannot exercise the defect —
+  and nothing in this wave changes that.
+
+---
+
+## §4 — Deferred, with reasons rather than predictions
+
+- **F52(d)** (a cost term in `J`) has lost most of its motivation: PR #187 made per-layer wavelet cost nearly
+  flat, so `StructureLayers` is no longer a cost driver and **a cost term added now would penalise an artifact**.
+- **F46(b)** (present the binning recommendation) — nothing depends on it.
+
+*Wave 9's lesson 1 applies to both: a deferral priced on a PREDICTION is not priced. Neither of these is deferred
+on a forecast about what a later check would say — F52(d)'s motivation is measurably gone, and F46(b) has no
+dependents.*
+
+---
+
+## §5 — Traps this wave inherits, and how each is handled
+
+| trap | handling |
+|---|---|
+| `D:\hf_w9\f32_arms.sh` is `FANOUT=1` and must stay so until F55 is fixed | every wave-10 pass is sequential; §2 is the work that would lift it |
+| the wing threshold (0.20) rests on TWO datasets | that is item 1 |
+| `ContinueOptimizingAdviceText` reuses φ = 0.50 as a **DIAGNOSTIC** | never to be confused with the CONSTRAINT of the same value, which wave 9 refuted as a default (σ_focus ×2000 on `vsn07`) |
+| `score_f32.py` coerces Newtonsoft `"NaN"` STRINGS | `Panos` has a genuinely degenerate σ fit in every arm; any new scorer inherits both facts |
+| the banks hold wave 9's arm A landing, measured on version 1 | §0.3 — the gate and item 1 both run at that same invocation |
+| the csproj PostBuild xcopy fails **silently** when NINA is running | a build reporting "Copying …" may have deployed nothing; verify before believing an in-app test |
+| wave 8's AF changes are **still unconfirmed in the app** | ask before assuming they work |
+
+## §6 — Measurement discipline this wave is bound by
+
+Each line cost real time to learn, and they are repeated because wave 9 caught itself with several of them.
+
+1. **Write the falsification rule down BEFORE running.** RULE G voided a 7-hour arm; applying it as written was
+   the whole value of running it. RULE P and RULE S are in §1.2 and §3.4, above the results.
+2. **The population that did not motivate a hypothesis is the one that tests it.** This fired twice in wave 9 and
+   both times the conclusion reversed. Use full-bank populations for anything that decides a default.
+3. **Verify the instrument is CONNECTED before believing a null.** An instrument that is not connected reports
+   perfect agreement (`WSLENV`, §2.5).
+4. **A FLOP count is not a benchmark.** Wave 9 rewrote a kernel on an arithmetic argument and shipped something
+   50 % slower, because the stage is memory-bandwidth bound.
+5. **Pin `--settings` on every arm** (F42) and never rebuild an arm's exe directory (F53).
+6. **`BaselineJ` is a FREE control** (F41) — and a number agreeing *too* well is also an instrument failure.
+7. **Check whether a cheap instrument already exists, and whether the expensive step is necessary at all**,
+   before planning it. F19(c) cost minutes and cancelled a re-render.
+8. **Ask of every harness: what would this do if the thing it checks were completely broken?** §1.4 and §3.4
+   answer it in writing.
+9. **Verify your own test comments' discriminating power.** Wave 9 caught two overclaims of its own that way.
+10. **A gate's false-negative count is an UPPER BOUND** on what relieving it buys, not an estimate (F50).
+11. **On CI, verify the test COUNT, not the tick** (F37 — a native host crash reports ZERO failures with a
+    REDUCED count), and remember an ABSENT check is more dangerous than a red one.

--- a/docs/synthetic-af-bank-followups-wave10-design.md
+++ b/docs/synthetic-af-bank-followups-wave10-design.md
@@ -152,6 +152,22 @@ is not "is the wing fraction high" but "is it higher than the INNER third's"**, 
 > **Adopting a replacement on the refuting data would be fishing**, and this wave does not do it. The
 > measurement (`WingRejectedFraction`) stays; only the ACTION is withdrawn.
 
+### §1.2b What "withdraw the action" reaches — THREE sites, not one
+
+Enumerated before the verdict, because the third one was not obvious and is the most consequential:
+
+| # | site | what it does today |
+|---|---|---|
+| 1 | `rawFactor = max(rawFactor, WingProbeFactor)` | raises the recommended exposure to **2× current** |
+| 2 | `exposureIsNotTheLimit = … && !wingIsShedding` | flips the user-facing verdict from *"your exposure is fine"* to *"exposure is the limit"*, which also re-routes `StarSignalCopy.RemedyFor` (F49) |
+| 3 | `StarDetectionOptimizerWizardVM.BuildSearchExposureAdvice` | **tells the user to CANCEL a running two-hour optimization** |
+
+**Site 3 is why this matters more than an exposure number.** F52(c) shipped in wave 9 on the explicit reasoning
+that *"facts about COST need no statistic; ADVICE needs one"* — and the statistic it was given is the one under
+test. It is computed from the **seed** evaluation, i.e. in the first minute, and if it fires on most runs then
+most users are advised to abandon their optimization before it has done anything. A statistic that fires
+everywhere is not merely uninformative there; it is expensive.
+
 ### §1.3 Why `D10` and `D17` are the pre-registered fires
 
 They are the bank's only two **ceiling**-clamped datasets: their own derivation asks 335.6 s and 40.4 s and both

--- a/docs/synthetic-af-bank-followups-wave10-design.md
+++ b/docs/synthetic-af-bank-followups-wave10-design.md
@@ -127,6 +127,31 @@ Measured across **all 20 synthetic datasets + the 19-run real bank** (`astrodet`
 in the *other* direction from the usual over-firing worry. Both directions are pre-registered so neither can be
 explained away afterwards.
 
+### §1.2a The control the statistic never had, and the SUCCESSOR — both fixed before the pass finished
+
+*Added while the pass was still running, after two rows had been seen. Recorded as such, because a candidate
+written after a refutation is motivated by it and has to be held to a higher bar, not a lower one.*
+
+`WingRejectedFraction` is `rejected / (rejected + accepted)` over the outer third. Its CLAIM is that the **wings**
+shed candidates a longer exposure could convert. But the detector rejects most connected components everywhere —
+most of them are noise — so a high fraction out there may say nothing about wings. **The discriminating question
+is not "is the wing fraction high" but "is it higher than the INNER third's"**, and that control is free from the
+`FrameDiagnostics` this pass already writes.
+
+> **The successor, `WingRejectedRatio` = wing-third fraction ÷ inner-third fraction, is PRE-REGISTERED AND NOT
+> ADOPTED THIS WAVE.** If RULE P fires, the shipped probe is withdrawn and the successor is left as a candidate
+> with its acceptance rule fixed here:
+>
+> - **RULE W1–W4 unchanged** (the wave-9 ladder: `D02`@0.5 s ≥ 2×; `D16`@2 s < 1.25×; converges; `D16`@0.5 s asks).
+> - **NEW W5 — it must SEPARATE.** Its threshold must sit above the median wing/inner ratio measured on the
+>   full bank, or it is the same defect in a new coordinate.
+> - **NEW W6 — the population that refuted the predecessor may not adopt the successor.** It must be validated
+>   on an arm run for it, not scored on this pass's rows. That is wave 9's R3 lesson applied in advance: a
+>   statistic tuned on the data that killed its predecessor has been fitted, not tested.
+>
+> **Adopting a replacement on the refuting data would be fishing**, and this wave does not do it. The
+> measurement (`WingRejectedFraction`) stays; only the ACTION is withdrawn.
+
 ### §1.3 Why `D10` and `D17` are the pre-registered fires
 
 They are the bank's only two **ceiling**-clamped datasets: their own derivation asks 335.6 s and 40.4 s and both

--- a/docs/synthetic-af-bank-followups-wave10-results.md
+++ b/docs/synthetic-af-bank-followups-wave10-results.md
@@ -89,8 +89,16 @@ differ between the two measurements — the binary and the folder state** — an
   without the file present, identical) — but on `D16` and on the v1 binary, not here.
 - **The decisive control is §3.1's cross-build probe**, which runs `toml999` on wave 9's v1 binary against
   TODAY's folder state. Same folder, different binary: if it returns wave 9's 0.997840, folder state is excluded
-  and the wavelet is the cause; if it returns 0.983477, the folder state is the cause and the wavelet is
+  and the BINARY is the cause; if it returns 0.983477, the folder state is the cause and the binary is
   exonerated. **The seed-evaluation claim above is held open until that control reports.**
+
+**And "the binary" is not yet "the wavelet", which is a second step.** The two exes differ by PR #187 *plus*
+whatever wave-9 code landed after `D:\hf_w9\exe` was built (its `.dll` is stamped 2026-08-06 19:40, and several
+wave-9 commits post-date it). Those additions are all post-search or UI — wave 9 verified the wing statistic is
+computed *after* the search and is inert on it, and F49/F51/F52(c) are copy — so PR #187 is the only plausible
+search-relevant term. **Plausible is not measured**, which is why §3.2's bisect build exists: the wave-10 tree
+with `StarDetector.cs`'s two call sites reverted to the legacy dense path isolates the wavelet from every other
+difference at once. Until it reports, this section attributes to *the binary*, not to *the wavelet*.
 
 *(`D:\hf_w9\exe`, `exe2`, `exe_f56` and `exe_bisect` were each confirmed to be v1 builds before any of this was
 attributed — `strings <dll> | grep AtrousWaveletFast` returns 0 on all four and 1 on `D:\hf_w10\exe`. That is a

--- a/docs/synthetic-af-bank-followups-wave10-results.md
+++ b/docs/synthetic-af-bank-followups-wave10-results.md
@@ -161,7 +161,64 @@ under the validated guard; nothing in §2 is measured on the contaminated data.
 
 ## §2 — Item 1: F19's population check
 
-*(pending — the pass is running)*
+### §2.1 The real bank, all 19 runs
+
+Shipped-default invocation, sequential, `--settings` pinned. `WingRejectedFraction` is the shipped statistic;
+`inner` is **the control it never had** — its own quantity computed on the INNER third of the sweep instead of
+the outer third.
+
+| run | wing | inner | wing/inner | fires |
+|---|---|---|---|---|
+| `CWhiteFocus` | 0.879 | 0.795 | 1.11 | yes |
+| `FlyData` | 0.675 | 0.572 | 1.18 | yes |
+| **`LinwoodFocus`** | **0.375** | **0.537** | **0.70** | **yes** |
+| `Panos` | 0.817 | 0.442 | 1.85 | yes |
+| `SorenVance` | 0.520 | 0.242 | 2.15 | yes |
+| `bobp` | 0.610 | 0.247 | 2.47 | yes |
+| `bobp_m101` | 0.446 | 0.264 | 1.69 | yes |
+| `caboose` | **0.000** | 0.000 | — | no |
+| **`cwhite_2026`** | **0.868** | **0.883** | **0.98** | **yes** |
+| `fmeschia_Focus` | 0.352 | 0.317 | 1.11 | yes |
+| `lumos` | **NaN** | 0.376 | — | no |
+| `mccomiskey` | **0.000** | 0.000 | — | no |
+| `mufti` | 0.661 | 0.577 | 1.15 | yes |
+| `muggsie` | 0.855 | 0.617 | 1.39 | yes |
+| `standard_example1` | 0.863 | 0.775 | 1.11 | yes |
+| `timmer` | 0.819 | 0.524 | 1.56 | yes |
+| **`toml999`** | **0.544** | **0.567** | **0.96** | **yes** |
+| `uneven` | 0.727 | 0.635 | 1.14 | yes |
+| **`vsn07`** | **0.853** | **0.905** | **0.94** | **yes** |
+
+**16 of 19 fire. Median wing/inner = 1.15.**
+
+### §2.2 Two findings, and the second one is the sharper
+
+**(a) The wings are not special.** Four runs — `LinwoodFocus` 0.70, `vsn07` 0.94, `toml999` 0.96, `cwhite_2026`
+0.98 — reject **fewer** candidates in their wings than in their cores, and all four fire. The statistic's whole
+justification is that the wing rejections are faint stars a longer exposure could convert; if the core rejects at
+the same rate, where the stars are brightest and most numerous, the rejected population is dominated by noise the
+detector is *supposed* to reject. **The statistic cannot tell "the wings are losing faint stars" from "the
+detector is rejecting noise everywhere", and on this bank it is measuring the second.**
+
+**(b) THE THRESHOLD DOES NO WORK.** The measured fractions are **0.000, 0.000** and then **0.352 … 0.879**.
+Nothing on the real bank lands between them. So **every threshold in (0, 0.352) selects exactly the same 16
+runs**, and 0.20 is an arbitrary point inside a wide gap. What the test actually asks is *"did the gate reject
+anything at all?"* — which is
+[F28](followups.md#f28--lowsensitivity-reads-exactly-zero-precisely-when-the-sensitivity-gate-has-collapsed)'s
+question, and which `GateIsProvablyInert` already answers with a different field.
+
+**Where the 0.20 came from, and why it looked reasonable.** The unit fixtures span a rejected fraction of
+**0.002** (`wingRejected: 1, wingAccepted: 500`, the "healthy wings" pole) to **0.75** (`600 / 800`, the
+"shedding" pole), and 0.20 sits sensibly between them. **No real run in the bank resembles the healthy pole.**
+The threshold was calibrated against a range the data does not occupy — which is a thing a unit test cannot
+notice, and which only a population can.
+
+**And every firing run asks exactly 2×.** `rawFactor = max((10/S_now)², 2.0)`, and the accepted-star term is
+0.000–0.30 on every one of these runs, so the probe always wins. The recommendation therefore carries no
+information beyond *"it fired"*.
+
+*(§2.3, the synthetic half and the RULE P verdict, follows — P1 and P3 name synthetic datasets and the pass is
+still running. **16/39 is 41 %, so P2's verdict genuinely depends on the synthetic half** and is not called here.)*
 
 ---
 

--- a/docs/synthetic-af-bank-followups-wave10-results.md
+++ b/docs/synthetic-af-bank-followups-wave10-results.md
@@ -20,13 +20,16 @@ Register: [`docs/followups.md`](followups.md).
 
 | item | state |
 |---|---|
-| **RULE G10-A** — the fixed point reproducing against itself | see §1.3 |
-| **RULE G10-B** — how many landings a ≤ 3e-8 change moves | **FIRES AT THE TOP TIER: 6 of 8.** And the seed evaluation — no search at all — moved on `toml999`. See §1 |
-| **item 1** — F19's population check | see §2 |
-| **item 2** — F55(b), the nondeterminism | see §3 |
-| **item 3** — the step recommender | see §4 |
-| **F53** — the build stamp | **SHIPPED.** And the field that claimed to identify the build is shown not to. See §3.4 |
-| **F49(c)** — what a capped step says | **SHIPPED**, with a ratio that is exact and measured against 22 on-disk rounds. See §4 |
+| **RULE G10-A** — the fixed point reproducing against itself | **PASS, 8 of 8 to 6 dp.** See §2.4 |
+| **RULE G10-B** — how many landings a ≤ 3e-8 change moves | fired at its top tier (6 of 8) and is **VOID**: its own pre-registered control refuted the attribution. **The wavelet is exonerated; the active NINA profile is the cause.** See §1.2–§1.3 |
+| **item 1** — F19's population check | **RULE P FIRES (P2: 30 of 39 = 76.9 %). The wing verdict is WITHDRAWN**, along with the 2× ask, the verdict override and F52(c)'s abort advice. See §2 |
+| **item 2** — F55(b), the nondeterminism | **NOT solved.** The build-selects-the-attractor hypothesis is DEAD (15 runs, 3 binaries, identical to 10 dp); the amplifier's GAIN is measured and pinned by a test; the trigger RATE is still owed. See §3 |
+| **item 3** — the step recommender | **F49(c) SHIPPED** with an exact ratio; **F21's hypothesis refuted** (its round 0 reproduces, its collapse does not); **the deadband REFUTED before implementation** by the rule fixed to size it. See §4 |
+| **F53** — the build stamp | **SHIPPED** (`BuildId` + `DetectorVersion`, joined by `ProfileId` for F57). The field that claimed to identify the build is shown not to. See §3.3 |
+| **F49(c)** — what a capped step says | **SHIPPED**, with a ratio that is exact and measured against 22 on-disk rounds. See §4.1 |
+| **F55(c)** — concurrency | **SHIPPED as a FIELD.** This wave violated its own rule and needed it. See §1b |
+| **F57** — new | **A `--settings`-pinned arm is not pinned: the active NINA profile moves `BaselineJ` by 0.0144.** See §1.3 |
+| **the full suite** | **3722 passed, 0 failed** (`develop` was 3708 → **+14**, every one accounted for) |
 
 ---
 
@@ -50,60 +53,67 @@ sequentially, nothing else running ([F55](followups.md#f55--optimize-is-not-repr
 | `D19_cygnus_deep_shed` | 0.999187 | 0.999187 | = | 0.999557 | **0.999487** | **MOVED** |
 | `D20_m24_bright_control` | 0.999454 | 0.999454 | = | 0.999766 | **0.999738** | **MOVED** |
 
-### §1.2 RULE G10-B fires at its top tier, and the reading was fixed before the numbers arrived
+### §1.2 RULE G10-B fired at its top tier — AND IT IS VOID. The cause is not the wavelet.
 
-> **6 of 8 landings moved.** The pre-registered table said: 0 ⇒ inert; **1–3 ⇒ the expected pattern-search
-> amplification** ([F8](followups.md#f8--optimizer-landings-are-not-reproducible-across-invocations)); **≥ 5 ⇒
-> the "≤ 3e-8" claim describes the per-pixel RESIDUAL and not the detector's BEHAVIOUR, and PR #187 needs
-> re-examining as a change that moves product landings.**
+> **6 of 8 landings moved.** The pre-registered table said: 0 ⇒ inert; 1–3 ⇒ the expected pattern-search
+> amplification ([F8](followups.md#f8--optimizer-landings-are-not-reproducible-across-invocations)); **≥ 5 ⇒ the
+> "≤ 3e-8" claim describes the per-pixel RESIDUAL and not the detector's BEHAVIOUR.**
 
-**And the seed evaluation moved, which is the sharper half.** `BaselineJ` is a **single evaluation of the pinned
-seed with no search involved**, so nothing amplifies it. On `toml999` it moves by **0.0144** — six orders of
-magnitude above 3e-8 — between two binaries whose every printed seed input is identical: same settings file
-(same export stamp, same "0 advanced knobs overridden" warning), `Sensitivity=10`,
-`StarClippingMultiplier=2`, `NoiseClippingMultiplier=4`, `StructureLayers=4`, inferred step 21, exposure 5 s,
-`PixelScale 0.73944 arcsec/px (frame header)`, detection binning `1 from harness_settings.json`.
+That reading was written before the numbers and the numbers came back at its top tier, so it was published: a
+detector change bounded at 3e-8 per pixel appeared to move six product landings and one **seed evaluation** — a
+single evaluation of the pinned seed, no search, nothing to amplify it — by **0.0144**. Every printed seed input
+was identical.
 
-**This is not a defect in PR #187's own claim.** The two wavelet paths do agree to ≤ 3e-8 per pixel, and the
-version bump exists precisely because they are not bit-identical. What the gate measures is the **consequence**:
-a detector whose per-pixel output moves in the eighth decimal moves 6 of 8 product landings and one seed
-evaluation in the second. *A numerical-equivalence bound on an intermediate is not an equivalence bound on the
-answer* — the star gate is a threshold, and a threshold turns an eighth-decimal difference into a whole star
-appearing or not appearing.
+**Then the control that had been pre-registered for exactly this refuted it (§3.1).** Fifteen runs — five each on
+wave 9's v1 binary, wave 10's v2 binary, and a **bisect build** (wave 10's tree with the wavelet reverted to the
+legacy dense path), interleaved in one session on identical folder copies — all returned **`0.9834767969`,
+identical to ten decimal places.**
 
-**What it changes.** Wave 5's φ table, wave 6's arm R and wave 9's F32 verdict are all readable **within** their
-own binaries and none of them is retracted. What is now measured rather than assumed is that they cannot be
-compared **across** the version boundary at all — which is what wave 9's provenance banner asked for and what
-this table supplies with a number.
+- **The wavelet is exonerated outright.** v2 and the bisect differ *only* in the wavelet and agree exactly.
+- **The binary is exonerated.** v1 and v2 agree exactly.
+- **Folder state is exonerated**, one artifact at a time: removing `optimized_settings.json`,
+  `hocusfocus_star_detection.json`, `autofocus_report_Region0.json` or `run_meta.json` changed nothing, and the
+  frames and `harness_settings.json` predate both waves.
 
-### §1.3 The confound the seed result has to survive, and the control that settles it
+**What was left is the one input nobody compares:**
 
-`BaselineJ` is read on folders that a previous arm wrote into
-([F15](followups.md#f15--optimize---per-run-overwrites-each-runs-stored-settings)), and wave 9's gate ran on a
-wave-8-era folder state while wave 10's ran on wave 9's arm-A landing. So the honest reading is that **two things
-differ between the two measurements — the binary and the folder state** — and one of them is not the wavelet.
+| | wave 9's gate | wave 10's gate |
+|---|---|---|
+| `--settings` | `hf_w9\pinned_settings.json` | `hf_w10\pinned_settings.json` — **byte-identical**, `md5 df7c7cd1…` |
+| **`Profile:`** | **`Default (b10b1d6d-…)`** | **`astrodet (ce3f3e63-…)`** |
 
-- **`harness_settings.json` is excluded outright.** `toml999`'s is dated **2026-07-31 12:43**, i.e. untouched
-  since before wave 8, so it is byte-identical across both gates.
-- **`optimized_settings.json` is the live one.** F55's own investigation measured it as inert (run with and
-  without the file present, identical) — but on `D16` and on the v1 binary, not here.
-- **The decisive control is §3.1's cross-build probe**, which runs `toml999` on wave 9's v1 binary against
-  TODAY's folder state. Same folder, different binary: if it returns wave 9's 0.997840, folder state is excluded
-  and the BINARY is the cause; if it returns 0.983477, the folder state is the cause and the binary is
-  exonerated. **The seed-evaluation claim above is held open until that control reports.**
+**Re-running `toml999` today under `--profile-id b10b1d6d-…` returns `0.9978404571` — wave 9's value to 6 dp.**
 
-**And "the binary" is not yet "the wavelet", which is a second step.** The two exes differ by PR #187 *plus*
-whatever wave-9 code landed after `D:\hf_w9\exe` was built (its `.dll` is stamped 2026-08-06 19:40, and several
-wave-9 commits post-date it). Those additions are all post-search or UI — wave 9 verified the wing statistic is
-computed *after* the search and is inert on it, and F49/F51/F52(c) are copy — so PR #187 is the only plausible
-search-relevant term. **Plausible is not measured**, which is why §3.2's bisect build exists: the wave-10 tree
-with `StarDetector.cs`'s two call sites reverted to the legacy dense path isolates the wavelet from every other
-difference at once. Until it reports, this section attributes to *the binary*, not to *the wavelet*.
+**So G10-B is VOID, not merely uncertain.** It compared two waves that ran under different NINA profiles, and it
+therefore measures the profile at least as much as the binary. Nothing in this wave implicates PR #187. Filed as
+[F57](followups.md#f57--a---settings-pinned-arm-is-not-pinned-the-active-nina-profile-moves-baselinej-by-0014-and-every-cross-wave-comparison-inherits-it),
+rewritten from what it originally claimed.
 
-*(`D:\hf_w9\exe`, `exe2`, `exe_f56` and `exe_bisect` were each confirmed to be v1 builds before any of this was
-attributed — `strings <dll> | grep AtrousWaveletFast` returns 0 on all four and 1 on `D:\hf_w10\exe`. That is a
-retroactive build-identity check that works on every artifact directory already on disk, and it is how F53's
-question was answered for the binaries that predate F53's stamp.)*
+### §1.3 The finding that replaces it, and it is larger
+
+**`--settings` pins the DETECTOR knobs. This project has treated that as pinning the arm. It does not.** The
+harness also loads whichever NINA profile is ACTIVE, and that profile moves `BaselineJ` — the objective of a
+fixed seed on fixed frames, with no search anywhere in it — by **0.0144**, which is larger than the entire Δ`J`
+any wave has ever argued about.
+
+[F42](followups.md#f42--every-build-directory-silently-gets-its-own-detector-settings-and-the-run-instructions-require-a-new-one-per-arm)
+**predicted this in words** — *"`TryLoad("")` picks whichever profile is ACTIVE — two runs of the same data
+minutes apart were seeded from different telescopes"* — and the remedy it prompted, pinning the detector
+settings, does not close it. **The prediction was right, the remedy was incomplete, and the residue went
+unmeasured until a control written for an unrelated hypothesis forced it out.**
+
+Every cross-wave `BaselineJ`/landing comparison in the register is exposed to this. Waves 5–9's controls passed,
+which is evidence the active profile happened to be stable across them — **it is not evidence that it was
+pinned.** `ProfileId` now goes into `OptimizerProvenance` beside this wave's `BuildId` and `DetectorVersion`:
+the same argument, one input further out.
+
+**RULE G10-A is NOT affected and still passes 8 of 8** (§2.4). It compares two runs *within* wave 10, under one
+profile — which is exactly why this wave's own measurements remain readable while its cross-wave one does not.
+
+**And the lesson is about the shape of the control, not about profiles.** The three-way probe was designed to
+separate the wavelet from the binary. It answered a question nobody had asked, because it was built to *exclude
+things* rather than to confirm a favourite. A control that can only confirm would have returned "6 of 8, as
+predicted" and this wave would have shipped a false finding about PR #187.
 
 ### §1.4 A smaller thing the gate caught about its own instrument
 
@@ -261,15 +271,133 @@ is not yet `toml999`'s seed evaluation on the v1 binary (§3.1's control), but i
 
 ---
 
-## §3 — Item 2: F55(b)
+## §3 — Item 2: F55(b), the nondeterminism
 
-*(pending)*
+### §3.1 The cross-build probe, which answered a question nobody asked
+
+Five sequential repeats each of wave 9's **v1** binary, wave 10's **v2**, and a **bisect build** (wave 10's tree
+with `StarDetector.cs`'s two wavelet call sites reverted to the legacy dense path), **interleaved in one
+session** — blocked runs would have confounded the binary with elapsed time and machine warm-up, which is the
+class of confound F55 is made of — each on its own pristine copy of `toml999`, `--max-evals 1` so `BaselineJ` is
+the whole measurement.
+
+> **All 15 returned `0.9834767969`. Identical to ten decimal places.**
+
+**Three things follow.**
+
+1. **The BUILD does not select the attractor.** Wave 9's sharpest open clue was five sequential repeats at the
+   *other* attractor *"from one build"*, raising the possibility that part of F55 is build-to-build variation.
+   Here two binaries a wave apart agree exactly. **That hypothesis is dead**, and F55's mechanism is still open.
+2. **The wavelet is exonerated** (§1.2), and with it F57's original claim.
+3. **The seed evaluation IS a pure function of (frames, settings, profile).** Under a fixed profile it is
+   perfectly reproducible across binaries, folder states and sessions — which sharpens F55 rather than solving
+   it: whatever moves under CONCURRENCY is not moving under any of these.
+
+### §3.2 What was NOT run, and why
+
+**The landing-level wavelet bisect was not run.** `exe_v1wav` exists and the command is one line, but it is
+8 runs × 2 binaries ≈ 80 minutes, and it was not pre-registered. Running it would have displaced item 3, which
+was. **The seed-level answer is already in and is exact**; what remains open is only whether the pattern search
+amplifies an identical seed into different landings — which is [F8](followups.md#f8--optimizer-landings-are-not-reproducible-across-invocations),
+not a new question. It is written into F57's next step with its exact invocation.
+
+**`KappaSigmaNoiseEstimate` was not probed on the bank.** Design §2.4a names it as the specific bimodal
+amplifier: an OpenCV parallel reduction feeding a convergence test at `|Δσ| ≤ 1e-5`, where one flipped comparison
+buys an extra iteration and moves σ macroscopically. **The gain is now measured and permanent** — a unit test
+asserts that one extra iteration moves σ by ≥ 100× the tolerance that decides whether to take it, so if that ever
+stops being true the entry says so. **The trigger RATE is still unmeasured**, and that is what the 40-second
+probe would give.
+
+**Eliminated by reading, and recorded because it is the most F55-shaped thing in the path:**
+`CvImageUtility.CalculateStatistics` selects its median with a **quickselect whose pivot comes from
+`Random.Shared`** — process-level shared state consumed in a thread-interleaving-dependent order, exactly the
+signature. It is nevertheless **inert**: quickselect returns the value at rank *n* whatever the pivots were, and
+`Mat.GetArray` returns a **copy**, so the in-place permutation never reaches the image.
+
+### §3.3 F53 — the build stamp, shipped
+
+`OptimizerProvenance.ProducerVersion` claimed to identify the build and **cannot**: two builds of one version
+share it, which is exactly how wave 8's arm X became irreproducible from its own recorded `exe`. `BuildId` (the
+assembly **MVID**, regenerated on every build) and `DetectorVersion` now go into every landing and are printed by
+`optimize`. **And `ProfileId` joins them** — F57, the same argument one input further out.
+
+**A retroactive instrument, for the artifacts that predate the stamp:** `strings <dll> | grep AtrousWaveletFast`
+distinguishes a v1 build from a v2 build without running it. It is how wave 10 established that all four wave-9
+build directories are v1 rather than assuming it.
 
 ---
 
 ## §4 — Item 3: the step recommender
 
-*(pending)*
+### §4.1 F49(c) — SHIPPED, and the ratio it quotes is exact
+
+A capped recommendation now states that it is a **partial step**, names what it converges toward
+(`3 × HFR_min`), reports the HFR dynamic range **the sweep actually measured**, and quotes the **exact** factor
+the next capped run will apply.
+
+**The mechanism is arithmetic, not a mystery.** While the cap binds,
+`step′ = (MaxHalfWidthSampledHalfSpanMultiple × P / PointsPerSide) × step` — **1.714× at 4 offset steps, 2.143×
+at 4 offset + 1 recovery** — and nothing in it depends on the extrapolated half-width the cap exists to distrust.
+That is why the ratio is quotable to a user and **a projected run count is not**.
+
+**Measured against 22 capped rounds already on disk**, at zero compute: wave 7's F18 control arm has 22 capped
+rounds across six datasets and every one lands at a realized ratio of **1.667–1.750** (the scatter is integer
+rounding of the step). The field session behind F49/F51 ran **100 → 214 → 459** at P = 5: 100 × 2.143 = 214.3,
+214 × 2.143 = 458.6. The entry derives 459 independently from the screenshot's focuser axis, so those are two
+routes to the same number.
+
+**And the sequence terminates**, which is the half of the user's complaint that is not a defect: the widening is
+geometric until the sweep contains the band, and their runs 3 and 4 asked +3 % and +5 %. A unit test replays the
+session and asserts the cap releases.
+
+### §4.2 F21 — round 0 reproduces EXACTLY; the collapse does not
+
+F21's own reproduce line, run on this binary: `D17_cdk14_oiii5`, S0, `--max-rounds 2`.
+
+| | F21 as recorded | wave 10 |
+|---|---|---|
+| round 0 `HalfWidth` | 143.6 | **143.583** |
+| round 0 step | 41 | **41** |
+| round 1 | `HalfWidth` **12.1**, step **3** | **did not occur — converged in 1 round** |
+
+**The instrument is right and the pathology did not recur** — the same shape as F25, whose 4×→7× over-reach also
+failed to reproduce on re-measurement. So F21's headline remains a real observation of a real run and **not** a
+reproducible case.
+
+**Its stated hypothesis is not supported.** F21 blames `FindHalfWidth`'s coarse walk terminating early. But
+`FindHalfWidth` is exact for a hyperbola — it returns `√8 · HFR_min / κ` — so its output is **proportional to the
+fitted vertex HFR**. Wave 7's control arm, on disk, shows exactly that: over uncapped rounds `halfWidth / vertexY`
+holds to **×1.03–×1.14** within a dataset while `halfWidth` itself spans up to **×1.69**, and the ratio differs
+strongly *between* datasets as `√8/κ` should. **The walk is not what moves; the FIT's vertex is** — and
+`R² = 1.0000` is no evidence against that, because R² measures fit to the sampled points and says nothing about
+whether the vertex is identifiable from them. *Confirmed on six datasets, but not on F21's own, because F21's own
+case would not reproduce.*
+
+### §4.3 The deadband — REFUTED before implementation, by the rule fixed to size it
+
+Design §3.3(B) fixed the rule in advance: *"a deadband narrower than the recommender's own reproducibility is a
+deadband that does nothing"*, so the threshold must sit **at or above the measured run-to-run spread**.
+
+**The rule has no valid input, and that is the answer.** Measured:
+
+- **With a fixed seed the recommender is BIT-REPRODUCIBLE** — all six S0 half-widths are identical to full double
+  precision between wave 7's v1 binary and wave 10's v2 (130.132 / 129.313 / 399.122 / 396.872 / 168.835 /
+  73.358). Spread **zero**, so a rule-compliant deadband is zero and does nothing.
+- **The variability F21 describes comes from a different noise realization**, and its only recorded instance did
+  not reproduce (§4.2).
+- **And the asks it would have to suppress are large and possibly correct.** On S0 — where the bootstrap IS each
+  dataset's expected optimum — the recommender asks for a median **19.9 %** change (max 40 %). A deadband wide
+  enough to cover that would suppress **4 of 6** of them, which is RULE S's **S2** clause (*"the A3 final-step
+  assertion must pass on at least as many cells"*) failing by construction. Whether the recommender or the bank
+  is right about those 20 % gaps is F18's open question, and a deadband would bury it.
+
+**So RULE S was never applied: the mechanism it was written to accept was refuted before implementation.** That
+is the same shape as wave 9's §3.4 — the cheap refutation arriving before the expensive confirmation, including
+of one's own plan — and it cost one measurement on data already on disk.
+
+**Explicitly NOT closed:** F25's fit-quality gate, F26's deferral bound, and F18's `W_detect` default all stay
+open and untouched. F18/F21/F25/F26/F49(c)/F51 are one component read six ways, and a shipped copy change is not
+four entries closed.
 
 ---
 
@@ -285,11 +413,19 @@ without anyone having been watching. The register already contains the same move
 free control (F41), `DetectionBinningSource` as a field rather than a sentence (F39(a)), `BuildId` rather than a
 version string (F53).
 
-**1. A numerical-equivalence bound on an intermediate is not an equivalence bound on the answer.** PR #187's
-wavelet paths agree to ≤ 3e-8 per pixel and the claim is true. Six of eight product landings still moved, and one
-seed evaluation — no search, nothing to amplify it — moved by 0.0144. The star gate is a **threshold**, and a
-threshold converts an eighth-decimal difference into a whole star. Any future change justified as "equivalent to
-N decimals" needs the bound on the quantity the product REPORTS.
+**1. Design the control to EXCLUDE, not to confirm — and this wave's headline is what that bought.** The gate
+came back at RULE G10-B's top tier (6 of 8 landings moved), with a seed evaluation moving 0.0144 on inputs that
+printed identical. That was written up as "a ≤ 3e-8 detector change moves product answers", and it was **wrong**.
+The pre-registered three-way probe — v1, v2, and a wavelet bisect, interleaved — returned fifteen identical
+values and killed it, and one-artifact-at-a-time folder elimination killed the alternatives, leaving the one
+input nobody compares: **the active NINA profile**. A control built to confirm would have returned "6 of 8, as
+predicted" and this wave would have shipped a false finding about PR #187.
+
+**1b. A rule can be right and its remedy still incomplete.** F42 wrote down *"`TryLoad("")` picks whichever
+profile is ACTIVE"* and prompted `--settings` pinning. That pins the DETECTOR knobs and leaves the profile
+floating, and the residue moves `BaselineJ` — a fixed seed on fixed frames — by more than any Δ`J` this project
+has argued about. **A prediction is not a measurement, and a partial remedy reads exactly like a complete one
+until something forces the difference out.**
 
 **2. A unit fixture's range is not the population's range.** *(see §2)* The wing statistic's threshold was
 chosen against fixtures spanning a rejected fraction of 0.005 to 0.75. Whether that is the range real runs

--- a/docs/synthetic-af-bank-followups-wave10-results.md
+++ b/docs/synthetic-af-bank-followups-wave10-results.md
@@ -116,6 +116,49 @@ looked like a crash.
 
 ---
 
+## §1b — THE WAVE RAN ITS OWN POPULATION PASS TWICE AT ONCE, AND THE RULE AGAINST IT WAS ALREADY WRITTEN DOWN
+
+This belongs above the results it nearly destroyed, not in a footnote.
+
+**What happened.** The population pass must be sequential — F55 measures concurrent `optimize` moving **44 % of
+landings**. That was written into this wave's design, into its plan, and into the header of the script that ran
+it. A background launcher had been started to chain the pass behind the gate; it reported **"completed"**, and a
+`ps` check showed nothing surviving, so a second launch was issued. **The launcher's shell had exited; its
+`nohup`'d driver had not**, and it lived in a process namespace the checking shell could not see. Two drivers,
+two `optimize` processes, the same bank folders, for eleven minutes.
+
+**What caught it.** Not the rule, and not vigilance — an instrument built for something else. A trace diff,
+written to find the FIRST divergent evaluation between two runs of one invocation, printed an impossible
+improvement ladder; the log turned out to contain two complete optimizations.
+
+**That instrument had to be repaired before it could catch anything.** Its first version diffed the raw
+`[Phase] evals=N bestJ=…` lines — which come partly from a **wall-clock progress timer** that merely repeats the
+current best. A busier machine logs a different number of lines at different evaluation counts, so the first
+version reported "divergence" on every pair of runs, whether or not the search diverged. Asked the question this
+wave is bound by — *what would this do if the thing it checks were completely broken?* — the answer was **exactly
+the same thing**. Keeping only the entries where `bestJ` CHANGES leaves the improvement events, whose evaluation
+index is exact.
+
+**And the guard written in response was itself broken, in the most on-the-nose way available.** `grep -c` prints
+`0` **and exits 1** when there is no match, so `RUNNING=$(… | grep -ci … || echo 0)` produced the two-line string
+`"0\n0"`; the numeric comparison then errored and the guard **fell through, reporting SAFE unconditionally**.
+That is wave 9's *"an instrument that is not connected reports PERFECT AGREEMENT"*, reproduced inside the guard
+written to enforce it, within the hour. It was fixed and then **validated against a positive control** — a
+deliberately-started `optimize` — before being trusted. Both clauses fired.
+
+**What ships because of it.** `optimize` now claims a named mutex and records `ConcurrencyCheck`
+(`exclusive` / `concurrent` / `unknown`) into **every landing it writes**. Three values and not two, for the same
+reason `WingRejectedFraction` is NaN-never-0: a check that could not run must not read as a check that ran and
+found nothing. **A rule that depends on the operator noticing a violation is not a control; it is a hope.** The
+register is already full of the mechanical version of that move — `BaselineJ` as a free control (F41),
+`DetectionBinningSource` as a field rather than a sentence (F39(a)), `BuildId` rather than a version string
+(F53).
+
+**Cost:** eleven minutes of compute, discarded in full. The pass was deleted and restarted from zero at 14:06Z
+under the validated guard; nothing in §2 is measured on the contaminated data.
+
+---
+
 ## §2 — Item 1: F19's population check
 
 *(pending — the pass is running)*

--- a/docs/synthetic-af-bank-followups-wave10-results.md
+++ b/docs/synthetic-af-bank-followups-wave10-results.md
@@ -200,11 +200,19 @@ chosen against fixtures spanning a rejected fraction of 0.005 to 0.75. Whether t
 occupy is not a question a unit test can ask, and it was not asked until a full-bank population was measured.
 
 **3. Ask an instrument what it would say if the thing it checks were completely broken — and then make it say
-it.** This wave's trace diff would have reported divergence on every pair of runs (it diffed timer-driven log
-lines); its concurrency guard would have reported SAFE on every invocation (`grep -c` exits 1 on no match, so
-`|| echo 0` produced `"0\n0"` and the comparison errored through). Both were caught, and the guard was then
-**validated against a positive control** — a deliberately-started `optimize` — before being trusted. The
-question is cheap; asking it only of other people's instruments is the mistake.
+it.** Three of this wave's own instruments failed that question, and all three were caught:
+
+- the **trace diff** would have reported divergence on every pair of runs, because it diffed log lines that come
+  partly from a wall-clock timer;
+- the **concurrency guard** would have reported SAFE on every invocation — `grep -c` exits 1 on no match, so
+  `$(… || echo 0)` produced `"0\n0"` and the numeric comparison errored through. It was then **validated against
+  a positive control**, a deliberately-started `optimize`, before being trusted;
+- the **RULE P scorer** treated a dataset that had not been measured yet as one that *did not fire*, so a partial
+  run reported P1 as REFUTED. That is the scorer's own NaN-never-0 rule — the one it enforces on
+  `WingRejectedFraction` — being violated by the scorer. It now reports UNEVALUATED and refuses to present a
+  partial pass as a population verdict.
+
+The question is cheap. Asking it only of other people's instruments is the mistake.
 
 **4. Check whether a cheap instrument already exists — including one a previous wave left on disk.** The exact
 geometric ratio a capped step recommendation applies (`1.5 × P / PointsPerSide`) was validated against **22

--- a/docs/synthetic-af-bank-followups-wave10-results.md
+++ b/docs/synthetic-af-bank-followups-wave10-results.md
@@ -193,32 +193,71 @@ the outer third.
 
 ### §2.2 Two findings, and the second one is the sharper
 
-**(a) The wings are not special.** Four runs — `LinwoodFocus` 0.70, `vsn07` 0.94, `toml999` 0.96, `cwhite_2026`
-0.98 — reject **fewer** candidates in their wings than in their cores, and all four fire. The statistic's whole
-justification is that the wing rejections are faint stars a longer exposure could convert; if the core rejects at
-the same rate, where the stars are brightest and most numerous, the rejected population is dominated by noise the
-detector is *supposed* to reject. **The statistic cannot tell "the wings are losing faint stars" from "the
-detector is rejecting noise everywhere", and on this bank it is measuring the second.**
+**(a) The absolute fraction does not track the wing effect it claims to measure.** Four runs — `LinwoodFocus`
+0.70, `vsn07` 0.94, `toml999` 0.96, `cwhite_2026` 0.98 — reject **fewer** candidates in their wings than in their
+cores, and all four fire. The statistic's justification is that the wing rejections are faint stars a longer
+exposure could convert; where the core rejects at the same rate — with the stars at their brightest and most
+numerous — the rejected population is dominated by noise the detector is *supposed* to reject. **The statistic
+cannot separate "the wings are losing faint stars" from "the detector is rejecting noise everywhere."**
 
-**(b) THE THRESHOLD DOES NO WORK.** The measured fractions are **0.000, 0.000** and then **0.352 … 0.879**.
-Nothing on the real bank lands between them. So **every threshold in (0, 0.352) selects exactly the same 16
-runs**, and 0.20 is an arbitrary point inside a wide gap. What the test actually asks is *"did the gate reject
-anything at all?"* — which is
-[F28](followups.md#f28--lowsensitivity-reads-exactly-zero-precisely-when-the-sensitivity-gate-has-collapsed)'s
-question, and which `GateIsProvablyInert` already answers with a different field.
+> **Corrected against the full population (§2.3).** Read on the real bank alone this looked like *"the wings are
+> not special"*: median wing/inner 1.15. Over all 39 runs the median is **1.39**, so on average the wings **do**
+> reject somewhat more than the cores. **The defect is not that the wing effect is absent — it is that a
+> threshold on the ABSOLUTE fraction does not track it.** `D17_cdk14_oiii5` fires at a wing/inner of **0.59**;
+> `D20_m24_bright_control` fires with an inner fraction of exactly **0.000**. Same verdict, opposite structures.
+
+**(b) The threshold's entire discriminating power over 39 runs is ONE dataset.** Sorted, the bank's fractions
+are **0.000 ×8**, then **0.006** (`D16_esprit550_ha3`), then **0.246 … 0.883** — nothing else below 0.246. So
+every threshold in **(0.006, 0.246)** produces exactly the same 30 fires, and the only thing 0.20 separates is
+`D16` from the rest.
+
+> **Also corrected.** From the real half this read *"every threshold in (0, 0.352)"*, i.e. that the threshold did
+> no work at all. `D16`'s 0.006 is on the synthetic half and it is the run W2 requires to stay silent, so the
+> threshold **is** load-bearing — for exactly one dataset out of thirty-nine. That is a weaker claim than the one
+> the real half supported, and it is the true one.
 
 **Where the 0.20 came from, and why it looked reasonable.** The unit fixtures span a rejected fraction of
 **0.002** (`wingRejected: 1, wingAccepted: 500`, the "healthy wings" pole) to **0.75** (`600 / 800`, the
-"shedding" pole), and 0.20 sits sensibly between them. **No real run in the bank resembles the healthy pole.**
-The threshold was calibrated against a range the data does not occupy — which is a thing a unit test cannot
-notice, and which only a population can.
+"shedding" pole), and 0.20 sits sensibly between them. **Exactly one run in 39 resembles the healthy pole.** The
+threshold was calibrated against a range the data barely occupies — which a unit test cannot notice, and only a
+population can.
 
-**And every firing run asks exactly 2×.** `rawFactor = max((10/S_now)², 2.0)`, and the accepted-star term is
-0.000–0.30 on every one of these runs, so the probe always wins. The recommendation therefore carries no
-information beyond *"it fired"*.
+**And every firing run asks exactly 2×.** `rawFactor = max((10/S_now)², 2.0)`, and the accepted-star term is far
+below 2 on every firing run, so the probe always wins. The recommendation carries no information beyond *"it
+fired"*.
 
-*(§2.3, the synthetic half and the RULE P verdict, follows — P1 and P3 name synthetic datasets and the pass is
-still running. **16/39 is 41 %, so P2's verdict genuinely depends on the synthetic half** and is not called here.)*
+### §2.3 THE VERDICT — RULE P fires on P2, and the withdrawal ships
+
+39 runs, both full banks, sequential, shipped-default invocation.
+
+| clause | measured | verdict |
+|---|---|---|
+| **P1** the pre-registered fires | `D17` **fires**; `D10` does **not** | **silent** (P1 needed neither to fire) |
+| **P2** fire rate | **30 of 39 = 76.9 %** | **FIRES — REFUTED** |
+| **P3** `D16` at its derived exposure | 0.006, does not fire | **silent** — W2 survives |
+| **P4** NaN rate | 0 of 39 | **silent** — the instrument was connected |
+
+**RULE P fires. `WingIsShedding` does not stay a shipped default**, and the withdrawal named in §1.2b ships in
+this PR: the verdict and its three action sites go, `WingRejectedFraction` stays.
+
+**Two things worth stating that P1 does not capture.** `D10_rc16_3250mm_sparse` — the bank's most starved
+dataset, 26 on-frame stars, whose own physics asks 335.6 s against the 30 s it is rendered at — **does not
+fire**. And `D17`, which does fire and which P1 required, fires with wings that reject **less** than its core
+(0.297 vs 0.507). P1 was written as "at least one of the two", and it is satisfied; but the statistic reaches the
+right answer on `D17` by a route that is not the one it claims, and misses `D10` entirely.
+
+### §2.4 The free controls, and they are what make the verdict readable
+
+**RULE G10-A: PASS, 8 of 8 to 6 dp.** The population pass re-measured the gate's eight runs at the identical
+invocation and returned identical landings — `toml999` 0.995784, `CWhiteFocus` 0.996068, `uneven` 0.996368,
+`muggsie` 0.997195, `mccomiskey` 0.976746, `D18` 0.999882, `D19` 0.999487, `D20` 0.999738. **The fixed point
+reproduces against itself, so every wave-10 comparison rests on an instrument that was checked rather than
+assumed** — and F55 is not firing at rest.
+
+**And it is evidence on F57's folder-state confound.** Those eight ran on folders whose `optimized_settings.json`
+had been rewritten **twice** in between — once by the gate, once by the eleven minutes of contaminated
+double-running — and every landing reproduced to 6 dp. Folder state does not move a landing on these runs. That
+is not yet `toml999`'s seed evaluation on the v1 binary (§3.1's control), but it points the same way.
 
 ---
 

--- a/docs/synthetic-af-bank-followups-wave10-results.md
+++ b/docs/synthetic-af-bank-followups-wave10-results.md
@@ -9,12 +9,19 @@ Register: [`docs/followups.md`](followups.md).
 >
 > Every number below was measured on **`StarDetectorVersion` 2** (PR #187's `AtrousWaveletFast`), from
 > `D:\hf_w10\exe`, built from `02c62d8` — `TestApp.dll` sha256 `5e58b669…`, `NINA.Joko.Plugins.HocusFocus.dll`
-> sha256 `ccb3e3e9…`. **That directory was never rebuilt** ([F53](followups.md#f53--wave-8s-arm-x-does-not-reproduce-from-wave-8s-own-exe-because-the-arm-ran-on-an-earlier-build-of-it)(c));
-> later wave-10 builds went to `exe2` / `exe_v1wav`.
+> sha256 `ccb3e3e9…` — **under the NINA profile `astrodet (ce3f3e63-8fd3-4b72-a0ca-d90db9441382)`.**
+> `D:\hf_w10\exe` **was never rebuilt** ([F53](followups.md#f53--wave-8s-arm-x-does-not-reproduce-from-wave-8s-own-exe-because-the-arm-ran-on-an-earlier-build-of-it)(c));
+> later wave-10 builds went to `exe_v1wav` (the wavelet bisect) and `exe3` (item 3).
 >
-> This banner is written by hand for the LAST time: F53(a) shipped in this wave, so `optimize` now prints — and
-> every landing now stores — a `BuildId` (the assembly MVID, which the compiler regenerates on every build) and a
-> `DetectorVersion`. A reader diffs a field; nobody diffs a banner.
+> **The profile is in this banner because of what this wave found.** It was not in wave 9's, and that omission is
+> exactly [F57](followups.md#f57--a---settings-pinned-arm-is-not-pinned-the-active-nina-profile-moves-baselinej-by-0014-and-every-cross-wave-comparison-inherits-it):
+> `--settings` pins the DETECTOR knobs, the harness still loads whichever profile is ACTIVE, and that moves
+> `BaselineJ` by 0.0144. **No number here may be compared to a number measured under a different profile** — a
+> rule this wave learned by breaking it.
+>
+> This banner is written by hand for the LAST time: F53(a) shipped here, so `optimize` now prints — and every
+> landing now stores — a `BuildId` (the assembly MVID, regenerated on every build), a `DetectorVersion`, a
+> `ProfileId`, and a `ConcurrencyCheck`. **A reader diffs a field; nobody diffs a banner.**
 
 ## Status of this document
 

--- a/docs/synthetic-af-bank-followups-wave10-results.md
+++ b/docs/synthetic-af-bank-followups-wave10-results.md
@@ -174,3 +174,44 @@ under the validated guard; nothing in §2 is measured on the contaminated data.
 ## §4 — Item 3: the step recommender
 
 *(pending)*
+
+---
+
+## Lessons
+
+*(assembled as they were learned; numbers filled in from the sections above)*
+
+**0. A rule that depends on the operator noticing a violation is not a control; it is a hope.** F55(c) — "treat
+concurrent `optimize` as invalid, and say so in the run instructions" — was written into this wave's design, its
+plan, and the header of the script that ran the pass. The pass then ran twice at once. The fix is not more
+discipline; it is `ConcurrencyCheck` stamped into every landing, so a scorer can refuse contaminated data
+without anyone having been watching. The register already contains the same move three times: `BaselineJ` as a
+free control (F41), `DetectionBinningSource` as a field rather than a sentence (F39(a)), `BuildId` rather than a
+version string (F53).
+
+**1. A numerical-equivalence bound on an intermediate is not an equivalence bound on the answer.** PR #187's
+wavelet paths agree to ≤ 3e-8 per pixel and the claim is true. Six of eight product landings still moved, and one
+seed evaluation — no search, nothing to amplify it — moved by 0.0144. The star gate is a **threshold**, and a
+threshold converts an eighth-decimal difference into a whole star. Any future change justified as "equivalent to
+N decimals" needs the bound on the quantity the product REPORTS.
+
+**2. A unit fixture's range is not the population's range.** *(see §2)* The wing statistic's threshold was
+chosen against fixtures spanning a rejected fraction of 0.005 to 0.75. Whether that is the range real runs
+occupy is not a question a unit test can ask, and it was not asked until a full-bank population was measured.
+
+**3. Ask an instrument what it would say if the thing it checks were completely broken — and then make it say
+it.** This wave's trace diff would have reported divergence on every pair of runs (it diffed timer-driven log
+lines); its concurrency guard would have reported SAFE on every invocation (`grep -c` exits 1 on no match, so
+`|| echo 0` produced `"0\n0"` and the comparison errored through). Both were caught, and the guard was then
+**validated against a positive control** — a deliberately-started `optimize` — before being trusted. The
+question is cheap; asking it only of other people's instruments is the mistake.
+
+**4. Check whether a cheap instrument already exists — including one a previous wave left on disk.** The exact
+geometric ratio a capped step recommendation applies (`1.5 × P / PointsPerSide`) was validated against **22
+capped rounds across six datasets** already sitting in wave 7's artifacts, at zero compute. The same files
+refuted this wave's own deadband proposal before a line of it was written.
+
+**5. Name the successor before you need it, and bar it from the data that killed its predecessor.** The
+ratio-form wing statistic was written down mid-pass, with its acceptance rule, precisely so it could not be
+adopted on the population that refuted the original. A statistic tuned on the data that killed the last one has
+been fitted, not tested — which is wave 9's R3, one level up.

--- a/docs/synthetic-af-bank-followups-wave10-results.md
+++ b/docs/synthetic-af-bank-followups-wave10-results.md
@@ -1,0 +1,125 @@
+# Synthetic AF bank — followups wave 10 (results)
+
+Design: [`docs/synthetic-af-bank-followups-wave10-design.md`](synthetic-af-bank-followups-wave10-design.md).
+Plan: [`plans/synthetic-af-bank-followups-wave10-plan.md`](../plans/synthetic-af-bank-followups-wave10-plan.md).
+Wave 9: [`docs/synthetic-af-bank-followups-wave9-results.md`](synthetic-af-bank-followups-wave9-results.md).
+Register: [`docs/followups.md`](followups.md).
+
+> ## PROVENANCE — the thing wave 9 had to write by hand, and which is now a FIELD
+>
+> Every number below was measured on **`StarDetectorVersion` 2** (PR #187's `AtrousWaveletFast`), from
+> `D:\hf_w10\exe`, built from `02c62d8` — `TestApp.dll` sha256 `5e58b669…`, `NINA.Joko.Plugins.HocusFocus.dll`
+> sha256 `ccb3e3e9…`. **That directory was never rebuilt** ([F53](followups.md#f53--wave-8s-arm-x-does-not-reproduce-from-wave-8s-own-exe-because-the-arm-ran-on-an-earlier-build-of-it)(c));
+> later wave-10 builds went to `exe2` / `exe_v1wav`.
+>
+> This banner is written by hand for the LAST time: F53(a) shipped in this wave, so `optimize` now prints — and
+> every landing now stores — a `BuildId` (the assembly MVID, which the compiler regenerates on every build) and a
+> `DetectorVersion`. A reader diffs a field; nobody diffs a banner.
+
+## Status of this document
+
+| item | state |
+|---|---|
+| **RULE G10-A** — the fixed point reproducing against itself | see §1.3 |
+| **RULE G10-B** — how many landings a ≤ 3e-8 change moves | **FIRES AT THE TOP TIER: 6 of 8.** And the seed evaluation — no search at all — moved on `toml999`. See §1 |
+| **item 1** — F19's population check | see §2 |
+| **item 2** — F55(b), the nondeterminism | see §3 |
+| **item 3** — the step recommender | see §4 |
+| **F53** — the build stamp | **SHIPPED.** And the field that claimed to identify the build is shown not to. See §3.4 |
+| **F49(c)** — what a capped step says | **SHIPPED**, with a ratio that is exact and measured against 22 on-disk rounds. See §4 |
+
+---
+
+## §1 — The gate, and it is the wave's first finding rather than its permission slip
+
+### §1.1 What was measured
+
+The eight comparability runs at wave 5's exact invocation (`--per-run --max-evals 250`, `--settings` pinned to
+`md5 df7c7cd1…`, byte-identical to waves 5–9, [F42](followups.md#f42--every-build-directory-silently-gets-its-own-detector-settings-and-the-run-instructions-require-a-new-one-per-arm)),
+sequentially, nothing else running ([F55](followups.md#f55--optimize-is-not-reproducible-when-several-instances-run-at-once-and-the-seed-evaluation-is-what-moves)).
+13:04–13:46Z.
+
+| run | `BaselineJ` v1 | v2 | | `BestJ` v1 | v2 | |
+|---|---|---|---|---|---|---|
+| `toml999` | 0.997840 | **0.983477** | **MOVED** | 0.997993 | **0.995784** | **MOVED** |
+| `CWhiteFocus` | 0.994320 | 0.994320 | = | 0.998476 | **0.996068** | **MOVED** |
+| `uneven` | 0.991794 | 0.991794 | = | 0.996368 | 0.996368 | = |
+| `muggsie` | 0.993288 | 0.993288 | = | 0.997195 | 0.997195 | = |
+| `mccomiskey` | 0.846082 | 0.846082 | = | 0.994025 | **0.976746** | **MOVED** |
+| `D18_m24_deep_shed` | 0.997405 | 0.997405 | = | 0.999822 | **0.999882** | **MOVED** |
+| `D19_cygnus_deep_shed` | 0.999187 | 0.999187 | = | 0.999557 | **0.999487** | **MOVED** |
+| `D20_m24_bright_control` | 0.999454 | 0.999454 | = | 0.999766 | **0.999738** | **MOVED** |
+
+### §1.2 RULE G10-B fires at its top tier, and the reading was fixed before the numbers arrived
+
+> **6 of 8 landings moved.** The pre-registered table said: 0 ⇒ inert; **1–3 ⇒ the expected pattern-search
+> amplification** ([F8](followups.md#f8--optimizer-landings-are-not-reproducible-across-invocations)); **≥ 5 ⇒
+> the "≤ 3e-8" claim describes the per-pixel RESIDUAL and not the detector's BEHAVIOUR, and PR #187 needs
+> re-examining as a change that moves product landings.**
+
+**And the seed evaluation moved, which is the sharper half.** `BaselineJ` is a **single evaluation of the pinned
+seed with no search involved**, so nothing amplifies it. On `toml999` it moves by **0.0144** — six orders of
+magnitude above 3e-8 — between two binaries whose every printed seed input is identical: same settings file
+(same export stamp, same "0 advanced knobs overridden" warning), `Sensitivity=10`,
+`StarClippingMultiplier=2`, `NoiseClippingMultiplier=4`, `StructureLayers=4`, inferred step 21, exposure 5 s,
+`PixelScale 0.73944 arcsec/px (frame header)`, detection binning `1 from harness_settings.json`.
+
+**This is not a defect in PR #187's own claim.** The two wavelet paths do agree to ≤ 3e-8 per pixel, and the
+version bump exists precisely because they are not bit-identical. What the gate measures is the **consequence**:
+a detector whose per-pixel output moves in the eighth decimal moves 6 of 8 product landings and one seed
+evaluation in the second. *A numerical-equivalence bound on an intermediate is not an equivalence bound on the
+answer* — the star gate is a threshold, and a threshold turns an eighth-decimal difference into a whole star
+appearing or not appearing.
+
+**What it changes.** Wave 5's φ table, wave 6's arm R and wave 9's F32 verdict are all readable **within** their
+own binaries and none of them is retracted. What is now measured rather than assumed is that they cannot be
+compared **across** the version boundary at all — which is what wave 9's provenance banner asked for and what
+this table supplies with a number.
+
+### §1.3 The confound the seed result has to survive, and the control that settles it
+
+`BaselineJ` is read on folders that a previous arm wrote into
+([F15](followups.md#f15--optimize---per-run-overwrites-each-runs-stored-settings)), and wave 9's gate ran on a
+wave-8-era folder state while wave 10's ran on wave 9's arm-A landing. So the honest reading is that **two things
+differ between the two measurements — the binary and the folder state** — and one of them is not the wavelet.
+
+- **`harness_settings.json` is excluded outright.** `toml999`'s is dated **2026-07-31 12:43**, i.e. untouched
+  since before wave 8, so it is byte-identical across both gates.
+- **`optimized_settings.json` is the live one.** F55's own investigation measured it as inert (run with and
+  without the file present, identical) — but on `D16` and on the v1 binary, not here.
+- **The decisive control is §3.1's cross-build probe**, which runs `toml999` on wave 9's v1 binary against
+  TODAY's folder state. Same folder, different binary: if it returns wave 9's 0.997840, folder state is excluded
+  and the wavelet is the cause; if it returns 0.983477, the folder state is the cause and the wavelet is
+  exonerated. **The seed-evaluation claim above is held open until that control reports.**
+
+*(`D:\hf_w9\exe`, `exe2`, `exe_f56` and `exe_bisect` were each confirmed to be v1 builds before any of this was
+attributed — `strings <dll> | grep AtrousWaveletFast` returns 0 on all four and 1 on `D:\hf_w10\exe`. That is a
+retroactive build-identity check that works on every artifact directory already on disk, and it is how F53's
+question was answered for the binaries that predate F53's stamp.)*
+
+### §1.4 A smaller thing the gate caught about its own instrument
+
+`uneven`'s log contains **no `Optimization complete` line at all**, while every other run's does — so the gate
+script's own `grep` for that line reports a failure on a run that succeeded. The run is fine: its
+`aggregate_summary.json` has `LoadOk=True` and `BestJ = 0.996368`, exactly reproducing v1. **The JSON is the
+instrument; the console line is not.** Recorded because a scripted arm that gates on the console line would drop
+a good run, and because the first reading of this file was taken while it was still being flushed and briefly
+looked like a crash.
+
+---
+
+## §2 — Item 1: F19's population check
+
+*(pending — the pass is running)*
+
+---
+
+## §3 — Item 2: F55(b)
+
+*(pending)*
+
+---
+
+## §4 — Item 3: the step recommender
+
+*(pending)*

--- a/plans/synthetic-af-bank-followups-wave10-plan.md
+++ b/plans/synthetic-af-bank-followups-wave10-plan.md
@@ -1,5 +1,12 @@
 # Synthetic AF bank — followups wave 10 (plan)
 
+> **CLOSED 2026-08-08.** Results: [`docs/synthetic-af-bank-followups-wave10-results.md`](../docs/synthetic-af-bank-followups-wave10-results.md).
+> Step 0 ✅ (G10-A PASS 8/8; **G10-B fired and is VOID** — its own control refuted the attribution, see F57).
+> Step 1 ✅ (**RULE P FIRES**, the wing verdict is withdrawn). Step 2 ▲ partial (the build hypothesis is dead
+> and F53(a) shipped; the KappaSigma trigger rate is still owed). Step 3 ✅ (F49(c) shipped; F21 diagnosed; the
+> deadband refuted before implementation, so RULE S was never applied). Step 4 ✅ (3722/0).
+> **Not run, and named as such:** the landing-level wavelet bisect (§3.2) and the KappaSigma rate probe.
+
 Design: [`docs/synthetic-af-bank-followups-wave10-design.md`](../docs/synthetic-af-bank-followups-wave10-design.md).
 Register: [`docs/followups.md`](followups.md).
 Branch: `ghilios/synthetic-af-bank-followups-wave10` off `develop` @ `02c62d8`.

--- a/plans/synthetic-af-bank-followups-wave10-plan.md
+++ b/plans/synthetic-af-bank-followups-wave10-plan.md
@@ -1,0 +1,141 @@
+# Synthetic AF bank — followups wave 10 (plan)
+
+Design: [`docs/synthetic-af-bank-followups-wave10-design.md`](../docs/synthetic-af-bank-followups-wave10-design.md).
+Register: [`docs/followups.md`](followups.md).
+Branch: `ghilios/synthetic-af-bank-followups-wave10` off `develop` @ `02c62d8`.
+
+**Ordering is fixed and is not to be rearranged for convenience.** Step 0 gates everything. Steps 1–3 run in the
+order below because item 1 is live product behaviour validated on two datasets, item 2 makes every future arm
+cheaper and is 40 seconds per trial, and item 3 is the largest user-facing cluster but the one with no
+correctness deadline.
+
+**Nothing runs concurrently with an `optimize` pass** (F55). Code editing, doc writing and reading are fine; a
+second `optimize` process is not.
+
+---
+
+## Step 0 — The gate ✅ RUNNING
+
+| | |
+|---|---|
+| build | `dotnet.exe build TestApp.csproj -c Release -o 'D:\hf_w10\exe'` — **done**, `02c62d8`, `StarDetectorVersion` 2 |
+| settings | `D:\hf_w10\pinned_settings.json`, `md5 df7c7cd14181b4ace59b92b89e219f67` — **verified byte-identical to waves 5–9** (F42) |
+| provenance | recorded by hand in `gate_repro_w10.sh`'s header (F53's stamp does not exist yet) — `TestApp.dll` `5e58b669…`, plugin dll `ccb3e3e9…` |
+| script | `D:\hf_w10\gate_repro_w10.sh` → `D:\hf_w10\gate\` |
+
+0a. Run the eight sequentially. **Record all eight values as wave 10's fixed point.**
+0b. Apply **G10-A**: re-run one of the eight, sequentially and alone; must match to 6 dp. **If it fires, STOP** —
+    every wave-10 comparison is void before it is made.
+0c. Apply **G10-B**: count how many of the eight moved against wave 5's version-1 values, and read it against the
+    0 / 1–3 / ≥ 5 table fixed in the design. **This is a measurement, not a gate** — record the count and its
+    reading either way.
+0d. `D:\hf_w10\exe` is **never rebuilt**. Later builds → `exe2`, `exe_v1wav`, …
+
+> **Already true after run 1:** `toml999` = **0.995784**, which is wave 9's *fan-out* value, not its sequential
+> one. Design §0.2 states the H1/H2 fork this opens; Step 2a is its discriminator. Do not resolve it by argument.
+
+---
+
+## Step 1 — F19's population check (item 1)
+
+**RULE P is in design §1.2 and is fixed. Do not edit it after seeing a number.**
+
+1a. Write `D:\hf_w10\wing_pop.sh`: one **sequential** pass, shipped-default invocation (`--per-run`,
+    `--max-evals 250`, `--settings` pinned, no flags), over all 20 synthetic datasets + 19 real runs
+    (`astrodet` excluded, F14). `FrameDiagnostics` carried so the wing axis is populated.
+1b. Write `D:\hf_w10\score_wing_pop.py`: for every run emit `WingRejectedFraction`, `WingIsShedding`, the final
+    ask ratio, `BaselineJ`, `BestJ`, σ_focus. **Must distinguish NaN from 0** — that is P4's whole content, and
+    a scorer that coerces them together makes the instrument report an all-clear it never measured.
+    (`score_f32.py`'s Newtonsoft `"NaN"`-STRING coercion is the known trap; inherit the fix, not the bug.)
+1c. Run it. ~3–5 h. Nothing else runs.
+1d. Score against P1–P4. **Name every newly-firing dataset with a reason.**
+1e. Free controls, read before the verdict:
+    - the 8 gate runs' `BestJ` must match Step 0's values to 6 dp (F41/F55 — same invocation, same binary);
+    - `BaselineJ` across all 39 is the standing F55 control.
+1f. **F15:** this pass is the shipped-default invocation, so the banks end holding the shipped-default landing.
+    No re-land owed.
+
+**Outcome branches, both written down now:**
+- **RULE P silent** ⇒ the wing statistic is validated on a population instead of on two datasets. Record the
+  fire list and the rate; F19's remainder closes.
+- **RULE P fires** ⇒ turn `WingIsShedding` off by default in the same PR, with the measured reason. This is
+  product behaviour that can raise a user's exposure 2×; a refuted default does not stay shipped pending a wave.
+
+---
+
+## Step 2 — F55(b), the nondeterminism (item 2)
+
+Everything here is minutes-per-trial. **Do not re-run design §2.2's eliminated candidates.**
+
+2a. **The cross-build probe — decisive for Step 0's H1/H2 fork.** Determinism probe on `toml999`, 5× sequential
+    on `D:\hf_w9\exe` (v1) and 5× sequential on `D:\hf_w10\exe` (v2), **back to back in one session**.
+    - v1 → 0.997993 ×5 and v2 → 0.995784 ×5 ⇒ **the BUILD selects the attractor**; H1 holds, and F55's
+      `toml999` evidence was never about concurrency.
+    - either binary splitting within its own five ⇒ H2, and the attractor is session/load state.
+2b. **The wavelet bisect.** Build `D:\hf_w10\exe_v1wav` = this tree with `StarDetector.cs:619/622` calling the
+    legacy `CvImageUtility` dense path (which survives as the equivalence oracle). Re-run 2a's sequential phase.
+    Isolates the wavelet from the rest of the v1→v2 delta. **Not committed** — a bisect build, not a product
+    change.
+2c. **The OpenCV thread probe.** Pin OpenCV's thread count to 1; re-run the probe's **concurrent** phase.
+    Bimodality vanishing ⇒ design §2.4 is the mechanism.
+    **`WSLENV` must be set** and the probe must carry a **positive control**: a configuration known to change the
+    answer has to be shown changing it, or a null reading is an unplugged instrument (wave 9's own trap).
+2d. **F53(a) — the build stamp. Ships regardless of 2a–2c.** `optimize` prints informational version + commit +
+    `StarDetectorVersion`. Build to `exe2`; verify inertness by re-running one gate run and matching Step 0 to
+    6 dp. This is the standing fix for "a `Reproduce:` line names a COMMAND, not a result".
+2e. **F54** — check whether a build-selected attractor explains it for free. If it does, F54 closes without any
+    `ApplyFactor` defect; if not, say so and leave it open.
+2f. Whatever is found, update F55's entry with what was **eliminated by measurement** — the negative results are
+    the durable part.
+
+---
+
+## Step 3 — The step recommender (item 3)
+
+**RULE S is in design §3.4 and is fixed.**
+
+3a. **Measure F21's owed reproducibility first** — it is what sizes the deadband, and it is the diagnosis F21 has
+    owed since 2026-08-02. `synth-validate --scenarios S0` over the bank; record the run-to-run spread of
+    `HalfWidth` and of the recommended step at a fixed dataset+step. Instrument `FindHalfWidth`'s fitted minimum,
+    its `3 × min` target and the bracket it converged on, on the two saved `D17` sweeps, and confirm or refute
+    the coarse-walk hypothesis F21 names.
+3b. **(A) the copy** — capped ⇒ say it is a partial step, name what it converges toward (`3 × HFR_min`), and
+    quote the **exact** ratio (`1.5 × P / 3.5`). Do **not** quote a projected run count: it is computed from the
+    extrapolation the cap exists to distrust.
+3c. **(B) the deadband** — threshold set at or above 3a's measured spread. Below it the recommendation reads
+    "converged", not a new number.
+3d. Unit tests, each confirmed by **neutralizing** (remove the mechanism ⇒ the named test fails, and no other):
+    the ratio arithmetic at P = 4 and P = 5; the field session's 100 → 214 → 459 sequence; the deadband's
+    terminating behaviour at 459 → 474 → 482 (RULE S's S3); byte-identical behaviour when the deadband is
+    disabled.
+3e. Run RULE S's arm (`synth-validate`, control vs deadband, one binary, `--settings` pinned). **S2 is the
+    clause that can kill it and must not be relaxed.**
+3f. Ship or don't, per RULE S, and record which clause decided it.
+
+---
+
+## Step 4 — Verification and PR
+
+4a. **Full local suite** — `dotnet.exe test <sln> -c Debug --nologo`. **Record the COUNT, not the tick** (F37).
+    `develop` is **3708**; state the delta and what accounts for it.
+    Known-flaky and not to be chased on a full-suite run: `SendAsync_WritesOnABackgroundThread`.
+4b. Write `docs/synthetic-af-bank-followups-wave10-results.md`, opening with the **provenance** of every number
+    in it (`StarDetectorVersion` 2, `D:\hf_w10\exe`, the two sha256s) — wave 9's banner is the model.
+4c. Update `docs/followups.md`: F19, F55, F53, F54, F21, F49, F51 as measured; **flag new findings as new
+    entries** rather than folding them into old ones.
+4d. Re-check `githubstatus.com` before merging and verify the PR's check ran with the **full count**. An ABSENT
+    check is more dangerous than a red one.
+4e. Push the branch, open the PR against `develop`. **Never push `develop`.** Commit with the privacy email:
+    `322725+ghilios@users.noreply.github.com` for both author and committer.
+
+---
+
+## Known deferrals, priced rather than predicted
+
+| item | why it is not in this wave |
+|---|---|
+| **F52(d)** — a cost term in `J` | PR #187 made per-layer wavelet cost nearly flat; `StructureLayers` is no longer a cost driver and a cost term added now would penalise an artifact |
+| **F46(b)** — present the binning recommendation | nothing depends on it |
+| **F25's fit-quality gate** | a real defect in the same method; neither of Step 3's halves makes it worse, and bundling it would put two mechanisms behind one acceptance rule |
+| **F26's deferral bound** | the wizard's binning-first ORDERING, downstream of F22 — not the recommender's arithmetic |
+| **F18's `W_detect` default** | wave 7's arms returned a null; the bank cannot exercise the defect and nothing here changes that |


### PR DESCRIPTION
Wave 10 ran the population check wave 9 recorded as owed, re-established the gate on
`StarDetectorVersion` 2, and spent its budget finding out that one of its own headline findings
was wrong.

## The wing statistic is WITHDRAWN — RULE P fired at 30 of 39

Wave 9 shipped `WingIsShedding` validated on **two** datasets. Over both full banks (39 runs,
sequential, shipped-default invocation) it fires on **76.9 %** of them.

- **Four real-bank runs reject FEWER candidates in their wings than in their cores** — `LinwoodFocus`
  0.70, `vsn07` 0.94, `toml999` 0.96, `cwhite_2026` 0.98 as a wing/inner ratio — and every one fires.
  The inner-third control is free from the per-frame table the harness already writes, and the
  statistic never had it.
- **The threshold's whole discriminating power over 39 runs is one dataset.** Sorted, the fractions are
  `0.000 ×8`, then `0.006` (D16), then `0.246 … 0.883`. Every threshold in (0.006, 0.246) selects the
  same 30 runs.
- **Why 0.20 looked right:** the unit fixtures span 0.002 to 0.75 and it sits sensibly between them.
  Exactly one run in 39 resembles the healthy pole. *A unit fixture's range is not the population's.*

Withdrawn: the verdict and the **three** sites acting on it — the 2× ask, the `ExposureIsNotTheLimit`
override, and F52(c)'s advice to **cancel a running two-hour search**, computed from the seed
evaluation and so firing in the first minute of most runs. Kept: `WingRejectedFraction`, the
measurement. The successor (the wing-to-inner ratio) is pre-registered with W5/W6 and deliberately
**not** adopted on the data that refuted its predecessor.

## F57 — a `--settings`-pinned arm is not pinned

The gate came back at RULE G10-B's top tier: 6 of 8 landings moved and `toml999`'s `BaselineJ` — one
evaluation of a pinned seed, no search — moved 0.0144 on inputs that printed identical. That was
written up as PR #187's wavelet moving product answers.

**Its own pre-registered control refuted it.** Fifteen runs — five each on wave 9's binary, wave 10's,
and a wavelet-bisect build, interleaved — returned `0.9834767969`, identical to 10 dp. Folder state
was excluded one artifact at a time. What remained was the one input nobody compares: wave 9 ran under
profile `Default`, wave 10 under `astrodet`, and re-running with `--profile-id b10b1d6d-…` returns
`0.9978404571` — wave 9's value to 6 dp.

`--settings` pins the detector knobs; the harness still loads whichever NINA profile is active. F42
predicted this in words and the remedy it prompted did not close it. **G10-B is VOID; G10-A is
unaffected and passes 8/8**, because it compares two runs within one wave under one profile.

## Also shipped

- **F53(a)** — `BuildId` (assembly MVID) + `DetectorVersion` in every landing. The field that *claimed*
  to identify the build could not. `ProfileId` joins them for F57.
- **F55(c)** — `optimize` claims a mutex and records `ConcurrencyCheck` (`exclusive`/`concurrent`/
  `unknown`) into every landing. This wave ran its own population pass **twice at once** despite the
  rule being written in three places, because the violation was invisible.
- **F49(c)** — a capped step recommendation now names what it converges toward and the **exact** factor
  the next capped run applies (1.714× / 2.143×), validated against 22 capped rounds already on disk.
  No projected run count: that would come from the extrapolation the cap exists to distrust.
- **F21** — diagnosed. `FindHalfWidth` is exact (`√8·HFR_min/κ`); the fitted **vertex** is what moves.
  Round 0 reproduces exactly (143.583/41); the collapse does not recur.
- **F55(b)** — the build-selects-the-attractor hypothesis is dead; `KappaSigmaNoiseEstimate` is named as
  the amplifier and its **gain** is pinned by a test.

## Not done, and named

The landing-level wavelet bisect and the KappaSigma trigger-rate probe (results §3.2), and the deadband
— **refuted before implementation** by the rule fixed to size it, so RULE S was never applied.

## Verification

**3722 passed, 0 failed** (`develop` 3708 → **+14**, every one accounted for). Three neutralization
checks confirmed discrimination: breaking `CappedGrowthRatio` fails 3 tests, restoring the wing actions
fails 2, restoring the advice fails 3.

Docs: `docs/synthetic-af-bank-followups-wave10-{design,results}.md`,
`plans/synthetic-af-bank-followups-wave10-plan.md`, and `docs/followups.md` (F57 new; F19/F21/F49/F53/F55
updated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QTNWdSNar6g3Nj5wXnLZc6
