### PR TITLE
Wave 11: F55 and F57 are one defect — concurrent optimize processes each get a different NINA profile

### DIFF
--- a/.claude/docs/testapp-cli.md
+++ b/.claude/docs/testapp-cli.md
@@ -113,12 +113,42 @@ Headless driver of the optimizer. Args:
 (default `%LOCALAPPDATA%\NINA\Logs\hf-diag\optimize\<timestamp>`), `--max-evals <int>` (override the
 optimizer budget; wizard default 250), `--annotate extremes|all` (default `extremes` = min/max-focuser frames
 only), `--labels <dir>` (label JSON dir; activates the recall/precision objective term), `--verbose` (restore
-TRACE logging; default INFO). `optimize` has **no** `--defocus-*` switches — the combined `DefocusAwareGates`
+TRACE logging; default INFO), `--cv-threads <n>` (cap OpenCV's parallel-for pool; `0` restores the default —
+the effective `Cv2.GetNumThreads()` is printed either way, so the knob cannot be silently disconnected).
+`optimize` has **no** `--defocus-*` switches — the combined `DefocusAwareGates`
 flag is in the optimizer's curated search set (`OptimizerVariable.CreateCuratedSet`), so the optimizer explores
 the relaxation itself (guarded by the objective's `SDefocusPrecision` near-focus penalty); to force the gates
 on for diagnosis, use `diagnose-labels`/`contamination`. It writes
 `optimized_settings.json` into **each focus run's source folder** (the review handoff) **and** the `--out`
 dir (or each per-run subfolder).
+
+> ### PINNING AN ARM: `--settings` **AND** `--profile-id`. BOTH. EVERY TIME.
+>
+> **`--settings <fixed path>` pins the DETECTOR knobs** (F42). Every build directory otherwise bootstraps its own
+> `harness_settings.json` from whatever the live profile holds at that moment, so two arms built minutes apart can
+> run different detectors.
+>
+> **`--profile-id <guid>` pins the FIT, and for six waves nobody passed it** (F57/F58). `AutoFocusOptions` was read
+> from whichever NINA profile happened to be ACTIVE, and four of its values reach the AF fit. On the machine that
+> produced waves 5–11, nine profiles partition **2 / 7** on `MaxOutlierRejections` alone — enough to move
+> `BaselineJ` (one evaluation of a fixed seed on fixed frames, no search) by **0.0144**, larger than any Δ`J` the
+> project has argued about. Wave 9's gate ran under `Default`, wave 10's under `astrodet`, and the resulting
+> discrepancy was attributed to a wavelet change for half a day.
+>
+> **The default is LRU-BY-LAST-LOAD, so an unpinned arm is seeded by whatever the previous arm pinned.**
+> `Profile.Load` stamps `LastUsed = Now` and saves; `TryLoad("")` takes the newest. The act of measuring rewrites
+> the default for the next measurement.
+>
+> **And concurrent unpinned processes each get a DIFFERENT profile.** NINA holds the `.profile` open
+> (`FileShare.Read`) while it is loaded, `SelectProfile` returns false for a locked one, and `TryLoad`'s
+> `SkipWhile` silently takes the next by `LastUsed`. That is F55's "nondeterminism": *N* concurrent `optimize`
+> processes ran under *N* different fits. **With `--profile-id` the same situation fails LOUDLY** ("No active NINA
+> profile could be loaded", non-zero exit) instead of returning a wrong number — which is the right trade, and is
+> why fan-out needs one profile copy per worker.
+>
+> Since wave 11 the harness reads the fit inputs from the **pinned settings file**, and every landing records
+> `ProfileId` **and** `FitInputs` (`MaxOutlierRejections=…;OutlierRejectionConfidence=…;…` — values, not a hash,
+> so a reader sees *which* one moved). Check `ConcurrencyCheck` in the landing before reading any arm.
 
 - **Run discovery is attempt-anchored** (pure logic in `OptimizationRunDiscovery`): it recursively finds
   `attempt<NN>` folders (1–4 levels under `--runs`) that contain ≥3 distinct focuser positions, mirroring

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/Harness/HarnessFitInputsTests.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/Harness/HarnessFitInputsTests.cs
@@ -1,0 +1,229 @@
+#region "copyright"
+
+/*
+    Copyright © 2021 - 2026 George Hilios <ghilios+NINA@googlemail.com>
+
+    This Source Code Form is subject to the terms of the Mozilla Public
+    License, v. 2.0. If a copy of the MPL was not distributed with this
+    file, You can obtain one at http://mozilla.org/MPL/2.0/.
+*/
+
+#endregion "copyright"
+
+using NINA.Joko.Plugins.HocusFocus.AutoFocus;
+using NINA.Joko.Plugins.HocusFocus.Interfaces;
+using NINA.Joko.Plugins.HocusFocus.StarDetection;
+using NINA.Profile.Interfaces;
+using NSubstitute;
+using NUnit.Framework;
+using System.Collections.Generic;
+using TestApp;
+
+namespace NINA.Joko.Plugins.HocusFocus.Tests.Harness;
+
+/// <summary>
+/// F58 — the four values that reach the AF fit, and the guarantee that <c>--settings</c> now pins them.
+///
+/// <para><b>What these are protecting.</b> <c>optimize</c> pinned the DETECTOR knobs with <c>--settings</c> and
+/// read the fit's four inputs straight off <c>AutoFocusOptions</c>, which binds to whichever NINA profile is
+/// ACTIVE. The machine that produced waves 5–11 holds nine profiles that partition <b>2 / 7</b> on
+/// <c>MaxOutlierRejections</c>, and NINA hands concurrent processes DIFFERENT profiles (it holds the
+/// <c>.profile</c> open, and <c>TryLoad</c> skips a locked one for the next by <c>LastUsed</c>). One integer
+/// therefore produced two discrete values of <c>J</c>, which were chased as a floating-point race for two
+/// waves.</para>
+/// </summary>
+[TestFixture]
+public class HarnessFitInputsTests {
+
+    private static AutoFocusOptions OptionsOver(params (string Key, string Value)[] pairs) {
+        var bag = new Dictionary<string, string>();
+        foreach (var (k, v) in pairs) {
+            bag[k] = v;
+        }
+        var profileService = Substitute.For<IProfileService>();
+        return new AutoFocusOptions(profileService, new HarnessSettingsStore.FileOptionsAccessor(bag));
+    }
+
+    // ---- The fit reads the FILE, not the profile ------------------------------------------------------------
+
+    [Test]
+    public void FitInputs_ComeFromTheHarnessFile() {
+        var options = OptionsOver(
+            ("MaxOutlierRejections", "0"),
+            ("OutlierRejectionConfidence", "0.99"),
+            ("WeightedHyperbolicFitEnabled", "False"),
+            ("HyperbolicFitModel", "TiltedHyperbola"));
+
+        var inputs = HarnessFitInputs.From(options);
+        Assert.Multiple(() => {
+            Assert.That(inputs.MaxOutlierRejections, Is.EqualTo(0));
+            Assert.That(inputs.RejectionConfidence, Is.EqualTo(0.99).Within(1e-12));
+            Assert.That(inputs.UseWeights, Is.False);
+            Assert.That(inputs.PreferredModel, Is.EqualTo(HyperbolicFitModel.TiltedHyperbola));
+        });
+    }
+
+    [Test]
+    public void FitInputs_FallBackToTheDOCUMENTEDCodeDefaults_WhenTheFileDoesNotCarryThem() {
+        // THE BACK-COMPATIBILITY CLAUSE, and it is load-bearing. `pinned_settings.json` -- byte-identical across
+        // waves 5-10, md5 df7c7cd1... -- carries NONE of these four keys, so every historical arm run against the
+        // fixed binary resolves them here. If these four numbers ever change, every pre-wave-11 pinned file
+        // silently starts describing a different fit, and this test is what says so.
+        var inputs = HarnessFitInputs.From(OptionsOver());
+        Assert.Multiple(() => {
+            Assert.That(inputs.MaxOutlierRejections, Is.EqualTo(1));
+            Assert.That(inputs.RejectionConfidence, Is.EqualTo(0.95).Within(1e-12));
+            Assert.That(inputs.UseWeights, Is.True);
+            Assert.That(inputs.PreferredModel, Is.EqualTo(HyperbolicFitModel.Hybrid));
+        });
+    }
+
+    // ---- Values, not a hash ---------------------------------------------------------------------------------
+
+    [Test]
+    public void ToString_RendersTheVALUES_SoAReaderSeesWHICHOneMoved() {
+        var inputs = HarnessFitInputs.From(OptionsOver(
+            ("MaxOutlierRejections", "1"), ("OutlierRejectionConfidence", "0.99")));
+
+        Assert.That(inputs.ToString(), Is.EqualTo(
+            "MaxOutlierRejections=1;OutlierRejectionConfidence=0.99;WeightedHyperbolicFitEnabled=True;HyperbolicFitModel=Hybrid"));
+    }
+
+    [Test]
+    public void ToString_IsStable_ForIdenticalInputs() {
+        var a = HarnessFitInputs.From(OptionsOver(("MaxOutlierRejections", "1"))).ToString();
+        var b = HarnessFitInputs.From(OptionsOver(("MaxOutlierRejections", "1"))).ToString();
+        Assert.That(a, Is.EqualTo(b));
+    }
+
+    [Test]
+    public void ToString_ChangesWhenANYONEInputChanges() {
+        // Discriminating on all four axes: a provenance field that moved on only some of them would report
+        // "unchanged" for exactly the kind of drift it exists to catch.
+        var baseline = HarnessFitInputs.From(OptionsOver()).ToString();
+        Assert.Multiple(() => {
+            Assert.That(HarnessFitInputs.From(OptionsOver(("MaxOutlierRejections", "0"))).ToString(),
+                Is.Not.EqualTo(baseline), "MaxOutlierRejections");
+            Assert.That(HarnessFitInputs.From(OptionsOver(("OutlierRejectionConfidence", "0.99"))).ToString(),
+                Is.Not.EqualTo(baseline), "OutlierRejectionConfidence");
+            Assert.That(HarnessFitInputs.From(OptionsOver(("WeightedHyperbolicFitEnabled", "False"))).ToString(),
+                Is.Not.EqualTo(baseline), "WeightedHyperbolicFitEnabled");
+            Assert.That(HarnessFitInputs.From(OptionsOver(("HyperbolicFitModel", "TiltedHyperbola"))).ToString(),
+                Is.Not.EqualTo(baseline), "HyperbolicFitModel");
+        });
+    }
+
+    [Test]
+    public void ToString_IsCultureInvariant() {
+        // The field is diffed across machines and pasted into results documents; a comma decimal separator would
+        // also collide with nothing here but would silently break a `;`-and-`=` split downstream.
+        var previous = System.Threading.Thread.CurrentThread.CurrentCulture;
+        try {
+            System.Threading.Thread.CurrentThread.CurrentCulture = new System.Globalization.CultureInfo("de-DE");
+            Assert.That(HarnessFitInputs.From(OptionsOver(("OutlierRejectionConfidence", "0.95"))).ToString(),
+                Does.Contain("OutlierRejectionConfidence=0.95"));
+        } finally {
+            System.Threading.Thread.CurrentThread.CurrentCulture = previous;
+        }
+    }
+
+    // ---- The export carries them, densely ---------------------------------------------------------------------
+
+    [Test]
+    public void CopyOptionSurface_CarriesTheFitInputs_EvenWhenTheyEqualTheCodeDefault() {
+        // DENSITY is the point, not merely presence. `MaxOutlierRejections = 1` IS the code default, so a copy
+        // that skipped unchanged values would leave the key ABSENT and the file would inherit whatever the
+        // default is AT LOAD TIME -- behaviour-preserving today and silently wrong the day a default moves. That
+        // is precisely the drift a pinned settings file exists to prevent.
+        var destination = new Dictionary<string, string>();
+        HarnessSettingsStore.CopyOptionSurface(
+            OptionsOver(("MaxOutlierRejections", "1"), ("OutlierRejectionConfidence", "0.95")),
+            new AutoFocusOptions(Substitute.For<IProfileService>(),
+                new HarnessSettingsStore.FileOptionsAccessor(destination)));
+
+        Assert.Multiple(() => {
+            Assert.That(destination, Does.ContainKey("MaxOutlierRejections"));
+            Assert.That(destination["MaxOutlierRejections"], Is.EqualTo("1"));
+            Assert.That(destination, Does.ContainKey("OutlierRejectionConfidence"));
+            Assert.That(destination, Does.ContainKey("WeightedHyperbolicFitEnabled"));
+            Assert.That(destination, Does.ContainKey("HyperbolicFitModel"));
+        });
+    }
+
+    [Test]
+    public void CopyOptionSurface_RoundTripsANonDefaultBudget() {
+        // astrodet's value. This is the one that moved toml999's BaselineJ by 0.0144 and split D16 into two
+        // "attractors"; if it does not survive the export, --settings still does not pin the arm.
+        var destination = new Dictionary<string, string>();
+        HarnessSettingsStore.CopyOptionSurface(
+            OptionsOver(("MaxOutlierRejections", "0")),
+            new AutoFocusOptions(Substitute.For<IProfileService>(),
+                new HarnessSettingsStore.FileOptionsAccessor(destination)));
+
+        Assert.That(HarnessFitInputs.From(new AutoFocusOptions(Substitute.For<IProfileService>(),
+            new HarnessSettingsStore.FileOptionsAccessor(destination))).MaxOutlierRejections, Is.EqualTo(0));
+    }
+
+    // ---- F59: a VALIDATING setter must not be dropped from the export -------------------------------------------
+
+    [Test]
+    public void CopyOptionSurface_CarriesAKnobWhoseSetterTHROWSOnTheObviousPoison() {
+        // F59, and it cost five knobs for six waves. `MaxDistortion` validates to [0, 1] and THROWS outside it,
+        // so the old one-shot `current + 1` poison (0.65 -> 1.65) raised ArgumentException, a single enclosing
+        // catch swallowed it, and the property was skipped ENTIRELY -- neither poison nor value written.
+        // `pinned_settings.json`, the file waves 5-11 called "the pinned detector", is missing MaxDistortion,
+        // StarCenterTolerance, SaturationThreshold, HotpixelThreshold and Sensitivity for exactly this reason.
+        //
+        // Confirmed discriminating by neutralizing: restore the single-candidate poison and this test fails
+        // while the rest of the fixture passes.
+        // UseAdvanced=True deliberately: in Simple mode `DerivePresetSettings()` overwrites ~16 advanced knobs
+        // from the Simple_* presets (F42(3)), so the source would read back the PRESET's MaxDistortion rather
+        // than the file's and this test would be measuring that instead of the export.
+        var source = new Dictionary<string, string> {
+            ["UseAdvanced"] = "True", ["MaxDistortion"] = "0.65", ["StarCenterTolerance"] = "0.325",
+        };
+        var destination = new Dictionary<string, string>();
+        var profileService = Substitute.For<IProfileService>();
+        var from = new StarDetectionOptions(profileService, new HarnessSettingsStore.FileOptionsAccessor(source));
+
+        HarnessSettingsStore.CopyOptionSurface(
+            from, new StarDetectionOptions(profileService, new HarnessSettingsStore.FileOptionsAccessor(destination)));
+
+        Assert.Multiple(() => {
+            Assert.That(destination, Does.ContainKey("MaxDistortion"), "bounded to [0,1]; current+1 throws");
+            Assert.That(double.Parse(destination["MaxDistortion"], System.Globalization.CultureInfo.InvariantCulture),
+                Is.EqualTo(from.MaxDistortion).Within(1e-12));
+            Assert.That(destination, Does.ContainKey("StarCenterTolerance"));
+            Assert.That(double.Parse(destination["StarCenterTolerance"], System.Globalization.CultureInfo.InvariantCulture),
+                Is.EqualTo(from.StarCenterTolerance).Within(1e-12));
+        });
+    }
+
+    // ---- Simple mode does not reach them -----------------------------------------------------------------------
+
+    [Test]
+    public void SimpleModePresetOverrides_DoesNotTouchTheFitInputs() {
+        // F42(3): `UseAdvanced = False` makes DerivePresetSettings() overwrite ~16 advanced DETECTOR knobs from
+        // the Simple_* presets, so editing them in a pinned file does nothing, silently. Asserted by MEASUREMENT
+        // rather than by a comment claiming the fit inputs are out of scope -- the whole point of that entry is
+        // that the list cannot be trusted to a human's reading of the class.
+        var file = new Dictionary<string, string> {
+            ["UseAdvanced"] = "False",
+            ["Simple_NoiseLevel"] = "Typical",
+            ["Simple_PixelScale"] = "Typical",
+            ["Simple_FocusRange"] = "Typical",
+            ["MaxOutlierRejections"] = "0",
+            ["OutlierRejectionConfidence"] = "0.99",
+            ["WeightedHyperbolicFitEnabled"] = "False",
+            ["HyperbolicFitModel"] = "Hyperbolic",
+        };
+        var overridden = HarnessSettingsStore.SimpleModePresetOverrides(file, Substitute.For<IProfileService>());
+
+        Assert.Multiple(() => {
+            Assert.That(overridden, Does.Not.Contain("MaxOutlierRejections"));
+            Assert.That(overridden, Does.Not.Contain("OutlierRejectionConfidence"));
+            Assert.That(overridden, Does.Not.Contain("WeightedHyperbolicFitEnabled"));
+            Assert.That(overridden, Does.Not.Contain("HyperbolicFitModel"));
+        });
+    }
+}

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/Joko.NINA.Plugins.HocusFocus.Tests.csproj
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/Joko.NINA.Plugins.HocusFocus.Tests.csproj
@@ -26,6 +26,7 @@
     <Compile Include="..\TestApp\GoldenGeometry.cs" Link="Golden\GoldenGeometry.cs" />
     <Compile Include="..\TestApp\BankVerification.cs" Link="Bank\BankVerification.cs" />
     <Compile Include="..\TestApp\HarnessSettingsStore.cs" Link="Harness\HarnessSettingsStore.cs" />
+    <Compile Include="..\TestApp\HarnessFitInputs.cs" Link="Harness\HarnessFitInputs.cs" />
     <Compile Include="..\TestApp\MonoFits16Writer.cs" Link="Golden\MonoFits16Writer.cs" />
     <!-- G5's golden policy (StarTruth to GoldenFrame): pure, no NINA/OpenCV coupling, so it links the same way. -->
     <Compile Include="..\TestApp\SynthBank\GoldenFromTruth.cs" Link="Golden\GoldenFromTruth.cs" />

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/StarDetection/Optimization/ExposureRecommenderTests.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/StarDetection/Optimization/ExposureRecommenderTests.cs
@@ -1069,6 +1069,150 @@ public class ExposureRecommenderTests {
         Assert.That(rec.WingRejectedFraction, Is.EqualTo(600.0 / 1800.0).Within(1e-9));
     }
 
+    // ── F19's SUCCESSOR: WingRejectedRatio = wing-third / inner-third ──────────────────────────────────────
+    //
+    // A MEASUREMENT ONLY. Nothing in the product reads it, and nothing may until RULE W1-W6 have been met on an
+    // arm run for it -- wave 10 pre-registered both the coordinate and that rule while the pass that refuted its
+    // predecessor was still running, precisely so it could not be adopted on the data that killed the last one.
+    //
+    // AND THESE FIXTURES DO NOT ESTABLISH THE POPULATION'S RANGE. That is the mistake that shipped the
+    // predecessor: its unit fixtures spanned a rejected fraction of 0.002 to 0.75, 0.20 sat sensibly between
+    // them, and exactly ONE run in 39 turned out to resemble the 0.002 pole. What is asserted below is the
+    // CONTRACT -- especially the four states -- and nothing about which of them real runs occupy.
+
+    /// <summary>
+    /// A 9-frame sweep on the wing axis with UNAMBIGUOUS thirds: positions 1000 + 10i against a fitted focus of
+    /// 1000, so the nine |offsets| are 0..80 and all distinct. The outer third is therefore exactly frames 8/7/6
+    /// and the inner third exactly frames 2/1/0, with no ordering tie for the sort to break either way.
+    /// </summary>
+    private static RunEvaluationMetrics RatioMetrics(
+            int wingRejected, int wingAccepted, int innerRejected, int innerAccepted, bool placeable = true) {
+        const int n = 9;
+        var rejected = new int[n];
+        var accepted = new int[n];
+        for (var i = 0; i < n; i++) {
+            var isWing = i >= 6;
+            var isInner = i <= 2;
+            rejected[i] = isWing ? wingRejected : isInner ? innerRejected : 0;
+            accepted[i] = isWing ? wingAccepted : isInner ? innerAccepted : 500;
+        }
+        return new RunEvaluationMetrics {
+            FrameStarSnrs = Enumerable.Range(0, n).Select(_ => (IReadOnlyList<double>)FullFrame(40.0)).ToArray(),
+            FrameStarCounts = accepted,
+            FrameLowSensitivityCounts = rejected,
+            FrameTooFlatCounts = new int[n],
+            FrameFocuserPositions = Enumerable.Range(0, n).Select(i => 1000 + i * 10).ToArray(),
+            BestFocusPosition = placeable ? 1000.0 : double.NaN,
+            StepSize = 10.0
+        };
+    }
+
+    [Test]
+    public void WingRejectedRatio_IsTheWingFractionOverTheInnerFraction() {
+        // wings 300/(300+300) = 0.50 ; core 100/(100+300) = 0.25 ; ratio 2.0.
+        var ratio = ExposureRecommender.WingRejectedRatioOf(
+            RatioMetrics(wingRejected: 300, wingAccepted: 300, innerRejected: 100, innerAccepted: 300), null);
+
+        Assert.That(ratio, Is.EqualTo(2.0).Within(1e-12));
+    }
+
+    [Test]
+    public void WingRejectedRatio_IsPositiveInfinity_WhenTheCoreRejectsNOTHINGAndTheWingsDo() {
+        // D20_m24_bright_control's shape: an inner rejected fraction of EXACTLY 0.000 against wings that reject.
+        // Genuinely unbounded, and the strongest signal the statistic can carry -- so it is +Infinity rather than
+        // a clamp, and it is NOT NaN, because the instrument looked and found something.
+        //
+        // It is also the pre-stated reason to expect this successor to be refuted in its turn: a statistic that
+        // asks the bank's BRIGHT CONTROL for more exposure is wrong on the one dataset whose name says otherwise.
+        var ratio = ExposureRecommender.WingRejectedRatioOf(
+            RatioMetrics(wingRejected: 300, wingAccepted: 300, innerRejected: 0, innerAccepted: 400), null);
+
+        Assert.That(double.IsPositiveInfinity(ratio), Is.True, $"expected +Infinity, got {ratio}");
+    }
+
+    [Test]
+    public void WingRejectedRatio_IsONE_WhenNeitherThirdRejectsAnything() {
+        // caboose's and mccomiskey's shape (wave 10 measured both at a wing fraction of exactly 0.000). The two
+        // rates are EQUAL, and the ratio of equal things is 1 -- not 0, which would read as "the wings are
+        // cleaner than the core", and not NaN, which would read as "we could not look" and would push the P4
+        // NaN-rate clause toward firing on runs where the instrument was working perfectly.
+        var ratio = ExposureRecommender.WingRejectedRatioOf(
+            RatioMetrics(wingRejected: 0, wingAccepted: 400, innerRejected: 0, innerAccepted: 400), null);
+
+        Assert.That(ratio, Is.EqualTo(1.0).Within(1e-12));
+    }
+
+    [Test]
+    public void WingRejectedRatio_IsNaN_WhenTheRunCannotBePlacedOnTheWingAxis() {
+        var ratio = ExposureRecommender.WingRejectedRatioOf(
+            RatioMetrics(300, 300, 100, 300, placeable: false), null);
+
+        Assert.That(ratio, Is.NaN);
+    }
+
+    [Test]
+    public void WingRejectedRatio_IsNaN_WhenTheInnerThirdFormedNoCandidatesAtAll() {
+        // No denominator exists. "We could not look" -- distinct from "we looked and the core rejected none",
+        // which is the +Infinity case above. Collapsing the two is exactly what the NaN-never-0 rule forbids.
+        var ratio = ExposureRecommender.WingRejectedRatioOf(
+            RatioMetrics(wingRejected: 300, wingAccepted: 300, innerRejected: 0, innerAccepted: 0), null);
+
+        Assert.That(ratio, Is.NaN);
+    }
+
+    [Test]
+    public void WingRejectedRatio_IsNaN_WhenTheTwoThirdsWouldOVERLAP() {
+        // A one-frame axis would compare a set with ITSELF and return 1.0 -- a number that looks like a
+        // measurement and is not one. Declining is the honest answer.
+        var single = new RunEvaluationMetrics {
+            FrameStarSnrs = new[] { (IReadOnlyList<double>)FullFrame(40.0) },
+            FrameStarCounts = new[] { 400 },
+            FrameLowSensitivityCounts = new[] { 100 },
+            FrameTooFlatCounts = new int[1],
+            FrameFocuserPositions = new[] { 1000 },
+            BestFocusPosition = 1000.0,
+            StepSize = 10.0
+        };
+
+        Assert.That(ExposureRecommender.WingRejectedRatioOf(single, null), Is.NaN);
+    }
+
+    [Test]
+    public void WingRejectedRatio_SurvivesTheROUNDTRIPAsAString_SoAScorerCannotSilentlyCoerceIt() {
+        // Newtonsoft writes NaN and Infinity as the STRINGS "NaN" and "Infinity". A scorer that coerces either to
+        // a number disables its own falsification rule -- which is precisely how wave 10's RULE P scorer came to
+        // read an unmeasured dataset as one that did not fire and report a partial run as a population verdict.
+        // Asserted here so the serialized contract is pinned rather than assumed.
+        var json = Newtonsoft.Json.JsonConvert.SerializeObject(new ExposureRecommendation {
+            WingRejectedRatio = double.PositiveInfinity
+        });
+        var nan = Newtonsoft.Json.JsonConvert.SerializeObject(new ExposureRecommendation {
+            WingRejectedRatio = double.NaN
+        });
+
+        Assert.Multiple(() => {
+            Assert.That(json, Does.Contain("\"WingRejectedRatio\":\"Infinity\""));
+            Assert.That(nan, Does.Contain("\"WingRejectedRatio\":\"NaN\""));
+        });
+    }
+
+    [Test]
+    public void Recommend_ReportsTheRatioBesideTheFraction_AndDerivesNoVerdictFromEither() {
+        var rec = ExposureRecommender.Recommend(
+            RatioMetrics(wingRejected: 300, wingAccepted: 300, innerRejected: 100, innerAccepted: 300),
+            DefaultConstants(), currentExposureSeconds: 0.5);
+
+        Assert.Multiple(() => {
+            Assert.That(rec.WingRejectedRatio, Is.EqualTo(2.0).Within(1e-12));
+            Assert.That(rec.WingRejectedFraction, Is.EqualTo(0.5).Within(1e-12));
+            // Every accepted star measures S/N 40 against a target of 10, so the accepted-star statistic says
+            // "exposure is not the limit" -- and a wing ratio of 2.0 does NOT override it. Wave 9's wingIsShedding
+            // did exactly that, on a statistic that fired on 30 of 39 runs.
+            Assert.That(rec.ExposureIsNotTheLimit, Is.True);
+            Assert.That(rec.RecommendedSeconds, Is.LessThanOrEqualTo(0.5));
+        });
+    }
+
     /// <summary>Builds an inclusive ascending double range [start, end] -- a small local helper to keep the
     /// 40-value quantile test readable.</summary>
     private static double[] Range(int start, int end) {

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/ExposureRecommender.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/ExposureRecommender.cs
@@ -206,6 +206,40 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization {
         public double WingRejectedFraction { get; set; } = double.NaN;
 
         /// <summary>
+        /// F19 — <see cref="WingRejectedFraction"/> divided by the SAME quantity computed on the INNER third:
+        /// the control the absolute fraction never had. <b>A MEASUREMENT ONLY. Nothing acts on it</b>, and
+        /// nothing may until RULE W1–W6 have been met on an arm run for it.
+        ///
+        /// <para><b>Why the ratio, and why it is not obviously right either.</b> Wave 10's population check
+        /// refuted the absolute fraction on 39 runs: it fired on the great majority, and four real-bank runs
+        /// fired while rejecting FEWER candidates in their wings than in their cores. The claim was always
+        /// comparative — <i>the wings are losing faint stars a longer exposure would convert</i> — so the ratio is
+        /// the coordinate the claim was actually about. But <c>D17_cdk14_oiii5</c>, one of the two datasets a
+        /// wing statistic exists to catch, has a ratio of <b>0.59</b>, and <c>D20_m24_bright_control</c> — the
+        /// bank's BRIGHT CONTROL — has an inner fraction of exactly 0.000 and therefore an INFINITE ratio.
+        /// <b>Both are expected to refute it</b>, and they are written down here before the pass so that meeting
+        /// them cannot be presented as a surprise.</para>
+        ///
+        /// <para><b>Four states, because two different things divide by zero</b> — the NaN-never-0 rule extended
+        /// rather than reinterpreted:</para>
+        /// <list type="bullet">
+        /// <item><see cref="double.NaN"/> — the run cannot be placed on the wing axis, or the inner third formed
+        ///   no candidates at all. <i>"We could not look."</i></item>
+        /// <item><see cref="double.PositiveInfinity"/> — the inner third formed candidates and rejected NONE
+        ///   while the wings rejected some. <i>"The wings reject and the cores do not"</i> — a real measurement
+        ///   and the strongest signal this statistic can carry, not an error.</item>
+        /// <item><c>1.0</c> — both thirds formed candidates and both rejected nothing. Equal rates, and equal is
+        ///   what a ratio of equal things is. It is NOT NaN: the instrument looked and found symmetry.</item>
+        /// <item>otherwise the ratio.</item>
+        /// </list>
+        ///
+        /// <para><b>Newtonsoft writes the first two as the STRINGS <c>"NaN"</c> and <c>"Infinity"</c>.</b> A
+        /// scorer that coerces either to a number disables its own falsification rule — which is exactly how wave
+        /// 10's RULE P scorer came to read an unmeasured dataset as one that did not fire.</para>
+        /// </summary>
+        public double WingRejectedRatio { get; set; } = double.NaN;
+
+        /// <summary>
         /// True when the run's Sensitivity gate sat at or below <see cref="InertGateBound"/> AND
         /// <see cref="GateRejectedCount"/> is 0 — the gate could not have rejected anything, so its zero rejection
         /// count is empty by construction and is NOT evidence that the star field is exhausted (F28). Always false
@@ -652,8 +686,14 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization {
             // floored by the gate, and they are exactly the stars a longer exposure can convert. See
             // ExposureRecommendation.WingRejectedFraction.
             var wingRejectedFraction = WingRejectedFractionOf(metrics, isRecovery);
-            // NO VERDICT IS DERIVED FROM IT (wave 10 -- see the withdrawal note above the constants). The fraction
-            // is reported; nothing acts on it. Wave 9's `wingIsShedding` overrode the line below, which is how a
+            // And its CONTROL, which the absolute fraction never had: the same quantity on the INNER third. Wave
+            // 10's population check showed the absolute fraction cannot separate "the wings are losing faint
+            // stars" from "the detector rejects noise everywhere" -- four real-bank runs fired with wings CLEANER
+            // than their cores. The ratio is the coordinate the claim was always about. It is a MEASUREMENT ONLY
+            // and is expected to be refuted in its turn (D17 sits at 0.59; D20, the bright control, is infinite).
+            var wingRejectedRatio = WingRejectedRatioOf(metrics, isRecovery);
+            // NO VERDICT IS DERIVED FROM EITHER (wave 10 -- see the withdrawal note above the constants). They are
+            // reported; nothing acts on them. Wave 9's `wingIsShedding` overrode the line below, which is how a
             // statistic that fires on most runs came to flip most users' exposure verdict.
             var exposureIsNotTheLimit = signalIsSufficient && !everyFrameShort;
 
@@ -710,7 +750,8 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization {
                 FlatRejectedCount = flatRejectedCount,
                 InertGateBound = inertGateBound,
                 GateIsProvablyInert = gateIsProvablyInert,
-                WingRejectedFraction = wingRejectedFraction
+                WingRejectedFraction = wingRejectedFraction,
+                WingRejectedRatio = wingRejectedRatio
             };
         }
 
@@ -731,17 +772,81 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization {
         /// whose starvation is being measured.</para>
         /// </summary>
         internal static double WingRejectedFractionOf(RunEvaluationMetrics metrics, IReadOnlyList<bool> isRecovery) {
+            var usable = WingAxis(metrics, isRecovery);
+            if (usable == null) {
+                return double.NaN;
+            }
+
+            // At least one frame, so a short sweep still answers rather than silently declining to.
+            var wingCount = Math.Max(1, (int)Math.Round(usable.Count * WingFrameFraction));
+            var (rejected, accepted) = PoolRange(usable, 0, wingCount);
+            var formed = rejected + accepted;
+            // No candidates formed at all out here is not a shedding wing -- it is a frame with nothing on it, which
+            // is StarCountIsTheLimit's question, not this one.
+            return formed > 0 ? (double)rejected / formed : 0.0;
+        }
+
+        /// <summary>
+        /// F19's successor — <see cref="WingRejectedFractionOf"/> over the OUTER third divided by the same
+        /// quantity over the INNER third. See <see cref="ExposureRecommendation.WingRejectedRatio"/> for the
+        /// four-state contract and for why both <c>D17</c> and <c>D20</c> are expected to refute it.
+        ///
+        /// <para><b>A MEASUREMENT ONLY.</b> Nothing in the product reads it. Wave 10 withdrew its predecessor's
+        /// verdict on a 39-run population and pre-registered this coordinate together with the rule that must be
+        /// met before anything acts on it — precisely so it could not be adopted on the data that killed the last
+        /// one.</para>
+        /// </summary>
+        internal static double WingRejectedRatioOf(RunEvaluationMetrics metrics, IReadOnlyList<bool> isRecovery) {
+            var usable = WingAxis(metrics, isRecovery);
+            if (usable == null) {
+                return double.NaN;
+            }
+
+            var thirdCount = Math.Max(1, (int)Math.Round(usable.Count * WingFrameFraction));
+            // The two thirds must be DISJOINT or the ratio compares a set with itself and returns 1.0 for every
+            // short sweep -- a number that looks like a measurement and is not one. Declining is the honest
+            // answer, and it is NaN rather than 0 for the reason the whole statistic is NaN-never-0.
+            if (thirdCount * 2 > usable.Count) {
+                return double.NaN;
+            }
+
+            var (wingRejected, wingAccepted) = PoolRange(usable, 0, thirdCount);
+            var (innerRejected, innerAccepted) = PoolRange(usable, usable.Count - thirdCount, thirdCount);
+            var wingFormed = wingRejected + wingAccepted;
+            var innerFormed = innerRejected + innerAccepted;
+            if (innerFormed == 0) {
+                // Nothing was FORMED in the core, so there is no rate to compare against. "We could not look."
+                return double.NaN;
+            }
+
+            var wingFraction = wingFormed > 0 ? (double)wingRejected / wingFormed : 0.0;
+            var innerFraction = (double)innerRejected / innerFormed;
+            if (innerFraction == 0.0) {
+                // The core formed candidates and rejected NONE. If the wings rejected some, that is the strongest
+                // signal this statistic can carry and it is genuinely unbounded -- not an error to be clamped.
+                // If the wings also rejected none, the two rates are EQUAL, and the ratio of equal things is 1.
+                return wingFraction > 0.0 ? double.PositiveInfinity : 1.0;
+            }
+            return wingFraction / innerFraction;
+        }
+
+        /// <summary>
+        /// The non-recovery frames that can be placed on the wing axis — <c>(|offset from the fitted focus|,
+        /// rejected, accepted)</c>, FARTHEST FROM FOCUS FIRST. Null when the run cannot be placed at all.
+        ///
+        /// <para>A frame missing any of the three is left OUT rather than defaulted to zero: a defaulted frame
+        /// would enter the pool as "formed nothing and rejected nothing", which reads as a healthy wing.</para>
+        /// </summary>
+        private static List<(double Offset, int Rejected, int Accepted)> WingAxis(
+                RunEvaluationMetrics metrics, IReadOnlyList<bool> isRecovery) {
             var positions = metrics?.FrameFocuserPositions;
             var lowSens = metrics?.FrameLowSensitivityCounts;
             var counts = metrics?.FrameStarCounts;
             if (positions == null || lowSens == null || counts == null
                 || !double.IsFinite(metrics.BestFocusPosition) || !(metrics.StepSize > 0.0)) {
-                return double.NaN;
+                return null;
             }
 
-            // Non-recovery frames that carry all three of (position, rejection count, accepted count), keyed by
-            // |offset from the fitted focus|. A frame missing any of them cannot be placed or scored and is left
-            // out rather than defaulted to zero.
             var usable = new List<(double Offset, int Rejected, int Accepted)>(positions.Count);
             for (var i = 0; i < positions.Count; i++) {
                 if (IsRecoveryFrame(isRecovery, i) || i >= lowSens.Count || i >= counts.Count) {
@@ -750,21 +855,20 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization {
                 usable.Add((Math.Abs(positions[i] - metrics.BestFocusPosition), lowSens[i], counts[i]));
             }
             if (usable.Count == 0) {
-                return double.NaN;
+                return null;
             }
-
             usable.Sort((a, b) => b.Offset.CompareTo(a.Offset)); // farthest from focus first
-            // At least one frame, so a short sweep still answers rather than silently declining to.
-            var wingCount = Math.Max(1, (int)Math.Round(usable.Count * WingFrameFraction));
+            return usable;
+        }
+
+        private static (long Rejected, long Accepted) PoolRange(
+                List<(double Offset, int Rejected, int Accepted)> usable, int start, int count) {
             long rejected = 0, accepted = 0;
-            for (var i = 0; i < wingCount; i++) {
+            for (var i = start; i < start + count; i++) {
                 rejected += usable[i].Rejected;
                 accepted += usable[i].Accepted;
             }
-            var formed = rejected + accepted;
-            // No candidates formed at all out here is not a shedding wing -- it is a frame with nothing on it, which
-            // is StarCountIsTheLimit's question, not this one.
-            return formed > 0 ? (double)rejected / formed : 0.0;
+            return (rejected, accepted);
         }
 
         private static ExposureRecommendation NoRecommendation(double currentExposureSeconds, int usableFrameCount, int shortFrameCount) {
@@ -787,7 +891,8 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization {
                 GateIsProvablyInert = false,
                 // NaN, not 0: this run produced no recommendation at all, so it did not look at its wings either,
                 // and a consumer must not read a confident zero out of that.
-                WingRejectedFraction = double.NaN
+                WingRejectedFraction = double.NaN,
+                WingRejectedRatio = double.NaN
             };
         }
 

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/OptimizedStarDetectionSettings.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/OptimizedStarDetectionSettings.cs
@@ -442,6 +442,23 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization {
         public string ProfileId { get; set; }
 
         /// <summary>
+        /// The values that reach the AF <b>fit</b>, rendered as <c>key=value;key=value</c>. Null when the
+        /// producer does not record them.
+        ///
+        /// <para><b>F58.</b> <see cref="ProfileId"/> says which profile ran; this says what the profile (or the
+        /// pinned settings file) actually supplied. The two are not the same question, and the difference is the
+        /// entire defect: the fit reads four values, and wave 11 found that the machine's nine profiles partition
+        /// <b>2 / 7</b> on just one of them (<c>MaxOutlierRejections</c>) — which is why concurrent runs, each
+        /// having silently acquired a different profile, landed on two discrete values of <c>J</c> and looked
+        /// like a floating-point race for two waves.</para>
+        ///
+        /// <para><b>Values, not a hash.</b> A fingerprint tells a reader that something moved; these tell them
+        /// WHICH, without a second run. That is the same reason <see cref="BuildId"/> is an MVID rather than a
+        /// version string and <c>DetectionBinningSource</c> (F39(a)) is a field rather than a sentence.</para>
+        /// </summary>
+        public string FitInputs { get; set; }
+
+        /// <summary>
         /// The identity of the currently-loaded plugin build: <see cref="BuildId"/> and
         /// <see cref="DetectorVersion"/>, read off this assembly. Static so the harness and the shipping wizard
         /// stamp the same two values from the same place rather than each deriving its own.
@@ -465,6 +482,7 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization {
                 parts.Add($"CONCURRENCY={ConcurrencyCheck.ToUpperInvariant()}");
             }
             if (!string.IsNullOrWhiteSpace(ProfileId)) { parts.Add($"profile {ProfileId}"); }
+            if (!string.IsNullOrWhiteSpace(FitInputs)) { parts.Add($"fit[{FitInputs}]"); }
             if (!string.IsNullOrWhiteSpace(CommandLine)) { parts.Add(CommandLine); }
             if (!string.IsNullOrWhiteSpace(SettingsFingerprint)) { parts.Add($"settings#{SettingsFingerprint}"); }
             return parts.Count > 0 ? string.Join(" | ", parts) : "(no provenance)";

--- a/Joko.NINA.Plugins/TestApp/HarnessFitInputs.cs
+++ b/Joko.NINA.Plugins/TestApp/HarnessFitInputs.cs
@@ -1,0 +1,70 @@
+#region "copyright"
+
+/*
+    Copyright © 2021 - 2026 George Hilios <ghilios+NINA@googlemail.com>
+
+    This Source Code Form is subject to the terms of the Mozilla Public
+    License, v. 2.0. If a copy of the MPL was not distributed with this
+    file, You can obtain one at http://mozilla.org/MPL/2.0/.
+*/
+
+#endregion "copyright"
+
+using NINA.Joko.Plugins.HocusFocus.Interfaces;
+using System.Globalization;
+
+namespace TestApp {
+
+    /// <summary>
+    /// The four values that reach the AF <b>fit</b> — read once, used to build the fit AND to render the
+    /// <c>FitInputs</c> provenance field, so the values that drive a landing and the values recorded beside it
+    /// <b>cannot diverge</b>.
+    ///
+    /// <para><b>Why this type exists (F58).</b> <c>optimize</c> pinned the DETECTOR knobs with
+    /// <c>--settings</c> and read these four straight off <c>AutoFocusOptions</c>, which binds a
+    /// <c>PluginOptionsAccessor</c> to whichever NINA profile is ACTIVE. So the detector was pinned and the fit
+    /// was not, and six waves read <c>--settings</c> as pinning the arm. Wave 11 measured the consequence: the
+    /// machine's nine profiles partition <b>2 / 7</b> on <c>MaxOutlierRejections</c> alone, concurrent
+    /// <c>optimize</c> processes each silently acquire a DIFFERENT profile (NINA holds the <c>.profile</c> file
+    /// open, and <c>TryLoad</c> skips a locked one and takes the next by <c>LastUsed</c>), and the resulting two
+    /// discrete values of <c>J</c> were chased as a floating-point race across two waves.</para>
+    ///
+    /// <para>A guard test would keep the printed list in sync with the read list only until someone forgot to
+    /// update it. Routing both through one type removes the failure mode instead of watching for it — the same
+    /// move as <c>ConcurrencyCheck</c> replacing "say so in the run instructions".</para>
+    /// </summary>
+    internal sealed class HarnessFitInputs {
+
+        private HarnessFitInputs(bool useWeights, int maxOutlierRejections, double rejectionConfidence, HyperbolicFitModel preferredModel) {
+            UseWeights = useWeights;
+            MaxOutlierRejections = maxOutlierRejections;
+            RejectionConfidence = rejectionConfidence;
+            PreferredModel = preferredModel;
+        }
+
+        public bool UseWeights { get; }
+
+        public int MaxOutlierRejections { get; }
+
+        public double RejectionConfidence { get; }
+
+        public HyperbolicFitModel PreferredModel { get; }
+
+        public static HarnessFitInputs From(IAutoFocusOptions options) => new HarnessFitInputs(
+            options.WeightedHyperbolicFitEnabled,
+            options.MaxOutlierRejections,
+            options.OutlierRejectionConfidence,
+            options.HyperbolicFitModel);
+
+        /// <summary>
+        /// <c>key=value;…</c>, invariant-culture, stable ordering. This string goes into every landing's
+        /// <c>OptimizerProvenance.FitInputs</c> — values rather than a hash, because a hash tells a reader that
+        /// something moved and these tell them which one.
+        /// </summary>
+        public override string ToString() =>
+            $"MaxOutlierRejections={MaxOutlierRejections.ToString(CultureInfo.InvariantCulture)};" +
+            $"OutlierRejectionConfidence={RejectionConfidence.ToString("R", CultureInfo.InvariantCulture)};" +
+            $"WeightedHyperbolicFitEnabled={UseWeights};" +
+            $"HyperbolicFitModel={PreferredModel}";
+    }
+}

--- a/Joko.NINA.Plugins/TestApp/HarnessSettingsStore.cs
+++ b/Joko.NINA.Plugins/TestApp/HarnessSettingsStore.cs
@@ -636,73 +636,153 @@ namespace TestApp {
             // option's DEFAULT, which looks like a perfectly valid run. Assigning property-by-property makes the
             // options class itself emit the right keys with the right types, so the snapshot cannot drift from
             // what the class actually reads, and a newly added option is captured with no change here.
-            var fromProfile = new NINA.Joko.Plugins.HocusFocus.StarDetection.StarDetectionOptions(
-                profileService, new PluginOptionsAccessor(profileService, guid.Value));
-            var toFile = new NINA.Joko.Plugins.HocusFocus.StarDetection.StarDetectionOptions(
-                profileService, new FileOptionsAccessor(file.Options));
+            CopyOptionSurface(
+                new NINA.Joko.Plugins.HocusFocus.StarDetection.StarDetectionOptions(
+                    profileService, new PluginOptionsAccessor(profileService, guid.Value)),
+                new NINA.Joko.Plugins.HocusFocus.StarDetection.StarDetectionOptions(
+                    profileService, new FileOptionsAccessor(file.Options)));
 
-            foreach (var prop in typeof(NINA.Joko.Plugins.HocusFocus.StarDetection.StarDetectionOptions).GetProperties()) {
-                if (!prop.CanRead || !prop.CanWrite || prop.GetIndexParameters().Length > 0) {
-                    continue;
-                }
-                try {
-                    var value = prop.GetValue(fromProfile);
-                    // Write a DIFFERENT value first so the option's change-detecting setter actually fires.
-                    // Without this the snapshot is SPARSE: a value equal to the shipped default never reaches the
-                    // file, and the file then inherits whatever the default IS AT LOAD TIME. That is
-                    // behaviour-preserving today and quietly wrong the day a default changes — precisely the
-                    // silent drift a settings file exists to prevent. Density costs one extra write per property.
-                    var poison = Poison(value, prop.PropertyType);
-                    if (poison != null) {
-                        prop.SetValue(toFile, poison);
-                    }
-                    prop.SetValue(toFile, value);
-                } catch {
-                    // A property that refuses a round trip (computed, validated, or profile-coupled) is not a
-                    // detector knob we can carry; skip it rather than abort the whole export.
-                }
-            }
+            // F58 — THE FIT, not just the detector. `AutoFocusOptions` was the ONE options surface the harness
+            // still read straight off the active NINA profile, and four of its values reach the AF fit
+            // (WeightedHyperbolicFitEnabled, MaxOutlierRejections, OutlierRejectionConfidence,
+            // HyperbolicFitModel). So `--settings` pinned the detector and left the fit floating, and six waves
+            // read that as pinning the arm. It is not academic: this machine's nine profiles partition 2/7 on
+            // MaxOutlierRejections alone, and because NINA holds a `.profile` open while it is loaded (and
+            // TryLoad silently skips a locked one for the next by LastUsed), concurrent `optimize` processes each
+            // acquire a DIFFERENT profile -- which is how a single integer produced the two discrete "attractors"
+            // F55 spent two waves chasing as a floating-point race.
+            CopyOptionSurface(
+                new NINA.Joko.Plugins.HocusFocus.AutoFocus.AutoFocusOptions(
+                    profileService, new PluginOptionsAccessor(profileService, guid.Value)),
+                new NINA.Joko.Plugins.HocusFocus.AutoFocus.AutoFocusOptions(
+                    profileService, new FileOptionsAccessor(file.Options)));
             return file;
         }
 
         /// <summary>
-        /// A value of <paramref name="type"/> guaranteed to differ from <paramref name="value"/>, used only to
-        /// trip a change-detecting setter. Null when no such value can be produced, in which case the property is
-        /// written once and may stay absent from the file (see <see cref="ExportFromProfile"/>).
+        /// Copies an options class's whole PROPERTY SURFACE from one accessor-backed instance to another.
+        ///
+        /// <para>Property-by-property rather than by raw key, because the profile stores plugin options as typed
+        /// values with no "list my keys" API: a raw read has to guess both the key list and each key's type, and
+        /// a miss is SILENT — the loaded options fall back to the option's DEFAULT, which looks like a perfectly
+        /// valid run. Assigning through the class makes the class itself emit the right keys with the right
+        /// types, so the snapshot cannot drift from what it actually reads, and a newly added option is captured
+        /// with no change here.</para>
         /// </summary>
-        private static object Poison(object value, Type type) {
+        internal static void CopyOptionSurface<T>(T fromProfile, T toFile) {
+            foreach (var prop in typeof(T).GetProperties()) {
+                if (!prop.CanRead || !prop.CanWrite || prop.GetIndexParameters().Length > 0) {
+                    continue;
+                }
+                object value;
+                try {
+                    value = prop.GetValue(fromProfile);
+                } catch {
+                    continue;   // a computed or profile-coupled property; not a knob we can carry
+                }
+
+                // Write a DIFFERENT value first so the option's change-detecting setter actually fires. Without
+                // this the snapshot is SPARSE: a value equal to the shipped default never reaches the file, and
+                // the file then inherits whatever the default IS AT LOAD TIME — behaviour-preserving today and
+                // quietly wrong the day a default changes, which is precisely the drift a pinned settings file
+                // exists to prevent.
+                //
+                // F59 — AND ONE POISON CANDIDATE IS NOT ENOUGH, WHICH COST FIVE KNOBS FOR SIX WAVES. These
+                // setters VALIDATE and THROW: `MaxDistortion` demands [0, 1] and `OutlierRejectionConfidence`
+                // demands (0.5, 1.0) exclusive, so the obvious `current + 1` poison raised ArgumentException,
+                // a single enclosing catch swallowed it, and the property was skipped ENTIRELY — neither the
+                // poison NOR the real value written. `pinned_settings.json`, the file waves 5–11 called "the
+                // pinned detector", is missing `MaxDistortion`, `StarCenterTolerance`, `SaturationThreshold`,
+                // `HotpixelThreshold` and `Sensitivity` for exactly this reason. So:
+                //   * candidates are TRIED IN TURN until one lands inside the property's own valid range, and
+                //   * the poison is VERIFIED BY READ-BACK rather than assumed to have taken, and
+                //   * the real write has its OWN try, so a poison failure can never cost it again.
+                foreach (var poison in PoisonCandidates(value, prop.PropertyType)) {
+                    try {
+                        prop.SetValue(toFile, poison);
+                        if (!Equals(prop.GetValue(toFile), value)) {
+                            break;      // it took; the real write below will now fire the change detector
+                        }
+                    } catch {
+                        // Outside THIS property's valid range. Try the next candidate rather than giving up.
+                    }
+                }
+
+                try {
+                    prop.SetValue(toFile, value);
+                } catch {
+                    // The property genuinely refuses its own current value (computed, or validated against
+                    // state this instance does not have). Skip it rather than abort the whole export.
+                }
+            }
+        }
+
+        /// <summary>
+        /// Values of <paramref name="type"/> that differ from <paramref name="value"/>, to be tried IN TURN until
+        /// one trips the property's change-detecting setter without tripping its VALIDATION.
+        ///
+        /// <para><b>F59 — why this is a sequence and not a single value.</b> The one-candidate version returned
+        /// <c>current + 1</c>, which is outside the valid range of every knob bounded above: <c>MaxDistortion</c>
+        /// demands [0, 1] and <c>OutlierRejectionConfidence</c> demands (0.5, 1.0) exclusive, so the poison threw
+        /// and the property was dropped from the export entirely. The numeric spread below deliberately includes
+        /// candidates on BOTH sides of the current value and INSIDE the unit interval, so a bounded knob still
+        /// gets poisoned. Caller verifies by read-back — no candidate is assumed to have taken.</para>
+        /// </summary>
+        private static IEnumerable<object> PoisonCandidates(object value, Type type) {
             var t = Nullable.GetUnderlyingType(type) ?? type;
             if (t == typeof(bool)) {
-                return !(bool)(value ?? false);
+                yield return !(bool)(value ?? false);
+                yield break;
             }
             if (t == typeof(string)) {
-                return (value as string) == "~" ? "~~" : "~";
+                yield return (value as string) == "~" ? "~~" : "~";
+                yield break;
             }
             if (t.IsEnum) {
                 foreach (var candidate in Enum.GetValues(t)) {
                     if (!Equals(candidate, value)) {
-                        return candidate;
+                        yield return candidate;
                     }
                 }
-                return null;
+                yield break;
+            }
+            if (t == typeof(DateTime)) {
+                yield return ((DateTime)(value ?? DateTime.UnixEpoch)).AddDays(1);
+                yield break;
             }
             if (t == typeof(double) || t == typeof(float) || t == typeof(decimal)
                 || t == typeof(int) || t == typeof(long) || t == typeof(short)
                 || t == typeof(byte) || t == typeof(sbyte)
                 || t == typeof(uint) || t == typeof(ulong) || t == typeof(ushort)) {
+                double current;
                 try {
-                    // +1 in the property's own type. Doubles that are NaN compare unequal to everything, so any
-                    // finite value already differs; 0 is a safe, in-range choice for every numeric knob here.
-                    var current = Convert.ToDouble(value ?? 0);
-                    return Convert.ChangeType(double.IsNaN(current) ? 0.0 : current + 1.0, t);
+                    current = Convert.ToDouble(value ?? 0);
                 } catch {
-                    return null;
+                    yield break;
+                }
+                if (double.IsNaN(current) || double.IsInfinity(current)) {
+                    current = 0.0;
+                }
+                // Both directions, and inside the unit interval, so a knob bounded to [0,1] or (0.5,1.0) is
+                // still reachable. Integer knobs round on conversion, which is why +/-1 come first.
+                var spread = new[] {
+                    current + 1.0, current - 1.0,
+                    (current + 1.0) / 2.0, current / 2.0,
+                    current * 1.01, current * 0.99,
+                    0.0, 1.0
+                };
+                foreach (var candidate in spread) {
+                    object converted;
+                    try {
+                        converted = Convert.ChangeType(candidate, t);
+                    } catch {
+                        continue;   // out of the TYPE's range (e.g. -1 into a byte)
+                    }
+                    if (!Equals(converted, value)) {
+                        yield return converted;
+                    }
                 }
             }
-            if (t == typeof(DateTime)) {
-                return ((DateTime)(value ?? DateTime.UnixEpoch)).AddDays(1);
-            }
-            return null;
         }
     }
 }

--- a/Joko.NINA.Plugins/TestApp/OptimizationDiagnosticRunner.cs
+++ b/Joko.NINA.Plugins/TestApp/OptimizationDiagnosticRunner.cs
@@ -234,6 +234,22 @@ namespace TestApp {
                 Console.WriteLine("Verbose logging enabled (TRACE).");
             }
 
+            // --cv-threads <n> caps OpenCV's parallel-for pool (0 = restore the default). It exists so the F55
+            // family can be probed WITHOUT an environment variable: wave 9 tried to set the plugin's
+            // Parallel.For degree from WSL and silently measured the SAME configuration five times, because WSL
+            // environment variables do not reach a Windows process unless WSLENV names them -- "an instrument
+            // that is not connected reports perfect agreement". A flag cannot be disconnected that way, and
+            // Cv2.GetNumThreads() is printed with the provenance below as its positive control, whether or not
+            // the flag was passed.
+            var cvThreadsArg = DiagnosticUtil.GetArg(args, "--cv-threads");
+            if (!string.IsNullOrWhiteSpace(cvThreadsArg)) {
+                if (!int.TryParse(cvThreadsArg, NumberStyles.Integer, CultureInfo.InvariantCulture, out var cvThreads)) {
+                    throw new ArgumentException($"--cv-threads expects an integer, got '{cvThreadsArg}'");
+                }
+                Cv2.SetNumThreads(cvThreads);
+                Console.WriteLine($"--cv-threads {cvThreads}: OpenCV parallel-for pool capped.");
+            }
+
             // The real ProfileService.ActiveProfile setter writes to Application.Current.Resources, so a
             // (non-running) WPF Application must exist or it NREs (mirrors ContaminationDiagnosticRunner).
             if (Application.Current == null) {
@@ -267,6 +283,18 @@ namespace TestApp {
             // on every build; the detector version says which OUTPUT contract produced the numbers (wave 9's
             // whole results doc needed a hand-written banner for want of it).
             var build = OptimizerProvenance.CurrentBuild();
+            var accessor = harnessSettings.Accessor;
+            var starDetectionOptions = new StarDetectionOptions(profileService, accessor);
+            // F58: the harness accessor, NOT the profile. `new AutoFocusOptions(profileService)` binds a
+            // PluginOptionsAccessor to whichever profile is ACTIVE, so the DETECTOR was pinned by --settings and
+            // the FIT was not -- and the fit reads MaxOutlierRejections, on which this machine's nine profiles
+            // partition 2/7. Concurrent processes each acquire a DIFFERENT profile (NINA holds the .profile file
+            // open, and TryLoad skips a locked one and takes the next by LastUsed), which is how one integer
+            // produced the two discrete "attractors" F55 chased as a floating-point race for two waves. The live
+            // plugin is unchanged: the wizard and the AF engine must keep reading the profile, because there
+            // these ARE the user's settings.
+            var afOptions = new AutoFocusOptions(profileService, accessor);
+            var fitInputs = HarnessFitInputs.From(afOptions);
             var provenance = new OptimizerProvenance {
                 Producer = "TestApp optimize",
                 CommandLine = string.Join(" ", args ?? Array.Empty<string>()),
@@ -278,18 +306,17 @@ namespace TestApp {
                 ConcurrencyCheck = ClaimExclusiveOptimize(),
                 // F57: --settings pins the detector knobs and NOT the arm. The active profile moves BaselineJ by
                 // 0.0144 on toml999, so which profile ran is part of a landing's identity.
-                ProfileId = $"{activeProfile.Name} ({activeProfile.Id})"
+                ProfileId = $"{activeProfile.Name} ({activeProfile.Id})",
+                // F58: and WHICH profile is a different question from WHAT it supplied. The values, not a hash.
+                FitInputs = fitInputs.ToString()
             };
             Console.WriteLine($"provenance: {provenance}");
+            Console.WriteLine($"OpenCV threads: {Cv2.GetNumThreads()}");
             if (provenance.ConcurrencyCheck != "exclusive") {
                 Console.WriteLine($"WARNING: concurrency check = {provenance.ConcurrencyCheck}. F55: concurrent " +
                     "`optimize` moves 44% of LANDINGS and 15% of seed evaluations, so any arm read on landings " +
                     "is INVALID. The value is recorded in every landing this run writes.");
             }
-            var accessor = harnessSettings.Accessor;
-            var starDetectionOptions = new StarDetectionOptions(profileService, accessor);
-            var afOptions = new AutoFocusOptions(profileService);
-
             // PixelScale = arcsec/pixel from the profile (pixel size / focal length) × binning, mirroring
             // HocusFocusStarDetection.GetStarDetectorParams. Production reads binning from per-frame metadata
             // (image.RawImageData.MetaData.Camera.BinX, which defaults to 1 when unset); the harness loads raw
@@ -398,6 +425,7 @@ namespace TestApp {
                 HarnessSettings = harnessSettings,
                 Provenance = provenance,
                 AfOptions = afOptions,
+                FitInputs = fitInputs,
                 AlglibAPI = alglibAPI,
                 Detector = detector,
                 Detection = detection,
@@ -450,6 +478,10 @@ namespace TestApp {
             /// knobs the curated axes do not cover (binning, contamination, PSF, saturation, ...).</summary>
             public StarDetectionOptions StarDetectionOptions;
             public AutoFocusOptions AfOptions;
+
+            /// <summary>The four values that reach the FIT, read once. See <see cref="HarnessFitInputs"/> — the
+            /// fit and the provenance field are built from this one object so they cannot diverge (F58).</summary>
+            public HarnessFitInputs FitInputs;
             public AlglibAPI AlglibAPI;
             public StarDetector Detector;
 
@@ -670,13 +702,15 @@ namespace TestApp {
             var stepSize = InferStepSize(d.Frames);
             var fitConfig = new RunFitConfig {
                 StepSize = stepSize,
-                UseWeights = ctx.AfOptions.WeightedHyperbolicFitEnabled,
-                MaxOutlierRejections = ctx.AfOptions.MaxOutlierRejections,
-                RejectionConfidence = ctx.AfOptions.OutlierRejectionConfidence,
+                // F58: read from ctx.FitInputs, NOT from ctx.AfOptions, so the values that build this fit are the
+                // same object that is rendered into every landing's OptimizerProvenance.FitInputs.
+                UseWeights = ctx.FitInputs.UseWeights,
+                MaxOutlierRejections = ctx.FitInputs.MaxOutlierRejections,
+                RejectionConfidence = ctx.FitInputs.RejectionConfidence,
                 // Was hard-coded null while the wizard's loader passes afOptions.HyperbolicFitModel. Currently
                 // informational (the evaluator always runs the Hybrid best-fit selection), but a silent divergence
                 // from the wizard is exactly what this work exists to remove.
-                PreferredModel = ctx.AfOptions.HyperbolicFitModel
+                PreferredModel = ctx.FitInputs.PreferredModel
             };
 
             // Split detector: the WIZARD'S OWN HocusFocusSplitFrameDetector (RunEvaluationLoader), not a harness
@@ -1336,7 +1370,7 @@ namespace TestApp {
         }
 
         private static void PrintUsage() {
-            Console.Error.WriteLine("Usage: TestApp optimize --runs <folder> [--per-run] [--profile-id <guid>] [--out <dir>] [--max-evals <int>] [--annotate extremes|all] [--labels <dir>] [--inspection] [--donut] [--start-from-current] [--continue-rounds <0-2>] [--verbose]");
+            Console.Error.WriteLine("Usage: TestApp optimize --runs <folder> [--per-run] [--profile-id <guid>] [--out <dir>] [--max-evals <int>] [--annotate extremes|all] [--labels <dir>] [--inspection] [--donut] [--start-from-current] [--continue-rounds <0-2>] [--verbose] [--cv-threads <n>]");
             Console.Error.WriteLine("  --runs       (required) folder of saved AF runs. Runs are 'attempt*' folders (recursively, <=4 deep) with >=3 focuser positions; or --runs itself.");
             Console.Error.WriteLine("  --per-run    (optional) optimize each discovered run INDEPENDENTLY into its own subfolder + an aggregate_summary.txt (use for a multi-setup bank).");
             Console.Error.WriteLine("  --profile-id (default active) NINA profile id to load (settings + PixelScale).");
@@ -1350,6 +1384,7 @@ namespace TestApp {
             Console.Error.WriteLine("  --legacy-objective (optional) disable the HFR-outlier penalty + region-coverage reward + saturated-HFR exclusion (the pre-change 'before' for an A/B).");
             Console.Error.WriteLine("  --continue-rounds (optional, 0-2) extra chained passes after the first, each re-seeded from the prior best (3 total).");
             Console.Error.WriteLine("  --verbose    (optional) restore TRACE logging (default INFO). Slower: serializes per-detection stage timings to the NINA log.");
+            Console.Error.WriteLine("  --cv-threads (optional) cap OpenCV's parallel-for pool (0 = default). F55/F58 probes; the effective value is always printed.");
             Console.Error.WriteLine("  --marginal-snr-strength (optional) override ObjectiveConstants.MarginalSnrStrength (F23 false-positive proxy). 0 disables the term.");
             Console.Error.WriteLine("  --marginal-snr-floor    (optional) override ObjectiveConstants.MarginalSnrFloor, the absolute peak-SNR floor in sigma (default 6).");
             Console.Error.WriteLine("  --sensitivity-floor     (optional) floor the SEARCHABLE Sensitivity range (F23 mechanism (b)). <=1.5 is provably inert at shipped defaults.");

--- a/docs/followups.md
+++ b/docs/followups.md
@@ -3453,10 +3453,153 @@ result is the argument against assuming any build-level change helps — the sta
 instruction width, so wider vectors have nothing to recover. Establish the bottleneck by measurement before
 buying or building anything.
 
+### F58 — Concurrent `optimize` processes each acquire a DIFFERENT NINA profile, and the profile decides the fit: F55's "two attractors" are two values of `MaxOutlierRejections`
+**Status:** Open · found 2026-08-08 (wave 11) **at zero compute, out of logs wave 9 left on disk** ·
+**this is the MECHANISM behind [F55](#f55--optimize-is-not-reproducible-when-several-instances-run-at-once-and-the-seed-evaluation-is-what-moves)
+and [F57](#f57--a---settings-pinned-arm-is-not-pinned-the-active-nina-profile-moves-baselinej-by-0014-and-every-cross-wave-comparison-inherits-it),
+which are one defect seen from two directions**
+
+Wave 10 established that the active NINA profile moves `BaselineJ` and left *which quantity* (F57(c)) and *the
+nondeterminism's trigger rate* (F55(b)) open. Both close on the same reading, and **no optimization had to be run
+to find it** — the evidence was already printed in a `Profile:` line that two waves had scrolled past.
+
+### The mechanism, read out of `NINA.Profile`
+
+1. **`Profile.Load(path)`** opens the `.profile` with `FileAccess.ReadWrite, FileShare.Read` and **holds the
+   stream for the profile's lifetime**. A second process's `Load` on the same file throws `IOException`
+   (`ERROR_SHARING_VIOLATION`), and `Load` **rethrows it** — the journal/backup recovery path is deliberately
+   skipped for the in-use case (`catch (IOException ex) when (IsFileInUse(ex)) { throw; }`).
+2. **`ProfileService.SelectProfile`** catches, logs, and returns **`false`**.
+3. **`ProfileService.TryLoad(id)`** orders candidates `OrderByDescending(x => x.LastUsed)` and then
+   `.SkipWhile(p => !SelectProfile(p)).FirstOrDefault()` — **so a locked profile is silently SKIPPED and the next
+   profile by `LastUsed` is loaded instead.**
+4. **`Profile.Load` also sets `LastUsed = DateTime.Now` and SAVES.** Loading a profile rewrites the ordering that
+   decides which profile the *next* unpinned run gets.
+
+**So N concurrent unpinned `optimize` processes acquire N DIFFERENT profiles**, and *which* process gets which is
+a race — the SET is determined (the top N by `LastUsed`), the assignment is not. That is F55's *"sporadic rather
+than per-arm"* exactly.
+
+### The observation, from `D:\hf_w9\det\{S,C}_{1..5}.log` — the 40-second reproducer, re-read
+
+`D16_esprit550_ha3`, `--max-evals 1`, so `BaselineJ` is the whole measurement:
+
+| repeat | `Profile:` printed by the run | `BaselineJ` |
+|---|---|---|
+| S_1 … S_5 (**sequential**) | `AA1600MM Copy (1bf0efaf-…)` — **all five the same** | `0.979173` ×5 |
+| C_1 (**concurrent**) | `AA1600MM (4cf31cda-…)` | **0.988555** |
+| C_2 | `Default (b10b1d6d-…)` | **0.988555** |
+| C_3 | `astrodet (ce3f3e63-…)` | `0.979173` |
+| C_4 | `Default-2026-08-05T10:57:42 (1a120eb1-…)` | **0.988555** |
+| C_5 | `AA1600MM Copy (1bf0efaf-…)` | `0.979173` |
+
+**Five concurrent processes, five different profiles**, and C_5 — which drew the same profile the sequential
+phase drew — returned the sequential phase's value.
+
+### And `J` partitions on ONE field
+
+The optimize path feeds exactly four profile-sourced values into the fit
+(`OptimizationDiagnosticRunner.cs:673–679`: `UseWeights`, `MaxOutlierRejections`, `RejectionConfidence`,
+`PreferredModel`). Across those five profiles three of the four are constant:
+
+| profile | `BaselineJ` | `MaxOutlierRejections` | `OutlierRejectionConfidence` | `WeightedHyperbolicFitEnabled` | `HyperbolicFitModel` |
+|---|---|---|---|---|---|
+| `AA1600MM Copy` | `0.979173` | **0** | *(absent ⇒ 0.95)* | *(absent ⇒ true)* | Hybrid |
+| `astrodet` | `0.979173` | **0** | *(absent ⇒ 0.95)* | true | *(absent ⇒ Hybrid)* |
+| `AA1600MM` | **0.988555** | **1** | *(absent ⇒ 0.95)* | true | *(absent ⇒ Hybrid)* |
+| `Default` | **0.988555** | **1** | **0.99** | true | *(absent ⇒ Hybrid)* |
+| `Default-2026-08-05T10:57:42` | **0.988555** | **1** *(absent ⇒ 1)* | *(absent ⇒ 0.95)* | *(absent ⇒ true)* | *(absent ⇒ Hybrid)* |
+
+> **`MaxOutlierRejections` = 0 ⇒ 0.979173. = 1 ⇒ 0.988555. Five of five.** `OutlierRejectionConfidence` varies
+> *within* the firing group (0.99 vs 0.95) and does not move `J` — which is what a rejection budget of one
+> predicts and a coincidence does not.
+
+**The machine holds 9 profiles and they partition 2 / 7 on this field** (`D:\hf_w11\profiles_before.txt`). *That
+is the bimodality.* Two discrete attractors because a small integer takes two values in the wild — never a
+floating-point race, which is the one property of F55 that never fit summation order.
+
+### Confirmed independently on three more datasets, also at zero compute
+
+Wave 9's **four-way concurrent control trial** (`D:\hf_w9\ctl_conc_*.log`) also printed its profiles:
+
+| log | profile loaded | `MaxOutlierRejections` | `BaselineJ` |
+|---|---|---|---|
+| `ctl_seq_toml999` (**sequential**) | `Default-2026-08-05T10:57:42` | 1 | 0.997840 |
+| `ctl_conc_toml999` | **the same profile** | 1 | **0.997840** |
+| `ctl_conc_bobp` | `astrodet` | 0 | 0.993122 |
+| `ctl_conc_caboose` | `Default` | 1 | 0.994753 → landed **0.996300** |
+| `ctl_conc_mufti` | `AA1600MM Copy` | 0 | **0.957603** |
+
+**Four processes, four different profiles** again. And two of these close open items in F55's own tables:
+`mufti`'s 0.957603 is arms **B/C**'s value (arm A's 0.957087 must therefore have drawn a `= 1` profile), and
+`caboose`'s 0.996300 is one of that run's two recorded landings.
+
+**The sharpest of them is the anomaly F55 had to hedge about.** F55 records *"one four-way concurrent trial did
+NOT reproduce the deviation"* and correctly refuses to read it as evidence against the fan-out, on the grounds
+that *"the effect appears on ~15 % of runs, so a single trial has no power to exclude it."* The hedge was right;
+the reason is now visible in the log rather than left to probability. **`ctl_conc_toml999` drew the same profile
+as `ctl_seq_toml999`**, so it was not a 15 % coin landing the same way — it was the same fit inputs, and the
+values are identical rather than merely close.
+
+### What it explains, and every one of these was paid for by measurement
+
+| eliminated by waves 9–10 | why F58 is consistent with it |
+|---|---|
+| the plugin's `Parallel.For` degree (1/2/4/8/48), swept, inert | this is not a thread race |
+| the BUILD (15 runs, 3 binaries, identical to 10 dp) | those fifteen ran in ONE session under ONE **pinned** profile |
+| folder state, one artifact at a time | irrelevant to which file the process opened at startup |
+| the per-run `optimized_settings.json`, the detection cache, OpenCL/`UMat`, `Merge`, rented sorts, `MedianInPlace`, timeouts | same |
+| **"stable within a process/session, variable across them … does fit some process-level state … acquired once"** | **a profile is acquired once, at startup.** Wave 9 named the shape of the answer and the search kept looking below the fit |
+
+**And it explains F57 without a second cause.** Wave 9's gate ran under `Default` (`MaxOutlierRejections = 1`),
+wave 10's under `astrodet` (`0`); `toml999`'s `BaselineJ` went 0.997840 → 0.983477, and allowing one Grubbs
+rejection improves a fit, which is the observed direction. **F57(c)'s answer is a named field**, and it is
+[F45](#f45--the-grubbs-test-rejects-the-in-focus-point-of-a-near-perfect-curve-and-the-blind-walk-then-buys-an-extra-exposure)'s
+outlier rejection deciding the objective from machine state that nothing recorded.
+
+### Two operational consequences that are not obvious
+
+- **A pinned run rewrites the default for the next unpinned run.** `LastUsed` is stamped by the act of loading,
+  so `--profile-id X` today makes X the active profile tomorrow. **Measured 2026-08-08:** wave 10's own F57 probe
+  pinned `Default` last, and an unpinned `optimize` on `toml999` today prints
+  `Profile: Default (b10b1d6d-…)` and returns `currentJ = 0.99784` — **wave 9's value, not the wave 10 the banks
+  were measured under.** An unpinned wave-11 gate would have reproduced the wrong wave and called it a pass.
+- **`--profile-id` and fan-out are mutually exclusive as things stand.** With the id filter the candidate list has
+  one entry, so a second concurrent process runs `SkipWhile` over an empty remainder, `TryLoad` returns `false`,
+  and `optimize` throws *"No active NINA profile could be loaded"*. **Pinning converts a silent wrong answer into
+  a loud failure**, which is the right trade and is not a fix.
+
+### The fix, and why it is the harness's and not the plugin's
+
+`HarnessSettingsStore` exists precisely so that *"a profile-sourced seed is mutable machine state nothing
+records"* cannot reach a run: its `FileOptionsAccessor` reads the pinned file and falls back to **code defaults**,
+never to the profile. `StarDetectionOptions` is built on it. **`AutoFocusOptions` is not** —
+`new AutoFocusOptions(profileService)` binds a `PluginOptionsAccessor` to the ACTIVE profile. So the detector is
+pinned and the fit is not, and `--settings` has been read as pinning the arm for six waves. **The asymmetry is
+the bug.** The remedy is to build the harness's `AutoFocusOptions` on the harness accessor (the seam already
+exists), carry the four fit inputs in the pinned file, and print them in provenance as **values, not a hash** —
+a hash says something moved, values say **which**. The live plugin is unchanged: the wizard and the AF engine
+must keep reading the profile, because there those *are* the user's settings.
+
+### Next step
+
+(a) **Intervene, do not stop at correlation** — five pre-existing profiles agreeing is not an experiment. Bisect
+`toml999` on synthetic single-field profiles under RULE C, whose **negative control** is that
+`OutlierRejectionConfidence` alone must move nothing when the rejection budget is 0.
+(b) **Pin the fit inputs** as above, then re-run the 40-second reproducer and require that the concurrent phase
+returns ONE value **while still loading five different profiles** — a fix that merely pinned the profile would
+pass a weaker test and prove nothing.
+(c) **Then say what is left.** `KappaSigmaNoiseEstimate`'s measured gain (F55) stays as a fact about the
+function; it is withdrawn only as *this* defect's explanation, and only once the residual check has run.
+Reproduce: `D:\hf_w9\det\{S,C}_{1..5}.log`, `D:\hf_w9\ctl_{seq,conc}_*.log`, `D:\hf_w11\profiles_before.txt`,
+`D:\hf_w11\pregate\pregate.log`.
+
 ### F57 — A `--settings`-pinned arm is NOT pinned: the active NINA profile moves `BaselineJ` by 0.014, and every cross-wave comparison inherits it
 **Status:** Open · found 2026-08-08 (wave 10) while running the pre-registered control for a DIFFERENT
 hypothesis, which it refuted · **this is [F42](#f42--every-build-directory-silently-gets-its-own-detector-settings-and-the-run-instructions-require-a-new-one-per-arm)'s
-warning, measured for the first time**
+warning, measured for the first time** · **(c) ANSWERED 2026-08-08 (wave 11): the quantity is
+`AutoFocusOptions.MaxOutlierRejections`, and the profile is acquired per PROCESS — see
+[F58](#f58--concurrent-optimize-processes-each-acquire-a-different-nina-profile-and-the-profile-decides-the-fit-f55s-two-attractors-are-two-values-of-maxoutlierrejections)**
 
 **How this was found is the point, so it is told in order.**
 
@@ -3517,8 +3660,16 @@ the residue until an unrelated control forced it.**
 `DetectorVersion` this wave added — the same argument, one input further out: a reader diffs a field.
 (b) **Every arm must pass `--profile-id` explicitly**, and the run instructions must say so beside F42's
 `--settings` rule; an arm that does not is pinned in one dimension and floating in another.
-(c) **Find WHICH profile-sourced quantity moves the objective.** `PixelScale` is excluded (both runs print
-`0.73944` from the frame header). `AutoFocusOptions` is read from the profile and is the obvious next place.
+(c) ~~**Find WHICH profile-sourced quantity moves the objective.**~~ — **ANSWERED 2026-08-08 (wave 11):
+`AutoFocusOptions.MaxOutlierRejections`, 1 under `Default` and 0 under `astrodet`, with
+`OutlierRejectionConfidence` (0.99 vs an absent 0.95) behind it and unreachable while the budget is 0. The guess
+recorded here — *"`AutoFocusOptions` … is the obvious next place"* — was right, and the read-level audit that
+confirmed it also excluded everything else: the detector knobs are genuinely pinned (`FileOptionsAccessor` falls
+back to CODE defaults, never the profile, so `SaturationThreshold` 0.99-vs-0.9 and `DetectionBinning` are inert),
+`ImageSettings` is byte-identical between the two profiles, `AutoFocusBinningConflict` only feeds a prompt, and
+the harness infers the step from the frames rather than from `FocuserSettings.AutoFocusStepSize`. **The profile
+is also acquired PER PROCESS, which is the same defect as F55** — see
+[F58](#f58--concurrent-optimize-processes-each-acquire-a-different-nina-profile-and-the-profile-decides-the-fit-f55s-two-attractors-are-two-values-of-maxoutlierrejections).
 (d) **Re-open the wavelet question properly, uncofounded**: run the eight gate runs on `exe_v1wav` against `exe`
 — same tree, same profile, same folders, differing only in the wavelet — at `--max-evals 250`. The seed-level
 answer is already in (identical), so this measures only whether the pattern search amplifies it into landings.
@@ -3526,7 +3677,12 @@ Reproduce: `D:\hf_w10\crossbuild_probe.sh`, `D:\hf_w10\crossbuild.log`, `D:\hf_w
 
 ### F55 — `optimize` is NOT reproducible when several instances run at once, and the SEED evaluation is what moves
 **Status:** Open · found 2026-08-07 (wave 9) when the confirmation arm's own pre-registered control fired ·
-**this voids the wave-9 F32 arm and constrains every future arm's design**
+**this voids the wave-9 F32 arm and constrains every future arm's design** ·
+**MECHANISM IDENTIFIED 2026-08-08 (wave 11): the concurrent processes were running under DIFFERENT NINA
+PROFILES, and the two attractors are two values of `AutoFocusOptions.MaxOutlierRejections` —
+[F58](#f58--concurrent-optimize-processes-each-acquire-a-different-nina-profile-and-the-profile-decides-the-fit-f55s-two-attractors-are-two-values-of-maxoutlierrejections).
+Every measurement in this entry stands; the `KappaSigmaNoiseEstimate` amplifier below is withdrawn as this
+defect's EXPLANATION (its measured gain stays as a fact about the function) pending F58's residual check.**
 
 Wave 9 ran F32's confirmation arm with a **fan-out of 4** — four `optimize --per-run` processes on distinct bank
 folders — to bring ~28 h of sequential compute down to ~7 h. The design pre-registered a free control for exactly
@@ -3681,7 +3837,15 @@ eight are one instrument"*, and it is applied as written: **no φ verdict is pub
 > and it explains the cross-SESSION observation wave 9 could not place. **What remains is only the behaviour
 > under CONCURRENCY**, which none of these controls touch — so this entry is narrower and no less real.
 >
-> ### The specific mechanism, named and half-measured
+> ### The specific mechanism, named and half-measured — ***and it is NOT this defect's mechanism***
+>
+> **Superseded 2026-08-08 (wave 11) by [F58](#f58--concurrent-optimize-processes-each-acquire-a-different-nina-profile-and-the-profile-decides-the-fit-f55s-two-attractors-are-two-values-of-maxoutlierrejections):
+> the concurrent processes were running under different NINA PROFILES, and the two attractors partition exactly
+> on `MaxOutlierRejections`.** Everything below remains TRUE about the function — the gain is measured and a unit
+> test pins it — and it remains a plausible amplifier for some *other* perturbation. It is withdrawn only as the
+> explanation of the runs in this entry. **The trigger RATE this section says is owed was owed for a mechanism
+> that was not firing**, which is why F58's residual check runs even after its own fix passes: a measured gain is
+> not a measured cause, and it is easy to mistake one for the other after paying to measure it.
 >
 > `CvImageUtility.KappaSigmaNoiseEstimate` is a **bimodal amplifier by construction**: an OpenCV parallel
 > reduction (`Cv2.MeanStdDev`) feeds a convergence test at `|Δσ| ≤ 1e-5`, so an arbitrarily small change in σ can
@@ -3729,6 +3893,21 @@ Reproduce: `D:\hf_w9\f32_arms.log`, `D:\hf_w9\score_f32.py`, `D:\hf_w9\ctl_seq_t
 > diffed raw progress lines, which come partly from a wall-clock timer, so it reported divergence on every pair
 > of runs whether or not the search diverged. Asked "what would this do if the thing it checks were completely
 > broken?", the answer was "exactly the same thing".)*
+>
+> ### (c)'s FIRST POSITIVE CONTROL, 2026-08-08 (wave 11) — and it found a real limit
+>
+> Wave 11's probe ran the guard in **both** directions for the first time: five sequential runs (must read
+> `exclusive`) and five concurrent ones (must read `concurrent`). **Both fired**, so the field works. But the
+> concurrent phase returned **four `concurrent` and ONE `exclusive`** — and that is correct behaviour, not a bug:
+> `WaitOne(0)` is won by exactly one of *N* contending processes, so **in any fan-out precisely one landing
+> truthfully reports `exclusive`.**
+>
+> **Therefore `ConcurrencyCheck == "exclusive"` on a SINGLE landing is not evidence that the machine was quiet.**
+> It says *this process won the mutex*. The check must be read **across a whole arm** — one `concurrent`
+> anywhere condemns all of it — and in wave 10's own two-driver contamination the first driver's landings would
+> have read `exclusive` throughout, so an operator sampling that driver's output would have seen a clean bill of
+> health. *An instrument that is right about the wrong scope is a new way to be wrong.* Recorded here rather than
+> "fixed", because the field is honest and it is its INTERPRETATION that needed pinning down.
 >
 > **What ships.** `optimize` claims a named mutex at startup and records `ConcurrencyCheck` —
 > `"exclusive"` / `"concurrent"` / `"unknown"` — into `OptimizerProvenance`, i.e. into **every landing it

--- a/docs/followups.md
+++ b/docs/followups.md
@@ -654,8 +654,11 @@ Reproduce: `D:\hf_w5\f24_arms.sh`, analysed by `D:\hf_w5\analyze_f24.py`.
 ### F19 — The exposure recommendation is decided by the 20 brightest stars, so a rich field can never earn one
 **Status:** **(a) refuted (wave 8) · (b) DONE (wave 8) · (c) RESOLVED "the floor stays", free, no re-render
 (wave 9) · THE REMAINDER IS OPEN AGAIN (wave 10): wave 9's wing verdict was REFUTED by the population check it
-recorded as owed, and is WITHDRAWN.** The gate-floor THEOREM stands; the wing rejected fraction stays as a
-measurement; the successor (the wing-to-inner RATIO) is pre-registered and deliberately not adopted
+recorded as owed, and is WITHDRAWN · AND THE SUCCESSOR IS REFUTED TOO (wave 11), before implementation, by
+RULE W2 on the exposure ladder: `D16` at 2 s has an inner rejected fraction of EXACTLY 0.000, so the ratio is
+INFINITE and fires where more exposure is measurably wrong. NO THRESHOLD SATISFIES RULE W.** The gate-floor
+THEOREM stands; `WingRejectedFraction` AND `WingRejectedRatio` both stay as measurements with no verdict
+attached; `WingRejectedExcess` = wing - inner is named as the next candidate and deliberately not evaluated
 · found 2026-08-02 deriving expected-optimal exposures for the synthetic AF bank
 
 `ExposureRecommender`'s `S_now` is the median, across non-recovery frames, of each frame's
@@ -976,6 +979,57 @@ derived-exposure rung on either dataset, this entry REOPENS.**
 > **So F19's remainder is OPEN again**, and honestly so: this wave did not fix F19, it corrected a wrong fix and
 > left a sharper question with a control that did not exist before.
 > Reproduce: `D:\hf_w10\wing_pop.sh`, `D:\hf_w10\score_wing_pop.py`, `D:\hf_w10\pop_score.txt`.
+
+> ## THE SUCCESSOR IS REFUTED TOO (2026-08-08, wave 11) — BEFORE IMPLEMENTATION, BY RULE W ITSELF
+>
+> `WingRejectedRatio` = wing-third ÷ inner-third was pre-registered with RULE W1–W6. Wave 11 shipped the
+> **measurement** and then applied the rule to size its threshold. **The rule has no satisfying input.**
+>
+> W1–W4 are validated on wave 7's exposure ladder. Wave 7's own aggregates predate `FrameDiagnostics`, but wave 9
+> left a 10-rung probe at `D:\hf_w9\wing2\` that has it, so the ratio was readable at **zero compute** — and was
+> then **re-measured on pinned provenance** (`exe_fix2`, `pinned_settings_w11.json`, `--profile-id astrodet`,
+> `--max-evals 120`, wave 7's frames, no re-render), because `wing2` ran on the v1 binary under an unrecorded
+> profile and that is exactly the provenance [F58](#f58--concurrent-optimize-processes-each-acquire-a-different-nina-profile-and-the-profile-decides-the-fit-f55s-two-attractors-are-two-values-of-maxoutlierrejections)
+> condemns. **All ten rungs reproduced**, across a binary change and a profile change, and the shipped field
+> agreed with an independent offline recomputation on every one.
+>
+> | clause | requirement | measured | implies |
+> |---|---|---|---|
+> | **W1** `D02`@0.5 s must fire | ratio ≥ T | **1.5683** | T ≤ 1.5683 |
+> | **W5** above the bank median | — | 1.39 | T > 1.39 |
+> | **W2** `D16`@2 s must stay SILENT | ratio < T | **+∞** | **T > +∞ — impossible** |
+>
+> **W1 ∧ W5 leave the window (1.39, 1.5683]. W2 empties it.**
+>
+> `D16` at 2 s has an inner rejected fraction of **exactly 0.000** against a wing fraction of **0.0064**, so its
+> ratio is infinite and it fires at every finite threshold. **That rung is where `D16`'s σ_focus is MINIMISED**
+> (0.17117 against 0.35169 / 0.26026 / 0.20421 / 0.19659), so firing there asks the user to make their focus
+> worse — which is the control the whole statistic exists to pass.
+>
+> **The mechanism is worse than the arithmetic.** On a clean, well-exposed narrowband run the core rejects
+> NOTHING, so ANY wing rejection at all becomes an infinite ratio: the ratio form is maximally unstable exactly
+> where the statistic must be silent. **The absolute fraction got this rung RIGHT** (0.0064 ≪ 0.20). On the one
+> control that matters the successor is not merely no better than its predecessor — **it is strictly worse**.
+>
+> **What ships:** `WingRejectedRatio` as a MEASUREMENT ONLY, four-state (`NaN` = could not look / `+∞` = the core
+> rejects nothing and the wings do / `1.0` = both reject nothing, i.e. equal rates / the ratio). Newtonsoft writes
+> the first two as the STRINGS `"NaN"` and `"Infinity"`, pinned by a serialization test — *a scorer that coerces
+> either disables its own falsification rule*, and wave 10's scorer, reused verbatim, would have mapped `+∞` to
+> NaN and hidden exactly the runs this form fails on. **No verdict, no threshold, no action ships.**
+>
+> **The predicted hazard class landed on a different dataset than the two named.** Wave 11's design named `D17`
+> (ratio 0.59) and `D20` (inner exactly 0.000). The killer was `D16`@2 s — the **same shape as `D20`** on a
+> dataset listed under a different clause. *Naming the hazard CLASS in advance worked even though the specific
+> dataset was wrong.*
+>
+> **`WingRejectedExcess` = wing − inner is named as the next candidate and is NOT evaluated anywhere in wave 11.**
+> The ladder is now the data that refuted the ratio, and W6 applies to the ladder exactly as it applied to the
+> 39-run population.
+>
+> **The 39-run population pass was NOT run**, and the trade is recorded rather than left as a silently smaller
+> pass: the refutation came on a NECESSARY clause, so the pass could not have changed the verdict, and W6 bars
+> its rows from sizing the next candidate. **This wave therefore publishes no 39-run distribution for the ratio.**
+> Reproduce: `D:\hf_w11\pop\ladder_w11.sh`, `D:\hf_w11\pop\ladder_score.txt`, `D:\hf_w11\pop\score_wing_pop_w11.py`.
 
 > ## (c) RESOLVED 2026-08-07 (wave 9): THE FLOOR STAYS, THE CEILING STAYS, AND NOTHING RE-RENDERS
 >
@@ -3453,6 +3507,71 @@ result is the argument against assuming any build-level change helps — the sta
 instruction width, so wider vectors have nothing to recover. Establish the bottleneck by measurement before
 buying or building anything.
 
+### F59 — The settings export drops every knob whose setter VALIDATES, so `pinned_settings.json` has been missing five detector knobs since wave 5
+**Status:** **Fixed (wave 11)** · found 2026-08-08 by a unit test written for
+[F58](#f58--concurrent-optimize-processes-each-acquire-a-different-nina-profile-and-the-profile-decides-the-fit-f55s-two-attractors-are-two-values-of-maxoutlierrejections)'s
+fit inputs, which failed on a property nobody was looking at
+
+`HarnessSettingsStore.ExportFromProfile` snapshots the options **through the class's own property surface**, so
+the class emits the right keys with the right types and the snapshot cannot drift from what it reads. To make the
+snapshot DENSE it writes a *poison* value first — a value equal to the shipped default would otherwise never fire
+the change-detecting setter, never reach the file, and leave the file inheriting whatever the default is **at load
+time**.
+
+**The poison was `current + 1`, and these setters THROW.**
+
+```
+MaxDistortion              must be within [0, 1]        0.65  -> poison 1.65 -> ArgumentException
+OutlierRejectionConfidence must be in (0.5, 1.0)        0.95  -> poison 1.95 -> ArgumentException
+```
+
+One `try` wrapped both the poison write and the real write, so the exception was caught by a `catch` whose comment
+says *"a property that refuses a round trip … skip it"* — **and the property was skipped entirely. Neither the
+poison NOR the value was written.** A poison-only failure is not a refusal to round-trip: the real value would
+have been accepted.
+
+**`StarDetectionOptions` has 28 validating setters.** Measured against `D:\hf_w11\pinned_settings.json` — the file
+that is byte-identical across waves 5–11 and that every arm has called "the pinned detector":
+
+| knob | in the pinned file? |
+|---|---|
+| `MaxDistortion`, `StarCenterTolerance`, `SaturationThreshold`, `HotpixelThreshold`, `Sensitivity` | **NO** |
+| `MinHFR`, `StarPeakResponse`, `BrightnessSensitivity`, … | yes |
+
+### What it does and does not invalidate
+
+- **Waves 5–11 are internally valid.** The missing keys resolve to **code defaults**, the same file and the same
+  defaults were used throughout, so every arm ran the same detector as every other arm.
+- **What is false is that the file DESCRIBES the detector.** It does not, for those five knobs — and
+  `ExportFromProfile`'s own docstring promises the bootstrap is *"behaviour-preserving, or the first run after
+  this change would silently differ from the last one before it"*, which for a validated knob it was not.
+- **The hazard is live rather than historical:** change any of those five code defaults and every pre-wave-11
+  pinned file silently starts describing a different detector. That is precisely the drift
+  [F42](#f42--every-build-directory-silently-gets-its-own-detector-settings-and-the-run-instructions-require-a-new-one-per-arm)
+  exists to prevent, defeated inside the mechanism written to prevent it.
+
+### Fixed
+
+Poison candidates are **tried in turn** until one lands inside the property's own valid range (the numeric spread
+runs both directions and through the unit interval), the poison is **verified by read-back** rather than assumed,
+and **the real write has its own `try`** so a poison failure can never cost it again.
+
+**The wave-11 pinned file deliberately does NOT gain the five recovered knobs.** Adding them would change the
+detector and move the coordinate system RULE G11 was just established on; they stay at code defaults, as they
+have been for seven waves, consistently. The fix changes what a FUTURE bootstrap exports.
+
+**How it was found is the point.** The test that failed was written to assert **density** — *"a value equal to the
+code default must still reach the file"* — and not presence. Presence would have passed: the four fit inputs it
+was written for include one (`MaxOutlierRejections = 1`) that IS the code default. *A test written for the
+property you care about finds the bug you were not looking for; a test written for the happy path does not.*
+
+### Next step
+
+None for the export. **But the five knobs are now known to have been at code defaults for waves 5–11**, which is
+worth stating in any write-up that describes `pinned_settings.json` as a full snapshot. Reproduce:
+`Joko.NINA.Plugins.HocusFocus.Tests/Harness/HarnessFitInputsTests.cs`
+(`CopyOptionSurface_CarriesAKnobWhoseSetterTHROWSOnTheObviousPoison`).
+
 ### F58 — Concurrent `optimize` processes each acquire a DIFFERENT NINA profile, and the profile decides the fit: F55's "two attractors" are two values of `MaxOutlierRejections`
 **Status:** Open · found 2026-08-08 (wave 11) **at zero compute, out of logs wave 9 left on disk** ·
 **this is the MECHANISM behind [F55](#f55--optimize-is-not-reproducible-when-several-instances-run-at-once-and-the-seed-evaluation-is-what-moves)
@@ -3591,6 +3710,14 @@ returns ONE value **while still loading five different profiles** — a fix that
 pass a weaker test and prove nothing.
 (c) **Then say what is left.** `KappaSigmaNoiseEstimate`'s measured gain (F55) stays as a fact about the
 function; it is withdrawn only as *this* defect's explanation, and only once the residual check has run.
+(d) **FOUR OTHER HARNESS RUNNERS HAVE THE SAME DEFECT AND ARE NOT FIXED HERE**, flagged rather than swept in
+because each needs its own validation and wave 11's budget went to `optimize`:
+`BankVerifyRunner` (twice — the recall/precision harness whose numbers feed the golden audits),
+`SynthValidateRunner`, `InspectAlignRunner`, `TiltCalibrationRunner`. Every one builds
+`new AutoFocusOptions(profileService)` and therefore takes its fit from whichever profile is ACTIVE. Until they
+are converted, **they must be run with `--profile-id`**, and two of their results measured under different
+profiles are not comparable. *(`HocusFocusPlugin.cs` also constructs it from the profile and is CORRECT — in the
+live app those are the user's settings.)*
 Reproduce: `D:\hf_w9\det\{S,C}_{1..5}.log`, `D:\hf_w9\ctl_{seq,conc}_*.log`, `D:\hf_w11\profiles_before.txt`,
 `D:\hf_w11\pregate\pregate.log`.
 

--- a/docs/synthetic-af-bank-followups-wave11-design.md
+++ b/docs/synthetic-af-bank-followups-wave11-design.md
@@ -1,0 +1,504 @@
+# Synthetic AF bank — followups wave 11 (design)
+
+Plan: [`plans/synthetic-af-bank-followups-wave11-plan.md`](../plans/synthetic-af-bank-followups-wave11-plan.md).
+Wave 10: [`docs/synthetic-af-bank-followups-wave10-results.md`](synthetic-af-bank-followups-wave10-results.md) ·
+[design](synthetic-af-bank-followups-wave10-design.md). Register: [`docs/followups.md`](followups.md).
+
+Wave 10 shipped as [PR #188](https://github.com/ghilios/hocus-focus/pull/188), **merged 2026-08-08** at `a54c48b`,
+which is `develop`'s head. CI was green at 3722/3722 against `develop`'s 3708 (+14, all accounted for).
+
+---
+
+## §0 — What this wave inherits, and the one thing that changed before it started
+
+Wave 10's own headline was that a `--settings`-pinned arm **is not pinned**: the harness loads whichever NINA
+profile is ACTIVE, and that moves `BaselineJ` — one evaluation of a fixed seed on fixed frames, no search — by
+**0.0144** ([F57](followups.md#f57--a---settings-pinned-arm-is-not-pinned-the-active-nina-profile-moves-baselinej-by-0014-and-every-cross-wave-comparison-inherits-it)).
+It left three things owed: F57(c) (*which* profile-sourced quantity), F55(b) (the nondeterminism's trigger rate),
+and F19's pre-registered successor.
+
+**Before this wave ran a single optimization, two of those three collapsed into one answer, at zero compute, out
+of logs wave 9 left on disk.** That is §0.1, and it re-shapes what items 1 and 2 have to do. It does not re-order
+them.
+
+### §0.1 — F55 and F57 are the SAME defect, and it is profile acquisition
+
+**This section is measured, not conjectured**, and every input is on disk or in NINA's source. It does not depend
+on wave 11's gate, because it is internal to one session, one binary and one probe.
+
+**The mechanism, read out of `NINA.Profile`:**
+
+1. `Profile.Load(path)` opens the `.profile` with `FileAccess.ReadWrite, FileShare.Read` and **keeps the stream
+   for the profile's lifetime**. A second process's `Load` on the same file throws `IOException`
+   (`ERROR_SHARING_VIOLATION`), and `Load` **rethrows it** — the journal/backup recovery path is explicitly
+   skipped for the in-use case.
+2. `ProfileService.SelectProfile` catches, logs, and returns **false**.
+3. `ProfileService.TryLoad(id)` builds the candidate list `OrderByDescending(LastUsed)` and then
+   `.SkipWhile(p => !SelectProfile(p)).FirstOrDefault()` — **so a locked profile is silently skipped and the NEXT
+   profile by `LastUsed` is loaded instead.**
+4. `Profile.Load` also sets `LastUsed = DateTime.Now` **and saves**. Loading a profile rewrites the ordering that
+   decides which profile the *next* unpinned run gets.
+
+**The consequence, observed in wave 9's own probe logs** (`D:\hf_w9\det\{S,C}_{1..5}.log`, the 40-second
+reproducer, `D16_esprit550_ha3`, `--max-evals 1` so `BaselineJ` is the whole measurement):
+
+| repeat | `Profile:` line printed by the run | `BaselineJ` |
+|---|---|---|
+| S_1 … S_5 (**sequential**) | `AA1600MM Copy (1bf0efaf-…)` — **all five the same** | `0.979173` ×5 |
+| C_1 (**concurrent**) | `AA1600MM (4cf31cda-…)` | **0.988555** |
+| C_2 | `Default (b10b1d6d-…)` | **0.988555** |
+| C_3 | `astrodet (ce3f3e63-…)` | `0.979173` |
+| C_4 | `Default-2026-08-05T10:57:42 (1a120eb1-…)` | **0.988555** |
+| C_5 | `AA1600MM Copy (1bf0efaf-…)` | `0.979173` |
+
+**Five concurrent processes loaded five DIFFERENT profiles**, exactly as the fall-through predicts, and one of
+them (C_5) got the same profile the sequential phase got and returned the sequential phase's value.
+
+**And J partitions on one field.** The optimize path feeds exactly four profile-sourced values into the fit
+(`OptimizationDiagnosticRunner.cs:673–679`). Across those five profiles, three of the four are constant:
+
+| profile | `BaselineJ` | `MaxOutlierRejections` | `OutlierRejectionConfidence` | `WeightedHyperbolicFitEnabled` | `HyperbolicFitModel` |
+|---|---|---|---|---|---|
+| `AA1600MM Copy` | `0.979173` | **0** | *(absent ⇒ 0.95)* | *(absent ⇒ true)* | Hybrid |
+| `astrodet` | `0.979173` | **0** | *(absent ⇒ 0.95)* | true | *(absent ⇒ Hybrid)* |
+| `AA1600MM` | **0.988555** | **1** | *(absent ⇒ 0.95)* | true | *(absent ⇒ Hybrid)* |
+| `Default` | **0.988555** | **1** | **0.99** | true | *(absent ⇒ Hybrid)* |
+| `Default-2026-08-05T10:57:42` | **0.988555** | **1** *(absent ⇒ 1)* | *(absent ⇒ 0.95)* | *(absent ⇒ true)* | *(absent ⇒ Hybrid)* |
+
+> **`MaxOutlierRejections` = 0 ⇒ 0.979173. `MaxOutlierRejections` = 1 ⇒ 0.988555. Five of five.**
+> `OutlierRejectionConfidence` varies *within* the firing group (0.99 vs 0.95) and does not move J, which is what
+> a rejection budget of one predicts and a coincidence does not.
+
+**What this explains, and the fit is total.** Every elimination waves 9 and 10 paid for is consistent with it and
+none of them could have caught it:
+
+- **the plugin's `Parallel.For` degree (1/2/4/8/48), swept and inert** — because this is not a thread race;
+- **the BUILD (15 runs, 3 binaries, identical to 10 dp)** — because those fifteen ran in ONE session under ONE
+  pinned profile;
+- **folder state, `optimized_settings.json`, the detection cache, OpenCL, `Merge`, rented sorts, timeouts** — all
+  irrelevant to which file the process opened at startup;
+- **wave 9's sharpest unexplained clue** — *"whatever selects the attractor is stable within a process/session
+  and variable across them … it does not fit a per-iteration data race and does fit some process-level state …
+  acquired once"*. **A profile is acquired once, at startup.** The clue named the shape of the answer and the
+  search kept looking below the fit.
+- **the bimodality**, which was the one property that never fit floating-point summation order: the attractors are
+  discrete because `MaxOutlierRejections` is a small integer that takes two values in the wild.
+- **wave 9's fan-out arm** (`D16`: arm A 0.988555, arms B/C 0.979173) — arm A's process got a
+  `MaxOutlierRejections = 1` profile and B/C's got a 0. The arm was voided for the right reason by the wrong
+  mechanism.
+
+**And it explains F57 without a second cause.** Wave 9's gate ran under `Default` (`MaxOutlierRejections = 1`),
+wave 10's under `astrodet` (`0`); `toml999`'s `BaselineJ` went 0.997840 → 0.983477, and allowing one Grubbs
+rejection improves a fit, which is the observed direction. **F57(c)'s answer is a named field**, and it is
+[F45](followups.md#f45--the-grubbs-test-rejects-the-in-focus-point-of-a-near-perfect-curve-and-the-blind-walk-then-buys-an-extra-exposure)'s
+outlier rejection deciding the objective from machine state nothing records. Item 2 still runs — a correlation
+over five profiles is not an intervention — but it now runs as a **confirmation with a negative control**, not as
+a search.
+
+**Two further consequences that are not obvious and that change how arms must be run:**
+
+- **A pinned run rewrites the default for the next unpinned run.** `LastUsed` is stamped by the act of loading,
+  so `--profile-id X` today makes X the active profile tomorrow. Wave 10's own F57 probe pinned `Default` last,
+  so **an unpinned run today should load `Default`, not the `astrodet` the wave measured under.** That is a free,
+  decisive check of this whole model and §1.2 runs it before the gate.
+- **`--profile-id` and fan-out are mutually exclusive as things stand.** With the id filter the candidate list has
+  one entry, so the second concurrent process gets `SkipWhile` over an empty remainder, `TryLoad` returns false,
+  and `optimize` throws *"No active NINA profile could be loaded"*. **Pinning turns a silent wrong answer into a
+  loud failure**, which is the right trade and not a fix. The fix is §2.3.
+
+**Filed as [F58](followups.md), cross-linked from F55 and F57.** F55's entry keeps its measurements and loses its
+named mechanism; the `KappaSigmaNoiseEstimate` amplifier is **not withdrawn as a fact** — wave 10 measured its
+gain and a unit test pins it — but it is withdrawn as *this* defect's explanation, and §2.4 is the residual check
+that says whether anything is left for it to explain.
+
+---
+
+## §1 — The gate: RULE G11, and the profile is pinned and NAMED in the script header
+
+### §1.1 Why the gate is not optional and not a formality
+
+Wave 5's φ table is invalid on **two** axes now — `StarDetectorVersion` (1 → 2) and the active profile — and this
+document does not quote it. Wave 11's coordinate system is **wave 10's eight values**, and they are only readable
+if they reproduce on a fresh binary under the profile they were measured on.
+
+The gate runs `D:\hf_w11\gate_repro_w11.sh`: wave 10's invocation, on a **fresh** `D:\hf_w11\exe`, sequentially,
+`--per-run --max-evals 250`, `--settings D:\hf_w11\pinned_settings.json` (a byte-copy of the file that is
+identical across waves 5–10, `md5 df7c7cd1…`, [F42](followups.md#f42--every-build-directory-silently-gets-its-own-detector-settings-and-the-run-instructions-require-a-new-one-per-arm)),
+**and `--profile-id ce3f3e63-8fd3-4b72-a0ca-d90db9441382` (`astrodet`), stated in the script header as a first-class
+input beside the settings file** — which is F57(b), applied to this wave's own first action.
+
+### §1.2 The pre-gate probe, which tests the §0.1 model for 40 seconds
+
+Run once, **before** the gate, on a scratch copy: `optimize --per-run --max-evals 1` with **no** `--profile-id`.
+
+> **Prediction, fixed here: it prints `Profile: Default (b10b1d6d-…)`.**
+>
+> `LastUsed` ordering currently puts `Default` (2026-08-08T12:54:20-04:00) ahead of `astrodet`
+> (2026-08-08T09:59:35-04:00), because wave 10's F57 probe loaded `Default` last.
+>
+> **If it prints anything else, §0.1's model of profile selection is wrong**, F58 must be re-derived before it is
+> filed, and items 1 and 2 revert to wave 10's framing. This is the clause that can kill the wave's headline
+> cheaply, and it runs first for that reason.
+
+### §1.3 RULE G11 — ONE pass/fail clause, fixed before the gate runs
+
+> **RULE G11 (pass/fail).** All eight runs must return wave 10's `BestJ` **to 6 dp**:
+>
+> | `toml999` | `CWhiteFocus` | `uneven` | `muggsie` | `mccomiskey` | `D18` | `D19` | `D20` |
+> |---|---|---|---|---|---|---|---|
+> | 0.995784 | 0.996068 | 0.996368 | 0.997195 | 0.976746 | 0.999882 | 0.999487 | 0.999738 |
+>
+> **A partial reproduction is a failure, not a warning — the eight are one instrument** (RULE G as originally
+> written). **If it fires, STOP.** Wave 11 has no coordinate system and nothing downstream is readable.
+
+Everything else the gate produces is a **measurement**, recorded and reported, never a gate:
+
+| free control | expectation | what a violation means |
+|---|---|---|
+| `Profile:` / landing `ProfileId` | `astrodet (ce3f3e63-…)` on all eight | the pin did not take; every value is void |
+| `ConcurrencyCheck` | `exclusive` on all eight | F55(c): something else was running; the pass is void |
+| `DetectorVersion` | 2 | wrong binary |
+| `BuildId` | **must DIFFER from wave 10's** | an MVID that matches means the build did not happen and this is wave 10's exe |
+| `strings exe/NINA.Joko.Plugins.HocusFocus.dll \| grep AtrousWaveletFast` | **hit** | a v1 build, retroactively (wave 10's instrument) |
+| `BaselineJ` for `toml999` | 0.983477 (wave 10 §1.1, under `astrodet`) | [F41](followups.md#f41--a-prior-waves-control-arm-is-not-a-control-for-a-later-waves-binary)'s free control |
+
+**`BaselineJ` agreeing is not automatically good news.** If every `BaselineJ` reproduces while landings move, the
+difference is in the search and not in the seed, which is [F8](followups.md#f8--optimizer-landings-are-not-reproducible-across-invocations)
+and must be said rather than absorbed. *A number that agrees too well is also an instrument failure.*
+
+**`uneven` emits no `Optimization complete` console line** (wave 10 §1.4). The scorer reads
+`aggregate_summary.json`; **any script that greps the console line reports a failure on a successful run.**
+
+---
+
+## §2 — Item 1: F55(b), and it is now confirm → fix → re-measure
+
+### §2.1 What is owed, restated after §0.1
+
+Wave 10 owed a **trigger rate** for a mechanism it had named and half-measured. §0.1 supplies a different
+mechanism with a complete partition over five observations, so what is owed changes shape:
+
+1. **Confirm by intervention**, not only by correlation over profiles that already existed.
+2. **Fix it**, so that a pinned arm is genuinely pinned and fan-out becomes safe.
+3. **Re-measure the phenomenon with the fix in place** — the strongest available evidence is a fix that removes
+   it — and run the **residual** check that says whether anything is left over for the kappa-sigma amplifier or
+   anything else to explain.
+
+### §2.2 RULE K — fixed before the probe runs
+
+The probe is `D:\hf_w11\det\determinism_probe_w11.sh`: wave 9's 40-second reproducer (`D16_esprit550_ha3`,
+`--max-evals 1`, 5 sequential then 5 concurrent, each repeat on its own pristine copy, **the banks are never
+touched**) on the wave-11 binary, with each repeat's printed `Profile:` line and landing `ProfileId` captured.
+
+> **K1 — the mechanism reproduces.** In phase C, the number of DISTINCT `BaselineJ` values must equal the number
+> of distinct `MaxOutlierRejections` values across the profiles the five processes actually loaded, and repeats
+> sharing a profile must share a value **to full double precision**. Anything else means the partition is not the
+> whole story.
+>
+> **K2 — phase S is single-profile and single-valued.** All five sequential repeats must load one profile and
+> return one value. If phase S splits, a second mechanism exists and F55 is not closed by F58.
+>
+> **K3 — pinning fails loudly under fan-out.** Phase C repeated with `--profile-id` must produce exactly one
+> success and four hard failures (`No active NINA profile could be loaded`, non-zero exit). If a pinned
+> concurrent process *succeeds* on a profile it was not given, §0.1's reading of `TryLoad` is wrong.
+>
+> **K4 — `ConcurrencyCheck` is exercised in both directions.** Phase S landings must stamp `exclusive`; phase C
+> landings must stamp `concurrent`. This is wave 10's shipped guard meeting its **positive control** for the
+> first time. If phase C stamps `exclusive`, the guard does not work and that is a finding of its own — *an
+> absent check is more dangerous than a red one.*
+>
+> **K5 — THE FIX REMOVES IT.** With §2.3 in place and the fit inputs pinned by `--settings`, phase C must return
+> **one** `BaselineJ`, identical to phase S to full double precision, **while still loading five different
+> profiles** (the `Profile:` lines must still differ — otherwise the test has merely stopped exercising the
+> hazard). **K5 is the clause this item is judged on.**
+>
+> **K6 — the residual.** If K5 fails and phase C still splits with the fit inputs pinned, then something below the
+> fit is still moving, and §2.4's σ instrument runs to say whether it is `KappaSigmaNoiseEstimate`. If K5 passes,
+> §2.4 runs **anyway, once**, as the check that the fix did not merely mask a second mechanism.
+>
+> **K7 — cross-profile identity, and it is the crispest statement of "pinned".** On the fixed binary with the
+> extended settings file, `toml999` at `--max-evals 1` under `--profile-id astrodet` and under `--profile-id
+> Default` must return **identical `BaselineJ` to full double precision**. Before the fix these differ by
+> **0.0144**. Two runs, ~1 minute.
+>
+> **K8 — the coordinate system survives its own fix.** The eight gate runs, on the fixed binary with the extended
+> file, must return RULE G11's eight values. Otherwise every future wave inherits an unverified discontinuity at
+> the exact commit that claimed to remove one. **It costs nothing**: §4's population pass is the shipped-default
+> invocation over both banks and the eight are among its 39, exactly as wave 10's pass was RULE G10-A at 8-fold
+> redundancy.
+
+**K5 is designed so that it can fail.** A fix that pinned the profile itself — one profile, one answer — would
+pass a weaker version of this clause while proving nothing about the fit inputs. Requiring the five processes to
+**still load five different profiles and still agree** is what makes the clause discriminating.
+
+### §2.3 The fix: pin the fit inputs the same way the detector knobs are pinned
+
+**The asymmetry is the bug.** `HarnessSettingsStore` exists precisely so that "a profile-sourced seed is mutable
+machine state nothing records" cannot reach a run — its `FileOptionsAccessor` reads the pinned file and falls
+back to **code defaults**, never to the profile. `StarDetectionOptions` is built on it. **`AutoFocusOptions` is
+not**: `new AutoFocusOptions(profileService)` constructs a `PluginOptionsAccessor` bound to the ACTIVE PROFILE.
+So the detector is pinned and the fit is not, and `--settings` has been read as pinning the arm for six waves.
+
+The seam already exists — `AutoFocusOptions` has an `internal AutoFocusOptions(IProfileService, IPluginOptionsAccessor)`
+constructor, and TestApp already uses the equivalent one on `StarDetectionOptions`. The change is:
+
+1. Build the harness's `AutoFocusOptions` on `harnessSettings.Accessor` instead of the profile.
+2. Carry the four fit inputs in the harness settings file, exported from the profile on bootstrap exactly as the
+   detector knobs are, so an existing pinned file keeps behaving as its own code defaults describe **and says so**.
+3. Record them in provenance as **values, not a hash**: `ProfileInputs =
+   "MaxOutlierRejections=1;OutlierRejectionConfidence=0.99;WeightedHyperbolicFitEnabled=True;HyperbolicFitModel=Hybrid"`.
+   A hash tells a reader that something moved; the values tell them **which** — and this register's whole
+   direction of travel is *a reader diffs a field* (`BuildId` over a version string, `DetectionBinningSource` over
+   a sentence, `ConcurrencyCheck` over a rule).
+
+**What this deliberately does NOT do.** It does not change the live plugin's behaviour: the wizard and the AF
+engine keep reading `AutoFocusOptions` from the profile, which is correct — those *are* the user's settings. It
+changes what the **harness** treats as pinned. And it does not remove the profile from the run: the image loader
+still needs one (§3.1), so `--profile-id` remains mandatory on every arm.
+
+**The pinned file's own hazard is inherited and must be checked.** `UseAdvanced = False` in
+`pinned_settings.json` means `DerivePresetSettings()` overwrites ~16 advanced knobs from the `Simple_*` presets
+(F42(3)); the store already warns and names them. The four new keys are **not** in that override set, and a test
+must assert it rather than a comment claiming it.
+
+### §2.4 The residual instrument, and why it is not the primary one
+
+`CvImageUtility.KappaSigmaNoiseEstimate` already returns `NumIterations`, and `StarDetector` already emits
+`Structure Map K-Sigma Noise Estimate: <σ>, Background Mean: <μ>, NumIterations=<n>` per detection at TRACE.
+`optimize --verbose` already sets TRACE. **The instrument exists; nothing needs to be written.**
+
+Two limits, stated because they bound what may be claimed:
+
+- **The trace line carries no frame identifier**, and frames are detected in parallel, so a run yields a
+  **multiset** of (σ, iterations), not a per-frame series. Multiset difference is enough for the question asked —
+  *does σ move between two runs of identical inputs, and does the iteration count move with it* — and the count of
+  differing entries is a per-detection rate. It is not enough to say *which frame*, and the write-up must not.
+- **`--verbose` is documented as "slower: serializes per-detection stage timings to the NINA log"** — a timing
+  perturbation, aimed at a load-sensitive phenomenon. So it carries its own control: **phase C must still split
+  with `--verbose` on** (compared against a `--verbose`-off phase C in the same session). If it does not, the
+  instrument destroys what it measures, and that is reported as the result rather than worked around.
+
+**Readings, fixed in advance:**
+
+- σ multiset **identical** across two runs that differ in landing ⇒ **`KappaSigmaNoiseEstimate` is exonerated**,
+  and F55's named mechanism is withdrawn as an explanation (its measured gain stays as a fact about the function).
+- σ differs **and** `NumIterations` differs ⇒ a **direct observation** of the named mechanism, not an inference.
+- σ differs and `NumIterations` is **identical** ⇒ the flip is inside `Cv2.MeanStdDev` itself, which is a
+  *different* mechanism from the one F55 names, and the entry must be rewritten to say so.
+
+**`--cv-threads <n>` (new, harness only)** calls `Cv2.SetNumThreads(n)` and `optimize` prints
+`Cv2.GetNumThreads()` in its provenance line. This replaces wave 9's `HF_STAREVAL_PAR` environment-variable route,
+which silently measured the same configuration five times because **WSL environment variables do not reach a
+Windows process without `WSLENV`** — *an instrument that is not connected reports perfect agreement*. A flag
+cannot be disconnected by a missing `WSLENV`, and the printed `GetNumThreads()` is its positive control. It runs
+only if σ is shown to move.
+
+### §2.5 Explicitly not re-run
+
+Every candidate waves 9 and 10 eliminated by measurement: the plugin's `Parallel.For` degree (1/2/4/8/48), the
+per-run `optimized_settings.json`, the disk detection cache, OpenCL/`UMat` (none exists), the frame-level fan-out,
+`StarDetectorMetrics.Merge`, rented-array sorts, `MedianInPlace`, load-sensitive timeouts, the build (15 runs, 3
+binaries), folder state one artifact at a time, and `MedianFloat`'s `Random.Shared` quickselect (F55-shaped and
+provably inert — rank *n* is rank *n*, and `Mat.GetArray` returns a copy).
+
+---
+
+## §3 — Item 2: F57(c), which profile-sourced quantity moves `J`
+
+### §3.1 The read-level audit, done first because it is free
+
+| profile-sourced input | reaches the objective? | status |
+|---|---|---|
+| **`AutoFocusOptions`** → `UseWeights`, `MaxOutlierRejections`, `RejectionConfidence`, `PreferredModel` | **YES** — `OptimizationDiagnosticRunner.cs:673–679` | **the only unpinned options surface**; 2 of the 4 differ between the two profiles |
+| detector knobs via `StarDetectionOptions` | no | `FileOptionsAccessor` falls back to **code defaults**, never the profile — so `SaturationThreshold` (0.99 vs 0.9) and `DetectionBinning` (`Bin1` vs absent) are inert |
+| `PixelScale` | no | resolved per run from the frame header; both runs printed `0.73944` |
+| image loading (`RenderedImageLoading.ForDetection`) | conditionally | **`ImageSettings` is byte-identical between the two profiles**, and `toml999` is mono, so the debayer decision is inert twice over |
+| `AutoFocusBinningConflict.Detect` | no | reports a conflict for a user prompt; does not resolve binning |
+| `FocuserSettings.AutoFocusStepSize` (479 vs 188) | no | the harness infers the step from the frames' focuser positions |
+
+**Two fields survive**, and one of them makes the other unreachable:
+
+| field | `Default` | `astrodet` |
+|---|---|---|
+| `MaxOutlierRejections` | **1** | **0** |
+| `OutlierRejectionConfidence` | **0.99** | *(absent ⇒ 0.95)* |
+
+### §3.2 RULE C — the bisect, with the clause that can break it
+
+`toml999`, `--max-evals 1`, on **copies** (F15: `optimize --per-run` rewrites the run folder, so the bank is not
+the test bed). The bisect uses **synthetic profiles**: a copy of `astrodet` with a fresh GUID and Name and one
+field changed, dropped into the profile folder — `TryLoad` enumerates `*.profile` and selects by Id, so the
+user's two real profiles are **never edited**. Both reference points are re-measured in this session; wave 10's
+0.983477 / 0.997840 are not quoted into the arithmetic.
+
+> **C0 — the reference points hold.** `astrodet ⇒ J_astro`, `Default ⇒ J_def`, measured today. If either differs
+> from wave 10's value, the bisect is void before it starts and *that* is the finding.
+>
+> **C1 — both fields together account for all of it.** `astrodet` + `MaxOutlierRejections=1` +
+> `OutlierRejectionConfidence=0.99` must equal `J_def` **to full double precision**. A residue means an
+> unenumerated profile read exists; report the residue, do not explain it away.
+>
+> **C2 — the single-field attribution.** `astrodet` + `MaxOutlierRejections=1` alone: equal to `J_def` ⇒
+> `MaxOutlierRejections` is the whole cause and the confidence is inert. Moves but short of `J_def` ⇒ both are
+> load-bearing, and C1 says by how much.
+>
+> **C3 — THE NEGATIVE CONTROL.** `astrodet` + `OutlierRejectionConfidence=0.99` alone **must return exactly
+> `J_astro`**, because a rejection budget of zero makes the confidence unreachable. **Any movement here means the
+> harness is not doing what it claims** — the synthetic profile is not being loaded, or the edit did not take, or
+> something else moved between runs — and **C1 and C2 must be discarded.** This is the clause that makes the
+> bisect an instrument rather than a demonstration.
+>
+> **C4 — connectedness.** Every bisect run must print its synthetic profile's own name and id in `Profile:` and
+> stamp it into the landing's `ProfileId`. A run that silently fell back to the active profile would otherwise
+> read as *"the field did nothing"* — which is wave 10's RULE-P-scorer failure in a new place.
+
+### §3.3 What ships from item 2
+
+- **(a)** already shipped in wave 10 (`ProfileId` in `OptimizerProvenance`).
+- **(b)** the run-instruction change: **every arm passes `--profile-id` explicitly**, beside F42's `--settings`
+  rule, recorded in `.claude/docs/testapp-cli.md` so it is not only in a wave document. §0.1 sharpens *why*: the
+  default is LRU-by-last-load, so an unpinned arm is seeded by **whatever the previous arm pinned**.
+- **(c)** answered: `MaxOutlierRejections`, with `OutlierRejectionConfidence` behind it — subject to RULE C.
+- **(d)** the standing instrument: `ProfileInputs` in provenance (§2.3), so the next wave diffs a field instead of
+  repeating §3.1.
+
+---
+
+## §4 — Item 3: F19's successor, and it is expected to be refuted
+
+### §4.1 The rule is already fixed and is NOT renegotiated here
+
+`WingRejectedRatio` = wing-third ÷ inner-third. Wave 10 fixed its acceptance rule **while the pass that refuted
+its predecessor was still running**, and this document restates it verbatim rather than improving it:
+
+- **W1–W4 unchanged** (wave 9's ladder, `D:\hf_w7\armE\t{0.5,1,2,4,8}`, still on disk, **no re-render**):
+  `D02`@0.5 s ≥ 2× · `D16`@2 s < 1.25× · converges · `D16`@0.5 s asks.
+- **W5** — its threshold must sit **above** the bank's median wing/inner ratio (**1.39** over 39 runs), or it is
+  the same defect in a new coordinate.
+- **W6** — it may **not** be validated on the population that refuted its predecessor; it needs its own arm.
+
+**The verdict rule is RULE P, unchanged** — the population rule wave 10 already wrote and already applied. No new
+pass/fail clause is invented for the successor, because inventing one after seeing wave 10's data is the exact
+move W6 exists to prevent. P2 (*fires on > 50 % of the 39 runs ⇒ it is a constant, not a diagnosis*) is what
+killed the predecessor and is what the successor must survive.
+
+### §4.2 How W6 is honoured, and where the honouring is imperfect
+
+The threshold is **chosen and written into the script header before the population pass runs**, from W1–W4 on the
+ladder and W5's floor. The 39-run pass is then the **test set**: it supplies the fire rate, which is the clause
+that decides.
+
+**The imperfection, stated rather than smoothed over:** W5's floor (1.39) is itself a statistic *of* that
+population. So the threshold is partly derived from the data it is tested on. What the population is not allowed
+to do — and does not do — is supply the threshold's *value*; it supplies a lower bound published in wave 10,
+before wave 11 existed. The fire rate remains an honest test. **This is weaker than a fresh population, and the
+results document must say so in those words.**
+
+### §4.3 The two known hazards, named before the pass
+
+Neither is a new clause. Both are pre-stated expectations, so that meeting them cannot be presented as a surprise
+or as a success:
+
+- **`D17_cdk14_oiii5` fires at a ratio of 0.59** — its wings reject *less* than its core (0.297 vs 0.507) — and
+  `D17` is one of P1's two pre-registered fires. **A ratio ≥ threshold cannot fire on a ratio of 0.59.** So the
+  ratio form is expected to *lose* a dataset the absolute form got right, by a route that was already wrong.
+- **`D20_m24_bright_control` has an inner fraction of exactly 0.000**, so its ratio is not finite. A statistic
+  that asks the bank's **bright control** for more exposure is wrong on the one dataset whose name says it needs
+  none.
+
+**The NaN contract is inherited and extended, because two different things divide by zero:**
+
+| case | value | meaning |
+|---|---|---|
+| the run cannot be placed on the wing axis | **NaN** | *"we could not look"* — never 0, wave 9's rule |
+| the inner third is populated and rejects **nothing**, wings do | **+∞** | *"the wings reject and the cores do not"* — the strongest real signal |
+
+`Newtonsoft` writes both as the **strings** `"NaN"` and `"Infinity"`. **A scorer that coerces either to a number
+disables its own falsification rule** — wave 10's scorer read an unmeasured dataset as *"did not fire"* and
+reported a partial run as a population verdict. The wave-11 scorer must have `UNEVALUATED`, `NaN`, `+∞` and a
+number as four distinguishable states, and must be shown a positive control for each.
+
+### §4.4 The successor-of-the-successor, named now and barred from this data
+
+If the ratio is refuted, the next candidate is **`WingRejectedExcess` = wing − inner**: bounded in [−1, 1],
+defined when the inner third rejects nothing, and unable to fire when wings and cores reject at the same rate —
+which is the failure the ratio inherits from `D17` and the absolute fraction. **It is named here so that it
+cannot be adopted on the data that refutes the ratio**, and its rule when the time comes is W1–W4 plus a
+separating clause against the excess's own bank median. *A statistic tuned on the data that killed the last one
+has been fitted, not tested* — the third time this register has had to write that sentence.
+
+### §4.5 The pass's operating constraints
+
+- **F15 is UNFIXED**: `optimize --per-run` still rewrites run folders and there is no suppress flag, so the
+  population pass **runs last and alone**. Nothing else may be in flight.
+- The concurrency guard in `D:\hf_w10\wing_pop.sh` is **validated** (against a deliberately-started `optimize`)
+  and is reused rather than rewritten. `ConcurrencyCheck` is checked in every landing afterwards regardless —
+  *a rule that depends on the operator noticing a violation is not a control, it is a hope.*
+- `lumos` exits rc=3 reproducibly and reports `WingRejectedFraction` NaN; `astrodet` (the dataset) is frameless
+  (F14) and excluded; `Panos` has a degenerate sigma fit. All three are **named in the score sheet as excluded or
+  NaN**, never silently dropped.
+- The banks currently hold **wave 10's shipped-default landing, measured under profile `astrodet` on
+  `StarDetectorVersion` 2**. Any arm read against them states both.
+
+---
+
+## §5 — Deferred, with reasons
+
+- **The landing-level wavelet bisect** (`exe_v1wav`, built in wave 10 and unused). The **seed-level answer is
+  already in and is exact** — 15 runs, identical to 10 dp — so the eight-run bisect measures only whether the
+  pattern search amplifies an identical seed into different landings. That is
+  [F8](followups.md#f8--optimizer-landings-are-not-reproducible-across-invocations), not a new question, and it
+  costs ~80 minutes. The invocation stays written down in F57(d).
+- **F52(d)** (a cost term in `J`): the motivation is measurably gone — PR #187 made per-layer wavelet cost nearly
+  flat, so a cost term now would penalise an artifact.
+- **F46(b), F54, F50**: nothing depends on them.
+
+---
+
+## §6 — Traps this wave carries
+
+- **`D:\hf_w10\exe` was never rebuilt** (F53(c)) and is the reference for wave 10's eight values. `exe3` and
+  `exe_v1wav` are later builds. **Never rebuild an arm's directory mid-wave** — wave 11 builds to `D:\hf_w11\exe`
+  and leaves it alone.
+- **`strings <dll> | grep AtrousWaveletFast`** distinguishes a v1 from a v2 build **retroactively**. Use it on any
+  `D:\hf_w*\exe` before trusting a `Reproduce:` line.
+- **The console `Optimization complete` line is not reliably emitted** (`uneven` has none). `aggregate_summary.json`
+  is the instrument.
+- **`optimize --per-run` rewrites run folders** (F15). Probes use copies; the population pass runs alone.
+- **The csproj PostBuild xcopy fails SILENTLY when NINA is running**, so **wave 8's and wave 9's AF/wizard changes
+  and wave 10's capped-step copy are STILL UNCONFIRMED IN THE APP.** Not this wave's item, but not to be claimed
+  as confirmed either.
+- **CI: verify the test COUNT, not the tick** (F37). `develop` is at **3722**. An absent check is more dangerous
+  than a red one.
+- **WSL environment variables do not reach a Windows process without `WSLENV`.** This wave uses flags instead.
+
+---
+
+## §7 — Order of work, and the discipline it is run under
+
+1. Pre-gate probe (§1.2) — 40 s, and it can kill the wave's headline.
+2. Build `D:\hf_w11\exe`; gate (§1.3) — RULE G11, the only pass/fail clause in the wave.
+3. Item 1 (§2) — confirm (K1–K4), fix (§2.3), re-measure (K5), residual (K6/§2.4).
+4. Item 2 (§3) — RULE C, including C3.
+5. Item 3 (§4) — threshold fixed in the header, then the population pass, alone and last.
+6. Full suite, results document, F58 filed, PR.
+
+**Every clause above was written before its measurement.** The rules this wave is run under, each of which has
+already cost this project real time:
+
+- **Design the control to EXCLUDE, not to confirm.** Wave 10's gate came back at its pre-registered top tier and
+  the finding was still wrong; a three-way probe built to exclude killed it. §1.2, K5 and C3 are this wave's
+  versions.
+- **Ask every instrument what it would say if the thing it checks were completely broken, and validate it against
+  a positive control.** K4 is `ConcurrencyCheck`'s first positive control; C4 is the bisect's; `--cv-threads`
+  prints `GetNumThreads()` for the same reason.
+- **A rule that depends on the operator noticing a violation is not a control, it is a hope.** Check
+  `ConcurrencyCheck` in the landing before reading any arm.
+- **Check whether a cheap instrument already exists, including one a previous wave left on disk.** §0.1 is the
+  whole wave's headline and it came out of `D:\hf_w9\det\C_*.log`, at zero compute, from a `Profile:` line that
+  had been printed and ignored for two waves.
+- **The population that did not motivate the hypothesis is the one that tests it**, and three two-dataset
+  conclusions have now reversed at full scale.
+- **Name the successor before you need it and bar it from the data that killed its predecessor** (§4.4).
+- **Pin `--settings` AND `--profile-id` on every arm.** `BaselineJ` is a free control; a number agreeing too well
+  is also an instrument failure.

--- a/docs/synthetic-af-bank-followups-wave11-results.md
+++ b/docs/synthetic-af-bank-followups-wave11-results.md
@@ -7,22 +7,32 @@ Register: [`docs/followups.md`](followups.md).
 
 > ## PROVENANCE — and this is the last wave that needs to say most of it in prose
 >
-> Every measurement below was produced by **`D:\hf_w11\exe`** (pre-fix) or **`D:\hf_w11\exe_fixed`**, both built
-> from `a54c48b` (PR #188's merge commit, `develop`'s head), **`StarDetectorVersion` 2**, **under the NINA profile
-> `astrodet (ce3f3e63-8fd3-4b72-a0ca-d90db9441382)`, PINNED WITH `--profile-id` ON EVERY INVOCATION.**
+> Every measurement below came from one of three binaries, all built from `a54c48b` (PR #188's merge commit,
+> `develop`'s head) plus this branch, all **`StarDetectorVersion` 2**, and — except where a probe deliberately
+> runs unpinned — all **under `astrodet (ce3f3e63-8fd3-4b72-a0ca-d90db9441382)`, PINNED WITH `--profile-id`.**
 >
-> | | |
-> |---|---|
-> | `exe` (pre-fix) | `TestApp.dll` sha256 `71ce1cd8…`, `HocusFocus.dll` sha256 `0aca4c20…`, `BuildId 40f08e36…` |
-> | `--settings` | `D:\hf_w11\pinned_settings.json`, md5 `df7c7cd1…` — byte-identical to waves 5–10 (F42) |
-> | `--settings` (post-fix) | `D:\hf_w11\pinned_settings_w11.json`, md5 `a67ffc06…` — the same **plus** the four fit inputs |
+> | directory | what it is | `TestApp.dll` sha256 | `BuildId` | used for |
+> |---|---|---|---|---|
+> | `exe` | **pre-fix** | `71ce1cd8…` | `40f08e36…` | the gate (§2), the probe's phases S/C/P (§3.1), the bisect (§4) |
+> | `exe_fixed` | first post-fix build | `b0a81968…` | `5cb7e474…` | superseded by `exe_fix2` when F59 landed |
+> | `exe_fix2` | **post-fix (F58 + F59)** | `857c5982…` | `5cb7e474…` | K5/K7 (§3.3), the ladder (§5.2), K8 (§6.1) |
+>
+> | settings file | md5 | contents |
+> |---|---|---|
+> | `pinned_settings.json` | `df7c7cd1…` | byte-identical to waves 5–10 (F42) |
+> | `pinned_settings_w11.json` | `a67ffc06…` | the same **plus** the four fit inputs at `astrodet`'s effective values |
 >
 > **`--profile-id` is in this banner because of what the wave found**, and it is not hygiene: measured before the
 > gate ran, an **unpinned** `optimize` on this machine today loads `Default` and returns `toml999`
 > `currentJ = 0.99784` — **wave 9's value, not the wave 10 the banks were measured under**. An unpinned wave-11
 > gate would have reproduced the wrong wave and called it a pass.
 >
-> `exe` and `exe_fixed` are each built once and never rebuilt (F53(c)).
+> **No directory was ever rebuilt** (F53(c)). `exe_fix2` exists precisely *because* F59 landed after `exe_fixed`
+> was built — a new directory rather than a rebuilt one — and K5/K7 were re-run on it and reproduced exactly.
+>
+> **This banner is now largely redundant, which is the point.** `BuildId`, `DetectorVersion`, `ProfileId`,
+> `ConcurrencyCheck` and — new this wave — `FitInputs` are all **fields on every landing**. A reader diffs a
+> field; nobody diffs a banner.
 
 ## Status of this document
 
@@ -30,10 +40,12 @@ Register: [`docs/followups.md`](followups.md).
 |---|---|
 | **F58** — new, and it is the wave's headline | **F55 and F57 are ONE defect: concurrent `optimize` processes each acquire a DIFFERENT NINA profile, and the two "attractors" are two values of `MaxOutlierRejections`.** Found at **zero compute**, out of logs wave 9 left on disk. See §1 |
 | **RULE G11** — the gate, the wave's only pass/fail clause | **PASS, 8 of 8 to 6 dp**, and all eight `BaselineJ` reproduce wave 10 exactly. See §2 |
-| **item 1** — F55(b) | *(pending — §3)* |
-| **item 2** — F57(c) | *(pending — §4)* |
-| **item 3** — F19's successor | **RULE W2 has no satisfying threshold on wave 9's on-disk ladder**; the pinned re-measurement is *(pending — §5)* |
-| **the full suite** | *(pending — §6)* |
+| **item 1** — F55(b) | **K1–K5, K7, K8 ALL PASS.** The mechanism is confirmed by intervention, fixed, and the fix removes the phenomenon while the hazard stays present. `KappaSigmaNoiseEstimate` is WITHDRAWN as the explanation. See §3 |
+| **item 2** — F57(c) | **ANSWERED: `AutoFocusOptions.MaxOutlierRejections`, one integer, 100 % of the 0.0144, residue exactly `0.0`** — with the negative control passing. See §4 |
+| **item 3** — F19's successor | **REFUTED BEFORE IMPLEMENTATION.** RULE W2 is unsatisfiable at any finite threshold; the pinned ladder reproduced all ten rungs. The MEASUREMENT ships, no verdict does. See §5 |
+| **F59** — new | **The settings export dropped every VALIDATING knob**: `pinned_settings.json` has been missing five detector knobs since wave 5. Found by a test written for density. Fixed. See §6.2 |
+| **K8** — the coordinate system survives its own fix | **PASS, 8 of 8, BIT-IDENTICAL to all 16 digits.** See §6.1 |
+| **the full suite** | **3740 passed, 0 failed** (`develop` was 3722 → **+18**, every one named) |
 
 ---
 
@@ -428,4 +440,115 @@ bars using its rows to size `WingRejectedExcess` in any case. What it would stil
 
 ---
 
-*(§6 the suite — pending)*
+## §6 — K8, the suite, and what the wave leaves open
+
+### §6.1 K8 — the coordinate system survives its own fix, bit for bit
+
+The eight RULE G11 runs re-run on `exe_fix2` with `pinned_settings_w11.json`, 23:24–00:07Z, sequential.
+
+| run | K8 `BestJ` (exact) | gate `BestJ` (exact) | bit-identical |
+|---|---|---|---|
+| `toml999` | 0.9957838768299878 | 0.9957838768299878 | **YES** |
+| `CWhiteFocus` | 0.9960675916058808 | 0.9960675916058808 | **YES** |
+| `uneven` | 0.9963677194179505 | 0.9963677194179505 | **YES** |
+| `muggsie` | 0.9971948738498605 | 0.9971948738498605 | **YES** |
+| `mccomiskey` | 0.9767460801208465 | 0.9767460801208465 | **YES** |
+| `D18_m24_deep_shed` | 0.9998815090506263 | 0.9998815090506263 | **YES** |
+| `D19_cygnus_deep_shed` | 0.9994870586135448 | 0.9994870586135448 | **YES** |
+| `D20_m24_bright_control` | 0.9997378027339423 | 0.9997378027339423 | **YES** |
+
+> **K8 PASS, 8 of 8 — and not merely to 6 dp. Every landing is IDENTICAL TO ALL SIXTEEN DIGITS across a
+> different binary and a different settings file.** `ConcurrencyCheck = exclusive` and
+> `FitInputs = MaxOutlierRejections=0;OutlierRejectionConfidence=0.95;WeightedHyperbolicFitEnabled=True;HyperbolicFitModel=Hybrid`
+> on all eight.
+>
+> So the fix is **exactly** behaviour-preserving for a pinned arm: wave 10's coordinate system carries forward
+> unchanged, and no future wave inherits an undocumented discontinuity at the commit that removed one.
+
+### §6.2 The suite
+
+**3740 passed, 0 failed, exit code 0.** `develop` was **3722**, so **+18**, and every one is named:
+
+| fixture | tests | what they pin |
+|---|---|---|
+| `HarnessFitInputsTests` | 10 | the fit reads the FILE; the documented code defaults for a file that lacks the keys (the back-compat clause every pre-wave-11 pinned file depends on); `FitInputs` renders values and moves on all four axes; culture invariance; the dense copy; **F59's validating-setter regression** |
+| `ExposureRecommenderTests` (new) | 8 | `WingRejectedRatio`'s four states, the two-thirds disjointness guard, the `"NaN"`/`"Infinity"` serialization contract, and that no verdict is derived from it |
+
+The count was verified, not the tick (F37). Nothing was piped to `tail`, which would have masked the exit code.
+
+### §6.3 What this wave closes, and what it does not
+
+| entry | state |
+|---|---|
+| **F58** | **new, and it is the wave.** Mechanism identified, reproduced, intervened on, fixed, and the fix shown to remove the phenomenon while the hazard stays present |
+| **F57** | **(c) ANSWERED** — one integer. **(b) shipped** as a run rule in `testapp-cli.md`. (a) shipped in wave 10 |
+| **F55** | **mechanism identified.** Its measurements stand; `KappaSigmaNoiseEstimate` is withdrawn as the explanation. **Still open at the LANDING level**: K5 is a seed-level result and F55's landing rate was 44 % |
+| **F59** | **new, fixed.** Five detector knobs missing from the pinned file since wave 5 |
+| **F19** | **the successor is refuted too**, before implementation, by RULE W2. `WingRejectedExcess` named and not evaluated |
+| **F15** | **still open**, and still what forces a population pass to run alone |
+| **F45** | **implicated**: the Grubbs rejection budget was deciding `J` from unrecorded machine state |
+
+**Explicitly still open, and not to be read as closed by this wave:**
+
+- **Fan-out is NOT authorised.** K5 is a seed-level result. Nothing here measured landings under concurrency with
+  the fix in place, and F55's landing rate was triple its seed rate.
+- **Four other harness runners have F58's defect** — `BankVerifyRunner` (×2, and it feeds the golden audits),
+  `SynthValidateRunner`, `InspectAlignRunner`, `TiltCalibrationRunner`. Flagged in F58(d), not converted: each
+  needs its own validation and wave 11's budget went to `optimize`.
+- **No 39-run distribution for `WingRejectedRatio`** (§5.6).
+- **Wave 8's, wave 9's and wave 10's AF/wizard changes are STILL UNCONFIRMED IN THE APP.** The csproj PostBuild
+  xcopy fails silently when NINA is running. Not this wave's item; not to be claimed as confirmed either.
+
+---
+
+## Lessons
+
+**0. A measured gain is not a measured cause — and paying to measure the gain makes the confusion easier.**
+Wave 10 named `KappaSigmaNoiseEstimate` as F55's bimodal amplifier, measured its gain, pinned it with a unit
+test, and recorded the trigger RATE as the cheapest thing still owed. **The rate was owed for a mechanism that
+was not firing.** The real cause was one integer in a file the process opened at startup. The gain measurement is
+still true; it was never evidence of causation, and the effort spent obtaining it is exactly what made it feel
+like it was.
+
+**1. The cheapest instrument is the one already printed and ignored.** F58 — the whole wave — came out of a
+`Profile:` line that `optimize` had been printing since before wave 9, sitting in `D:\hf_w9\det\C_*.log`, at zero
+compute. Two waves eliminated the plugin's `Parallel.For` degree, three binaries, folder state one artifact at a
+time, OpenCL, `Merge`, rented sorts and load-sensitive timeouts — all correctly, all expensively — while the
+answer was in the second line of every log they were reading. **Wave 10's lesson 4 said to check whether a cheap
+instrument already exists. It does not go far enough: check whether the instrument already RAN.**
+
+**2. Require the hazard to survive the fix.** K5 does not ask "is the answer stable now"; it asks "is the answer
+stable *while five processes still load five different profiles*". A fix that pinned the profile would have
+passed the weaker question and left every future arm exposed. The clause was written that way before the fix
+existed, and it is the only reason the result means anything.
+
+**3. The negative control is what makes the positive ones readable.** C3 — `OutlierRejectionConfidence` alone must
+move NOTHING, because a rejection budget of zero makes it unreachable — is the clause that could have shown the
+bisect harness was not doing what it claimed. It passed, so C1's residue of exactly `0.0` is a measurement rather
+than a coincidence. Wave 10's gate returned its pre-registered top tier and was still wrong; what killed it was a
+control built to exclude.
+
+**4. A validated instrument validated against a DIFFERENT contract is not validated.** Wave 10's population
+scorer maps the JSON strings `"NaN"`, `"Infinity"` and `"-Infinity"` all to NaN — correct for a statistic with no
+infinite state, and catastrophic for this one. Reused verbatim it would have read `+∞` as *"we could not look"*,
+hidden every run the ratio form fails on, and pushed the NaN-rate clause toward firing on runs where the
+instrument worked perfectly. **Reuse the instrument; re-derive its contract.**
+
+**5. An instrument can be right about the wrong SCOPE.** `ConcurrencyCheck` works — K4 fired it in both
+directions for the first time. But `WaitOne(0)` is won by exactly one of *N* contenders, so **one landing reading
+`exclusive` is not evidence the machine was quiet**; it says that process won the mutex. In wave 10's own
+two-driver contamination the first driver's landings would all have read `exclusive`. The field is honest; the
+*reading* of it needed pinning down, and only running it in both directions revealed that.
+
+**6. Test the property you care about, not the happy path.** F59 was found by a test asserting **density** — *a
+value equal to the code default must still reach the file* — and not presence. Presence would have passed. The
+bug it exposed had silently dropped five detector knobs from the pinned file since wave 5.
+
+**7. Name the hazard CLASS, not the dataset.** The design named `D17` (ratio 0.59) and `D20` (inner exactly
+0.000) as the two ways the ratio form could fail. The killer was `D16` at 2 s — `D20`'s shape on a dataset filed
+under the other clause. Naming the class worked; naming only the datasets would not have.
+
+**8. Say what you did not run.** The 39-run population pass was dropped once item 3 fell to a necessary clause.
+That is defensible, and it is only defensible **because the results say the distribution is missing** rather than
+presenting eight runs where thirty-nine were planned. *A scope that quietly shrinks is how a partial result gets
+read as a complete one.*

--- a/docs/synthetic-af-bank-followups-wave11-results.md
+++ b/docs/synthetic-af-bank-followups-wave11-results.md
@@ -192,4 +192,240 @@ such line at all, wave 10 §1.4).
 
 ---
 
-*(§3 item 1 · §4 item 2 · §5 item 3 · §6 the suite — pending)*
+## §3 — Item 1: F55(b). RULE K passes on all four clauses, and then the fix removes the phenomenon
+
+### §3.1 The probe (`D:\hf_w11\det\determinism_probe_w11_w11.sh`), 22:41–22:45Z
+
+Wave 9's 40-second reproducer on the wave-11 pre-fix binary, with each repeat's `Profile:` line captured.
+`D16_esprit550_ha3`, `--max-evals 1`, five pristine copies, **the banks never touched**.
+
+**The prediction was written before the probe ran**, from the `LastUsed` ordering snapshotted in
+`profiles_before.txt`: phase C should draw the top five profiles, which split **2 / 3** on
+`MaxOutlierRejections`.
+
+| phase | repeat | profile loaded | `MaxOutlierRejections` | `BaselineJ` | `ConcurrencyCheck` |
+|---|---|---|---|---|---|
+| **S** (sequential) | 1–5 | `astrodet` ×5 | 0 | `0.9791727071693058` ×5 | `exclusive` ×5 |
+| **C** (concurrent) | C_1 | `AA1600MM Copy` | **0** | `0.9791727071693058` | `concurrent` |
+| | C_2 | `astrodet` | **0** | `0.9791727071693058` | `concurrent` |
+| | C_3 | `Default-2026-08-05T10:57:42` | **1** | `0.9885546719484486` | `exclusive` |
+| | C_4 | `Default` | **1** | `0.9885546719484486` | `concurrent` |
+| | C_5 | `AA1600MM` | **1** | `0.9885546719484486` | `concurrent` |
+| **P** (concurrent, `--profile-id`) | P_1…P_4 | — | — | — **rc = 1**, *"No active NINA profile could be loaded"* | — |
+| | P_5 | `astrodet` | 0 | `0.9791727071693058` | `exclusive` |
+
+> **Five concurrent processes, FIVE DIFFERENT PROFILES, and a 2 / 3 split exactly as predicted — into wave 9's
+> two attractor values, to sixteen decimal places.**
+
+| clause | verdict | evidence |
+|---|---|---|
+| **K1** distinct `BaselineJ` == distinct `MaxOutlierRejections` | **PASS** | 2 vs 2; `MOR=0 → 0.9791727071693058`, `MOR=1 → 0.9885546719484486`, no collisions |
+| **K2** phase S is single-profile, single-valued | **PASS** | 1 profile, 1 value, 5 of 5 |
+| **K3** pinning under fan-out fails LOUDLY | **PASS** | exactly 1 success, 4 hard failures, no wrong-profile success |
+| **K4** `ConcurrencyCheck`'s first positive control | **PASS** | phase S `exclusive`; phase C contains `concurrent` |
+
+### §3.2 K4 found a real limit in wave 10's shipped guard
+
+Phase C returned **four `concurrent` and one `exclusive`** — and that is correct: `WaitOne(0)` is won by exactly
+one of *N* contenders, so **in any fan-out precisely one landing truthfully reports `exclusive`.**
+
+**So `ConcurrencyCheck == "exclusive"` on a SINGLE landing is not evidence that the machine was quiet.** It says
+*this process won the mutex*. The field must be read **across a whole arm**, and in wave 10's own two-driver
+contamination the first driver's landings would have read `exclusive` throughout — an operator sampling that
+driver would have seen a clean bill of health. The field is honest; it is its **scope** that needed pinning down,
+and only running it in both directions revealed that. *An instrument that is right about the wrong scope is a new
+way to be wrong.*
+
+### §3.3 The fix, and K5 is the clause it is judged on
+
+`AutoFocusOptions` is now built on the **harness accessor** rather than on the active profile, the four fit inputs
+are carried in the pinned settings file, and every landing records them as `FitInputs` — **values, not a hash,
+because a hash says something moved and values say which one**. `HarnessFitInputs` is one type used both to build
+the fit and to render the field, so they cannot diverge; a guard test would only have watched for divergence.
+
+**K5 — post-fix, five concurrent repeats, unpinned:**
+
+| repeat | profile loaded | `BaselineJ` | `FitInputs` |
+|---|---|---|---|
+| F_1 | `AA1600MM Copy` | `0.9791727071693058` | `MaxOutlierRejections=0;…=0.95;…=True;…=Hybrid` |
+| F_2 | `astrodet` | `0.9791727071693058` | *(identical)* |
+| F_3 | `AA1600MM` | `0.9791727071693058` | *(identical)* |
+| F_4 | `Default-2026-08-05T10:57:42` | `0.9791727071693058` | *(identical)* |
+| F_5 | `Default` | `0.9791727071693058` | *(identical)* |
+
+> **K5 PASS. Five different profiles — spanning BOTH `MaxOutlierRejections` groups — and ONE `BaselineJ`,
+> identical to the sequential value.** The hazard is *still fully present*; it no longer reaches `J`.
+>
+> **That the five profiles still differ is what makes the clause discriminating.** A "fix" that pinned the
+> profile would have produced one profile and one answer, passed a weaker version of this test, and left every
+> future arm exposed the moment two ran at once.
+
+**K7 — the crispest statement of "pinned".** `toml999` at `--max-evals 1` under `--profile-id astrodet` and under
+`--profile-id Default`, post-fix: **`0.9834767968919785` both times, identical to full double precision.** Before
+the fix those two differ by **0.0144**.
+
+### §3.4 The residual (K6), and what is NOT claimed
+
+`optimize --verbose` already emits `Structure Map K-Sigma Noise Estimate: <σ> … NumIterations=<n>` per detection,
+so the σ instrument needed no code. **It was not needed:** phase F is single-valued to full double precision
+across five profiles, so there is no residual divergence at the seed level for `KappaSigmaNoiseEstimate` — or
+anything else below the fit — to explain.
+
+**`KappaSigmaNoiseEstimate` is therefore withdrawn as F55's mechanism.** Its measured gain stays as a true fact
+about the function, pinned by wave 10's unit test; it is a plausible amplifier for some *other* perturbation.
+**The trigger RATE wave 10 recorded as owed was owed for a mechanism that was not firing** — and that is the
+sharpest lesson available here: *a measured gain is not a measured cause, and it is easy to mistake one for the
+other after paying to measure it.*
+
+**What is NOT claimed.** K5 is a **seed-level** result (`--max-evals 1`). F55's LANDING rate was **44 %**, triple
+its seed rate, and no landing-level fan-out was measured with the fix in place. **Fan-out is therefore still not
+authorised**, and the population pass in §5 ran sequentially and paid the ~3 h.
+
+`--cv-threads <n>` shipped as the F55-family probe knob and was validated by its positive control — the printed
+`Cv2.GetNumThreads()` follows the flag (1 → `1`, 4 → `4`, absent → `48`). It was **not needed** either, and it is
+recorded rather than used, because wave 9's env-var route silently measured one configuration five times.
+
+---
+
+## §4 — Item 2: F57(c). The answer is one integer, and the negative control is what makes it readable
+
+`toml999`, `--max-evals 1` so `BaselineJ` is the whole measurement, on **copies** (F15), on the **pre-fix**
+binary — because this arm measures what the PROFILE supplies. The bisect profiles are fresh GUIDs dropped into
+NINA's profile folder and deleted afterwards; **the user's two real profiles were never edited**, and
+`make_bisect_profile.py` refuses to run if their shape is not what it expects.
+
+**The read-level audit came first, because it is free**, and it left exactly one unpinned options surface:
+
+| profile-sourced input | reaches the objective? | why not |
+|---|---|---|
+| **`AutoFocusOptions`** → 4 values | **YES** | the only unpinned surface; 2 of the 4 differ between the profiles |
+| detector knobs via `StarDetectionOptions` | no | `FileOptionsAccessor` falls back to **code defaults**, never the profile |
+| `PixelScale` | no | resolved per run from the frame header (both printed `0.73944`) |
+| image loading | no | **`ImageSettings` is byte-identical between the two profiles**, and `toml999` is mono |
+| `AutoFocusBinningConflict` | no | feeds a user prompt; does not resolve binning |
+| `FocuserSettings.AutoFocusStepSize` (479 vs 188) | no | the harness infers the step from the frames |
+
+| arm | profile loaded | C4 | `BaselineJ` (exact) |
+|---|---|---|---|
+| reference | `astrodet` | PASS | `0.9834767968919785` |
+| reference | `Default` | PASS | `0.9978404571046091` |
+| **C1** `astrodet` + `MOR=1` + `conf=0.99` | `w11-C1-mor1-conf099` | PASS | **`0.9978404571046091`** |
+| **C2** `astrodet` + `MOR=1` | `w11-C2-mor1` | PASS | **`0.9978404571046091`** |
+| **C3** `astrodet` + `conf=0.99` *(negative control)* | `w11-C3-conf099` | PASS | **`0.9834767968919785`** |
+
+| clause | verdict | evidence |
+|---|---|---|
+| **C0** the reference points hold | **PASS** | `astrodet` reproduces wave 10 exactly; `Default` to 4.6e-12 (wave 10 quoted 10 dp) |
+| **C3** NEGATIVE CONTROL: confidence alone moves nothing | **PASS** | identical to `J_astro` — unreachable at a budget of 0, as predicted |
+| **C1** both fields == `J_def` to full double precision | **PASS** | **residue exactly `0.0`** |
+| **C2** single-field attribution | **SINGLE-FIELD** | `MOR=1` alone == `J_def`; the confidence is inert |
+
+> **F57(c) is answered: `AutoFocusOptions.MaxOutlierRejections`, one integer, accounts for 100 % of the 0.0144.**
+> `OutlierRejectionConfidence` is real but inert behind it — a rejection budget of zero makes the confidence
+> unreachable, which is exactly what C3 was written to check and exactly what it found.
+>
+> **C3 is why C1 and C2 are readable at all.** Had the confidence moved anything, the harness would not have been
+> doing what it claimed and both other clauses would have been discarded. Wave 10's gate came back at its
+> pre-registered top tier and was still wrong; what killed it was a control built to *exclude*.
+
+**And it is [F45](followups.md#f45--the-grubbs-test-rejects-the-in-focus-point-of-a-near-perfect-curve-and-the-blind-walk-then-buys-an-extra-exposure)
+wearing a different hat**: whether the fit may drop one Grubbs outlier was being decided by machine state that
+nothing recorded, and allowing the rejection improves the fit — which is the direction observed on every dataset
+where the two groups were compared.
+
+---
+
+## §5 — Item 3: F19's successor is refuted before implementation, by the rule fixed in advance to size it
+
+### §5.1 The ladder was already on disk, and it said what to expect
+
+W1–W4 are validated on wave 7's exposure ladder. Wave 7's own aggregates predate `FrameDiagnostics`, but **wave 9
+left a 10-rung probe at `D:\hf_w9\wing2\` that has it** — so the wing/inner ratio could be read at **zero
+compute**, before a threshold was chosen and before anything was run.
+
+**It was not published from there.** `wing2` ran on the v1 binary under an **unrecorded profile**, which is
+precisely the provenance F58 condemns, and publishing a refutation from it would have been the joke telling
+itself. It became the **pre-registered prediction** for a pinned re-measurement instead, written into
+`ladder_w11.sh`'s header before that ran.
+
+### §5.2 The pinned re-measurement, and every rung reproduces
+
+`exe_fix2`, `pinned_settings_w11.json`, `--profile-id astrodet`, `--max-evals 120` (wave 9's budget exactly), on
+wave 7's frames — **no re-render**.
+
+| dataset | rung | wing | inner | **`WingRejectedRatio`** | offline recomputation | wave-9 prediction | | σ_focus |
+|---|---|---|---|---|---|---|---|---|
+| `D02_rich_135mm` | 0.5 s | 0.6729 | 0.4290 | **1.5683035695977232** | 1.5683035695977232 | 1.5683 | SAME | 0.10063 |
+| | 1 s | 0.2909 | 0.2816 | 1.0328751392282651 | 1.0328751392282651 | 1.0329 | SAME | 0.09594 |
+| | 2 s | 0.3048 | 0.3465 | 0.8798132420671898 | 0.8798132420671898 | 0.8798 | SAME | 0.09191 |
+| | 4 s | 0.0000 | 0.0027 | 0.0 | 0.0 | 0.0 | SAME | **0.05208** |
+| | 8 s | 0.0000 | 0.0235 | 0.0 | 0.0 | 0.0 | SAME | 0.06465 |
+| `D16_esprit550_ha3` | 0.5 s | 0.0000 | 0.0000 | 1.0 | 1.0 | 1.0 | SAME | 0.35169 |
+| | 1 s | 0.0000 | 0.0000 | 1.0 | 1.0 | 1.0 | SAME | 0.26026 |
+| | **2 s** | **0.0064** | **0.0000** | **+∞** | +∞ | +∞ | SAME | **0.17117** |
+| | 4 s | 0.0000 | 0.0000 | 1.0 | 1.0 | 1.0 | SAME | 0.20421 |
+| | 8 s | 0.0000 | 0.0000 | 1.0 | 1.0 | 1.0 | SAME | 0.19659 |
+
+**Ten of ten reproduce, across a binary change (v1 → v2) and a profile change.** And the **shipped field agrees
+with an independent offline recomputation on every rung** — two routes to one number, for free.
+
+### §5.3 RULE W has no satisfying threshold
+
+| clause | requirement | measured | implies |
+|---|---|---|---|
+| **W1** `D02`@0.5 s must fire | ratio ≥ T | **1.5683** | T ≤ 1.5683 |
+| **W5** must sit above the bank median | — | 1.39 | T > 1.39 |
+| **W2** `D16`@2 s must stay SILENT | ratio < T | **+∞** | **T > +∞ — impossible** |
+
+> **W1 ∧ W5 leave the window (1.39, 1.5683]. W2 empties it. `WingRejectedRatio` is REFUTED BEFORE
+> IMPLEMENTATION, by the rule wave 10 fixed in advance to size it** — the same shape as wave 10's own deadband,
+> where the rule written to accept a mechanism had no valid input and that *was* the answer.
+
+**And the mechanism is worse than the arithmetic.** On a clean, well-exposed narrowband run the core rejects
+**nothing**, so **any** wing rejection at all — 0.64 % here — becomes an infinite ratio. The ratio form is
+maximally unstable exactly where the statistic is required to be silent, and `D16` @ 2 s is not an arbitrary
+rung: it is where `D16`'s σ_focus is **minimised** (0.17117, against 0.35169 / 0.26026 / 0.20421 / 0.19659), so
+firing there asks the user to make their focus worse. **The absolute fraction got this rung RIGHT** (0.0064 ≪
+0.20). *On the one control that matters, the successor is not merely no better than its predecessor — it is
+strictly worse.*
+
+### §5.4 What ships, and what does not
+
+| | |
+|---|---|
+| **ships** | `ExposureRecommendation.WingRejectedRatio` as a **MEASUREMENT ONLY**, with a four-state contract — `NaN` (could not look) / `+∞` (the core rejects nothing and the wings do) / `1.0` (both reject nothing: equal rates) / the ratio. Newtonsoft writes the first two as the **strings** `"NaN"` and `"Infinity"`, pinned by a serialization test |
+| **does NOT ship** | any verdict, threshold, probe factor, or action. Nothing in the product reads it |
+
+**The predicted hazard class landed on a different dataset than the two named, and that is the point.** The
+design named `D17` (ratio 0.59) and `D20` (inner fraction exactly 0.000) as the hazards. The killer was `D16`@2 s
+— **the same shape as `D20`** (inner exactly 0.000 ⇒ infinite) on a dataset the design had listed under a
+different clause. *Naming the hazard CLASS in advance worked even though the specific dataset was wrong*, which
+is more than naming a dataset would have bought.
+
+### §5.5 The successor-of-the-successor, named and NOT evaluated here
+
+`WingRejectedExcess` = wing − inner was named in the design **before this ladder was read**. It is bounded in
+[−1, 1], defined when the inner third rejects nothing, and cannot fire when wings and cores reject at the same
+rate. **Its verdict is deliberately not computed in this document.** The ladder is now the data that refuted the
+ratio, and W6's whole content is that a successor may not be validated on the data that killed its predecessor —
+which applies to the ladder exactly as it applied to the 39-run population. *A statistic tuned on the data that
+killed the last one has been fitted, not tested*, and this register has now had to write that sentence three
+times.
+
+### §5.6 The 39-run population pass was NOT run, and here is the trade
+
+The plan had item 3 decided by a 39-run pass over both banks (~3 h), with K8 riding along inside it for free.
+**Item 3 was refuted first, on a NECESSARY clause**, so that pass could no longer change the verdict — and W6
+bars using its rows to size `WingRejectedExcess` in any case. What it would still have bought is the population
+*range* of a refuted measurement, for three hours, while re-landing both banks under a new settings fingerprint.
+
+**So K8 was run on its own** (the eight RULE G11 runs, ~40 min) and the pass was dropped.
+
+> **What is lost, stated plainly: this wave publishes NO 39-run distribution for `WingRejectedRatio`.** Anyone
+> sizing a future wing statistic must measure their own population — which is what W6 requires of them anyway.
+> Recorded here rather than left as a silently smaller pass, because *"a scope that quietly shrinks is how a
+> partial result gets read as a complete one."*
+
+---
+
+*(§6 the suite — pending)*

--- a/docs/synthetic-af-bank-followups-wave11-results.md
+++ b/docs/synthetic-af-bank-followups-wave11-results.md
@@ -1,0 +1,195 @@
+# Synthetic AF bank — followups wave 11 (results)
+
+Design: [`docs/synthetic-af-bank-followups-wave11-design.md`](synthetic-af-bank-followups-wave11-design.md).
+Plan: [`plans/synthetic-af-bank-followups-wave11-plan.md`](../plans/synthetic-af-bank-followups-wave11-plan.md).
+Wave 10: [`docs/synthetic-af-bank-followups-wave10-results.md`](synthetic-af-bank-followups-wave10-results.md).
+Register: [`docs/followups.md`](followups.md).
+
+> ## PROVENANCE — and this is the last wave that needs to say most of it in prose
+>
+> Every measurement below was produced by **`D:\hf_w11\exe`** (pre-fix) or **`D:\hf_w11\exe_fixed`**, both built
+> from `a54c48b` (PR #188's merge commit, `develop`'s head), **`StarDetectorVersion` 2**, **under the NINA profile
+> `astrodet (ce3f3e63-8fd3-4b72-a0ca-d90db9441382)`, PINNED WITH `--profile-id` ON EVERY INVOCATION.**
+>
+> | | |
+> |---|---|
+> | `exe` (pre-fix) | `TestApp.dll` sha256 `71ce1cd8…`, `HocusFocus.dll` sha256 `0aca4c20…`, `BuildId 40f08e36…` |
+> | `--settings` | `D:\hf_w11\pinned_settings.json`, md5 `df7c7cd1…` — byte-identical to waves 5–10 (F42) |
+> | `--settings` (post-fix) | `D:\hf_w11\pinned_settings_w11.json`, md5 `a67ffc06…` — the same **plus** the four fit inputs |
+>
+> **`--profile-id` is in this banner because of what the wave found**, and it is not hygiene: measured before the
+> gate ran, an **unpinned** `optimize` on this machine today loads `Default` and returns `toml999`
+> `currentJ = 0.99784` — **wave 9's value, not the wave 10 the banks were measured under**. An unpinned wave-11
+> gate would have reproduced the wrong wave and called it a pass.
+>
+> `exe` and `exe_fixed` are each built once and never rebuilt (F53(c)).
+
+## Status of this document
+
+| item | state |
+|---|---|
+| **F58** — new, and it is the wave's headline | **F55 and F57 are ONE defect: concurrent `optimize` processes each acquire a DIFFERENT NINA profile, and the two "attractors" are two values of `MaxOutlierRejections`.** Found at **zero compute**, out of logs wave 9 left on disk. See §1 |
+| **RULE G11** — the gate, the wave's only pass/fail clause | **PASS, 8 of 8 to 6 dp**, and all eight `BaselineJ` reproduce wave 10 exactly. See §2 |
+| **item 1** — F55(b) | *(pending — §3)* |
+| **item 2** — F57(c) | *(pending — §4)* |
+| **item 3** — F19's successor | **RULE W2 has no satisfying threshold on wave 9's on-disk ladder**; the pinned re-measurement is *(pending — §5)* |
+| **the full suite** | *(pending — §6)* |
+
+---
+
+## §1 — F58: F55 and F57 are the same defect, and it was already on disk
+
+**Nothing was run to find this.** The evidence was printed in a `Profile:` line that two waves had scrolled past,
+and the reading that explains it is four lines of `NINA.Profile`.
+
+### §1.1 The mechanism
+
+1. **`Profile.Load(path)`** opens the `.profile` with `FileAccess.ReadWrite, FileShare.Read` and **holds the
+   stream for the profile's lifetime**. A second process's `Load` throws `IOException`
+   (`ERROR_SHARING_VIOLATION`), and `Load` **rethrows** — the journal/backup recovery path is explicitly skipped
+   for the in-use case.
+2. **`ProfileService.SelectProfile`** catches it and returns **`false`**.
+3. **`TryLoad(id)`** orders candidates `OrderByDescending(LastUsed)` and then
+   `.SkipWhile(p => !SelectProfile(p)).FirstOrDefault()` — **a locked profile is silently SKIPPED and the next by
+   `LastUsed` is loaded instead.**
+4. **`Profile.Load` also sets `LastUsed = DateTime.Now` and SAVES.**
+
+*(Checked rather than assumed: `Profile.Peek`, which builds the candidate list, opens with
+`FileAccess.Read, FileShare.ReadWrite` and therefore **succeeds** on a locked profile. So the list is complete and
+the skip happens exactly at `SelectProfile`, not earlier — which is what makes the fall-through silent instead of
+simply omitting the profile.)*
+
+### §1.2 The observation — wave 9's 40-second reproducer, re-read
+
+`D:\hf_w9\det\{S,C}_{1..5}.log`, `D16_esprit550_ha3`, `--max-evals 1`:
+
+| repeat | `Profile:` printed by the run | `BaselineJ` |
+|---|---|---|
+| S_1 … S_5 (**sequential**) | `AA1600MM Copy (1bf0efaf-…)` — **all five the same** | `0.979173` ×5 |
+| C_1 (**concurrent**) | `AA1600MM (4cf31cda-…)` | **0.988555** |
+| C_2 | `Default (b10b1d6d-…)` | **0.988555** |
+| C_3 | `astrodet (ce3f3e63-…)` | `0.979173` |
+| C_4 | `Default-2026-08-05T10:57:42 (1a120eb1-…)` | **0.988555** |
+| C_5 | `AA1600MM Copy (1bf0efaf-…)` | `0.979173` |
+
+**Five concurrent processes, five different profiles.** C_5 drew the profile the sequential phase drew and
+returned the sequential phase's value.
+
+### §1.3 And `J` partitions on ONE field
+
+The optimize path feeds exactly four profile-sourced values into the fit
+(`OptimizationDiagnosticRunner.cs:673–679`). Across those five profiles, three of the four are constant:
+
+| profile | `BaselineJ` | `MaxOutlierRejections` | `OutlierRejectionConfidence` | `Weighted…` | `HyperbolicFitModel` |
+|---|---|---|---|---|---|
+| `AA1600MM Copy` | `0.979173` | **0** | *(absent ⇒ 0.95)* | *(absent ⇒ true)* | Hybrid |
+| `astrodet` | `0.979173` | **0** | *(absent ⇒ 0.95)* | true | *(absent ⇒ Hybrid)* |
+| `AA1600MM` | **0.988555** | **1** | *(absent ⇒ 0.95)* | true | *(absent ⇒ Hybrid)* |
+| `Default` | **0.988555** | **1** | **0.99** | true | *(absent ⇒ Hybrid)* |
+| `Default-2026-08-05T10:57:42` | **0.988555** | **1** *(absent ⇒ 1)* | *(absent ⇒ 0.95)* | *(absent ⇒ true)* | *(absent ⇒ Hybrid)* |
+
+> **`MaxOutlierRejections` = 0 ⇒ 0.979173. = 1 ⇒ 0.988555. Five of five.**
+> `OutlierRejectionConfidence` varies *within* the firing group (0.99 vs 0.95) and does not move `J`, which is
+> what a rejection budget of one predicts and a coincidence does not.
+
+**The machine holds 9 profiles and they partition 2 / 7 on this field** (`D:\hf_w11\profiles_before.txt`,
+snapshotted before anything in this wave ran). **That is the bimodality** — two discrete attractors because a
+small integer takes two values in the wild, which is the one property of F55 that never fit summation order.
+
+### §1.4 Confirmed on three more datasets, also at zero compute
+
+Wave 9's **four-way concurrent control trial** (`D:\hf_w9\ctl_conc_*.log`) also printed its profiles:
+
+| log | profile loaded | `MaxOutlierRejections` | `BaselineJ` |
+|---|---|---|---|
+| `ctl_seq_toml999` (**sequential**) | `Default-2026-08-05T10:57:42` | 1 | 0.997840 |
+| `ctl_conc_toml999` | **the same profile** | 1 | **0.997840** |
+| `ctl_conc_bobp` | `astrodet` | 0 | 0.993122 |
+| `ctl_conc_caboose` | `Default` | 1 | 0.994753 → landed **0.996300** |
+| `ctl_conc_mufti` | `AA1600MM Copy` | 0 | **0.957603** |
+
+Four processes, four different profiles again. `mufti`'s 0.957603 is **arms B/C's** value in F55's own table
+(so arm A's 0.957087 drew a `= 1` profile), and `caboose`'s 0.996300 is one of that run's two recorded landings.
+
+**The sharpest of them is the anomaly F55 had to hedge about.** F55 records *"one four-way concurrent trial did
+NOT reproduce the deviation"* and correctly declines to read it as evidence against the fan-out, on the grounds
+that the effect appears on ~15 % of runs so a single trial has no power. **The hedge was right and the reason is
+now visible in the log rather than left to probability:** `ctl_conc_toml999` drew the *same profile* as the
+sequential control, so the values are identical rather than merely close.
+
+### §1.5 What it explains — and every one of these was paid for by measurement
+
+| eliminated by waves 9–10 | why F58 is consistent with it |
+|---|---|
+| the plugin's `Parallel.For` degree (1/2/4/8/48), swept, inert | it is not a thread race |
+| the BUILD (15 runs, 3 binaries, identical to 10 dp) | those fifteen ran in ONE session under ONE **pinned** profile |
+| folder state, one artifact at a time | irrelevant to which file the process opened at startup |
+| `optimized_settings.json`, the detection cache, OpenCL/`UMat`, `Merge`, rented sorts, `MedianInPlace`, timeouts | same |
+| **"stable within a process/session, variable across them … process-level state … acquired once"** | **a profile is acquired once, at startup.** Wave 9 named the shape of the answer, and the search kept looking below the fit |
+
+**And it explains F57 without a second cause.** Wave 9's gate ran under `Default` (`MaxOutlierRejections = 1`),
+wave 10's under `astrodet` (`0`); `toml999`'s `BaselineJ` went 0.997840 → 0.983477, and allowing one Grubbs
+rejection improves a fit, which is the observed direction. **F57(c)'s answer is a named field** — F45's outlier
+rejection deciding the objective from machine state nothing recorded.
+
+### §1.6 Two consequences that are not obvious
+
+- **A pinned run rewrites the default for the next unpinned run.** Wave 10's own F57 probe pinned `Default` last,
+  and an unpinned run today loads `Default` and returns wave 9's number. **The act of measuring rewrites the
+  default for the next measurement.**
+- **`--profile-id` and fan-out are mutually exclusive as things stand.** With the id filter the candidate list
+  has one entry, so the second concurrent process runs `SkipWhile` over an empty remainder and `optimize` throws
+  *"No active NINA profile could be loaded"*. **Pinning converts a silent wrong answer into a loud failure**,
+  which is the right trade and is not a fix.
+
+### §1.7 The asymmetry that is the actual bug
+
+`HarnessSettingsStore` exists precisely so that *"a profile-sourced seed is mutable machine state nothing
+records"* cannot reach a run: its `FileOptionsAccessor` reads the pinned file and falls back to **code defaults**,
+never to the profile, and `StarDetectionOptions` is built on it. **`AutoFocusOptions` was not.** So the detector
+was pinned and the fit was not, and `--settings` has been read as pinning the arm since wave 5.
+
+---
+
+## §2 — The gate: RULE G11 PASSES, 8 of 8
+
+`D:\hf_w11\gate_repro_w11.sh`, 21:58–22:41Z, sequential, `--per-run --max-evals 250`, `--settings` md5
+`df7c7cd1…`, **`--profile-id ce3f3e63-…` named in the script header as a first-class input beside the settings
+file** — which is F57(b) applied to this wave's own first action, and which the wave-10 gate script does not
+contain the string for.
+
+| run | `BestJ` (exact) | 6 dp | wave 10 | | `BaselineJ` | wave 10 | |
+|---|---|---|---|---|---|---|---|
+| `toml999` | 0.9957838768299878 | 0.995784 | 0.995784 | **MATCH** | 0.983477 | 0.983477 | ok |
+| `CWhiteFocus` | 0.9960675916058808 | 0.996068 | 0.996068 | **MATCH** | 0.994320 | 0.994320 | ok |
+| `uneven` | 0.9963677194179505 | 0.996368 | 0.996368 | **MATCH** | 0.991794 | 0.991794 | ok |
+| `muggsie` | 0.9971948738498605 | 0.997195 | 0.997195 | **MATCH** | 0.993288 | 0.993288 | ok |
+| `mccomiskey` | 0.9767460801208465 | 0.976746 | 0.976746 | **MATCH** | 0.846082 | 0.846082 | ok |
+| `D18_m24_deep_shed` | 0.9998815090506263 | 0.999882 | 0.999882 | **MATCH** | 0.997405 | 0.997405 | ok |
+| `D19_cygnus_deep_shed` | 0.9994870586135448 | 0.999487 | 0.999487 | **MATCH** | 0.999187 | 0.999187 | ok |
+| `D20_m24_bright_control` | 0.9997378027339423 | 0.999738 | 0.999738 | **MATCH** | 0.999454 | 0.999454 | ok |
+
+> **RULE G11: PASS, 8 of 8 to 6 dp.** Wave 11 has a coordinate system, and everything downstream is readable
+> against it. **And the free control (F41) passes at 8 of 8 too** — every `BaselineJ` reproduces wave 10 on a
+> *different build of a different commit*, which is the seed evaluation behaving as a pure function of
+> (frames, settings, profile) exactly as §1 says it does under a pinned profile.
+
+**The measurements beside it**, none of them gates:
+
+| field | value | reading |
+|---|---|---|
+| `ConcurrencyCheck` | `exclusive` × 8 | F55(c): the pass is uncontaminated, *checked* rather than assumed |
+| `DetectorVersion` | 2 × 8 | and `strings … \| grep AtrousWaveletFast` hits, retroactively |
+| `BuildId` | `40f08e36…` × 8 | **differs from wave 10's**, as a fresh build must; a match would have meant no build happened |
+| `ProfileId` | `astrodet (ce3f3e63-…)` × 8 | the pin took |
+| `FitInputs` | *absent* | expected — `exe` is the **pre-fix** binary and the field ships with the fix |
+
+**Wave 5's φ table is not quoted anywhere in this document.** It is invalid on two axes — `StarDetectorVersion`
+1 → 2 and the profile — and this wave's coordinate system is wave 10's eight values, not wave 5's.
+
+**No `Optimization complete` line was greped for.** `aggregate_summary.json` is the instrument (`uneven` emits no
+such line at all, wave 10 §1.4).
+
+---
+
+*(§3 item 1 · §4 item 2 · §5 item 3 · §6 the suite — pending)*

--- a/plans/synthetic-af-bank-followups-wave11-plan.md
+++ b/plans/synthetic-af-bank-followups-wave11-plan.md
@@ -1,0 +1,346 @@
+# Synthetic AF bank — followups wave 11 (plan)
+
+Design: [`docs/synthetic-af-bank-followups-wave11-design.md`](../docs/synthetic-af-bank-followups-wave11-design.md).
+Register: [`docs/followups.md`](../docs/followups.md).
+
+**Branch:** `ghilios/synthetic-af-bank-followups-wave11` off `develop` @ `a54c48b`. Never push `develop`.
+**Artifacts:** `D:\hf_w11\` — `gate/`, `det/`, `bisect/`, `pop/`, and the scripts named below.
+
+**Two binaries, and the split is load-bearing:**
+
+| directory | what it is | used for |
+|---|---|---|
+| `exe/` | `a54c48b` — **pre-fix**, built once, **never rebuilt** (F53(c)) | the gate; the bisect (which must measure what the PROFILE supplies); probe phases S/C/P |
+| `exe_fixed/` | the same tree **plus** the F58 fix | K5/K7/K8 — the re-measurement, which only means something against a pre-fix reference |
+
+**Two settings files, and the second one is a deliberate break with F42's byte-identity rule:**
+
+| file | md5 | contents |
+|---|---|---|
+| `pinned_settings.json` | `df7c7cd1…` | a byte-copy of wave 10's, itself identical across waves 5–10 |
+| `pinned_settings_w11.json` | `a67ffc06…` | the same **plus** the four fit inputs at `astrodet`'s effective values (`MaxOutlierRejections=0`, `OutlierRejectionConfidence=0.95`, `WeightedHyperbolicFitEnabled=True`, `HyperbolicFitModel=Hybrid`) |
+
+The break is justified and must be stated in the results: **the old file pinned less than it claimed.** A file
+that also pins the fit inputs to the values wave 10's coordinate system was measured under is *more* comparable,
+not less — and K8 is the clause that proves it rather than asserting it.
+
+**Build:**
+`dotnet.exe build "$(wslpath -w /home/ghilios/src/hocus-focus/Joko.NINA.Plugins/TestApp/TestApp.csproj)" -c Release -o 'D:\hf_w11\exe'`
+**Tests:**
+`dotnet.exe test "$(wslpath -w /home/ghilios/src/hocus-focus/Joko.NINA.Plugins/Joko.NINA.Plugins.sln)" -c Debug --nologo`
+
+**Standing rules for every task below.** Every `optimize` invocation passes **both** `--settings` and
+`--profile-id`. Every script states its pinned settings file **and its profile id** in its header. Nothing runs
+concurrently unless a task says so deliberately, and `ConcurrencyCheck` is read out of the landing afterwards
+regardless. Tests run at the milestones marked **[TEST]** and as a final gate — not after every edit.
+
+---
+
+## Task 0 — Branch, artifact tree, and the pre-gate probe
+
+**This runs before anything is built or changed, because it can invalidate the wave's headline for 40 seconds.**
+
+1. `git checkout -b ghilios/synthetic-af-bank-followups-wave11` (from `develop` @ `a54c48b`).
+2. `mkdir -p /mnt/d/hf_w11/{gate,det,bisect,pop}`; copy `pinned_settings.json` from `hf_w10` and **verify the
+   md5 is `df7c7cd14181b4ace59b92b89e219f67`**.
+3. Snapshot, read-only, into `D:\hf_w11\profiles_before.txt`: every `*.profile`'s `Name`, `Id` and `LastUsed`,
+   plus each one's four fit inputs (`MaxOutlierRejections`, `OutlierRejectionConfidence`,
+   `WeightedHyperbolicFitEnabled`, `HyperbolicFitModel`). This is the wave's record of the machine state that
+   F58 is about, and it is taken **before** any run perturbs `LastUsed`.
+4. **The pre-gate probe** (design §1.2), on wave 10's `D:\hf_w10\exe` so that no new build is involved: one
+   `optimize --per-run --max-evals 1` on a **copy** of `toml999`, with **no `--profile-id`**, output to
+   `D:\hf_w11\pregate\`.
+
+**Verify:** the run prints `Profile: Default (b10b1d6d-80eb-4dc4-9d89-f1fbf64c2b34)`.
+
+**Stop condition.** If it prints anything else, **stop and re-derive §0.1** before continuing: the model of
+profile selection is wrong, F58 is not filed as written, and items 1 and 2 revert to wave 10's framing. Record
+what it did print either way.
+
+---
+
+## Task 1 — File F58 in the register
+
+Write **F58 — `optimize` acquires a DIFFERENT NINA profile per concurrent process, and the profile decides the
+fit, so F55's "two attractors" are two values of `MaxOutlierRejections`** into `docs/followups.md`, containing:
+
+- the four-step mechanism read out of `NINA.Profile` (`FileShare.Read` lock → `SelectProfile` false →
+  `TryLoad`'s `SkipWhile` fall-through → `LastUsed = Now` **and save** on load);
+- the wave-9 `C_*.log` profile/`BaselineJ` table and the five-profile fit-input table (design §0.1);
+- what it explains and what it retires: the plugin `Parallel.For` sweep, the build probe, folder state, the
+  bimodality, wave 9's "stable within a session, variable across them" clue, and wave 9's fan-out arm;
+- the two operational consequences: **a pinned run rewrites the default for the next unpinned one**, and
+  **`--profile-id` + fan-out currently fails loudly** (which is the right trade, not a fix);
+- what is **not** claimed yet: this is a correlation over five profiles that already existed; Task 5's bisect is
+  the intervention, and Task 4's K5 is the test that a fix removes the phenomenon.
+
+Cross-link from **F55** (which keeps its measurements and loses its named mechanism — the `KappaSigmaNoiseEstimate`
+gain stays as a measured fact about the function, withdrawn only as *this* defect's explanation) and from
+**F57** (whose (c) this answers, subject to RULE C).
+
+**Verify:** `F58` resolves from both cross-links; F55's and F57's status lines are updated to point at it.
+
+---
+
+## Task 2 — Build `D:\hf_w11\exe` and run the gate (RULE G11)
+
+1. Build to `D:\hf_w11\exe`. Record `git rev-parse HEAD`, and the sha256 of `TestApp.dll` and
+   `NINA.Joko.Plugins.HocusFocus.dll`, into the script header.
+2. `strings D:\hf_w11\exe\NINA.Joko.Plugins.HocusFocus.dll | grep AtrousWaveletFast` — **must hit** (v2).
+3. Write `D:\hf_w11\gate_repro_w11.sh` from wave 10's, with **`--profile-id ce3f3e63-8fd3-4b72-a0ca-d90db9441382`
+   added to every invocation and named in the header** beside the settings file, and the build provenance above.
+4. Run it sequentially. Score from `aggregate_summary.json`, **never** from the console
+   `Optimization complete` line (`uneven` has none).
+
+**Verify — RULE G11, the wave's ONE pass/fail clause.** All eight `BestJ` to 6 dp:
+`toml999` 0.995784 · `CWhiteFocus` 0.996068 · `uneven` 0.996368 · `muggsie` 0.997195 · `mccomiskey` 0.976746 ·
+`D18` 0.999882 · `D19` 0.999487 · `D20` 0.999738. **A partial reproduction is a failure. If it fires, STOP.**
+
+**Record (measurements, not gates):** `ProfileId` = astrodet on all eight · `ConcurrencyCheck` = `exclusive` on
+all eight · `DetectorVersion` = 2 · **`BuildId` DIFFERS from wave 10's** (a match means the build did not happen)
+· `toml999` `BaselineJ` = 0.983477 · and, if every `BaselineJ` reproduces while any landing moves, say so — that
+is F8 and it must not be absorbed.
+
+---
+
+## Task 3 — The `--cv-threads` flag and the provenance thread count
+
+Small, and it lands before the probes so they can use it.
+
+- `optimize --cv-threads <n>` → `Cv2.SetNumThreads(n)`; `optimize` prints `Cv2.GetNumThreads()` in its provenance
+  line **unconditionally**, so the knob's connectedness is visible whether or not it was passed.
+- Replaces wave 9's `HF_STAREVAL_PAR` env-var route, which measured the same configuration five times because
+  WSL env vars do not reach a Windows process without `WSLENV`.
+
+**Verify — empirically, not by unit test.** `--cv-threads 1` prints `OpenCV threads: 1`; omitting it prints the
+machine default. **A unit test here would test `int.TryParse`**; what actually needs proving is that the knob
+reaches OpenCV, and only a printed `Cv2.GetNumThreads()` from a real process shows that. This is deliberately
+the *weaker*-looking option and the stronger check — wave 9's env-var sweep passed every unit test it could have
+had and still measured one configuration five times.
+
+---
+
+## Task 4 — Item 1: F55(b) — confirm, fix, re-measure
+
+### 4a — Confirm (K1–K4)
+
+Write `D:\hf_w11\det\determinism_probe_w11.sh` from `D:\hf_w9\det\determinism_probe.sh`, changed only by: the
+wave-11 exe, the wave-11 pinned settings, and **capturing each repeat's `Profile:` line and landing `ProfileId`**.
+Each repeat keeps its own pristine copy of `D16_esprit550_ha3`; **the banks are never touched**. Then run phase C
+a second time with `--profile-id` (K3).
+
+**Verify:**
+- **K1** — distinct phase-C `BaselineJ` values == distinct `MaxOutlierRejections` across the profiles actually
+  loaded; repeats sharing a profile share a value to full double precision.
+- **K2** — phase S loads one profile and returns one value, 5 of 5.
+- **K3** — pinned phase C: exactly one success, four hard failures (`No active NINA profile could be loaded`,
+  non-zero exit).
+- **K4** — phase S landings stamp `exclusive`; phase C landings stamp `concurrent`. **If phase C stamps
+  `exclusive`, wave 10's guard does not work and that is a finding of its own.**
+
+### 4b — Fix: pin the fit inputs the way the detector knobs are pinned
+
+1. Build the harness's `AutoFocusOptions` on `harnessSettings.Accessor` (the existing
+   `internal AutoFocusOptions(IProfileService, IPluginOptionsAccessor)` seam) instead of on the profile.
+2. Carry `MaxOutlierRejections`, `OutlierRejectionConfidence`, `WeightedHyperbolicFitEnabled` and
+   `HyperbolicFitModel` in the harness settings file, exported from the profile on bootstrap exactly as the
+   detector knobs are.
+3. Add `ProfileInputs` to `OptimizerProvenance` as **values, not a hash** —
+   `MaxOutlierRejections=1;OutlierRejectionConfidence=0.99;WeightedHyperbolicFitEnabled=True;HyperbolicFitModel=Hybrid`
+   — printed by `optimize` and stored in every landing.
+4. **The live plugin is not changed.** The wizard and the AF engine keep reading `AutoFocusOptions` from the
+   profile; those are the user's settings. Only the harness's notion of "pinned" changes.
+
+**[TEST]** — and each must be confirmed discriminating by neutralizing the behaviour and re-running:
+- the four keys round-trip through the harness settings file and reach the fit;
+- an existing pinned file **without** the keys behaves as the documented code defaults (1 / 0.95 / true / Hybrid)
+  and the file's own bootstrap warning names them;
+- the four keys are **not** in the `UseAdvanced = False` preset-override set (F42(3)) — asserted by measurement
+  against `SimpleModePresetOverrides`, not by a comment;
+- `ProfileInputs` changes when any one of the four changes, and is stable when none do.
+
+### 4c — Re-measure (K5, K7, K8) and the residual (K6)
+
+Re-run on `exe_fixed/` with `--settings pinned_settings_w11.json`.
+
+**Verify — K5, the clause this item is judged on:** phase C returns **one** `BaselineJ`, identical to phase S to
+full double precision, **while the five `Profile:` lines still differ**. If the profiles stop differing, the test
+has stopped exercising the hazard and the result means nothing.
+
+**K7 — cross-profile identity, and it is the crispest statement of "pinned".** `toml999` at `--max-evals 1`
+under `--profile-id astrodet` and under `--profile-id Default`, on the fixed binary with the extended file, must
+return **identical `BaselineJ` to full double precision**. Before the fix these two differ by **0.0144**, which
+is larger than any Δ`J` this project has argued about. Two runs, ~1 minute.
+
+**K8 — the coordinate system survives its own fix.** The eight gate runs, re-run on `exe_fixed/` with
+`pinned_settings_w11.json`, must return **RULE G11's eight values**. Without this, every future wave inherits an
+unverified discontinuity at the exact commit that claimed to remove one.
+
+> **K8 costs nothing, because the instrument already exists in this wave's own plan.** Task 6c's population pass
+> is the *shipped-default invocation* over both banks — the same invocation as the gate — and all eight gate runs
+> are among its 39. So running Task 6c on `exe_fixed/` with the extended pinned file makes K8 a free read of
+> eight of its rows, exactly as wave 10's population pass was RULE G10-A at 8-fold redundancy. **Do not spend a
+> separate 40 minutes on it.**
+
+**Fan-out stays OFF for the population pass, and this is deliberate.** K5 establishes agreement at the SEED
+level (`--max-evals 1`). F55's landing rate was **44 %**, triple its seed rate, and nothing in this wave has
+measured landings under concurrency with the fix in place. Fanning out a 3-hour pass on the strength of a
+seed-level result is precisely the over-reach this register keeps punishing. The pass runs **sequentially**, and
+the ~3 h is paid.
+
+**K6 — the residual, run once either way:** phase C with `--verbose`, comparing the multiset of
+`Structure Map K-Sigma Noise Estimate: <σ> … NumIterations=<n>` trace lines between runs.
+- Instrument control first: **phase C must still split with `--verbose` on** when the fix is disabled. If it does
+  not, the instrument destroys what it measures and that is the reported result.
+- σ multiset identical ⇒ `KappaSigmaNoiseEstimate` exonerated; its measured gain stays as a fact about the
+  function and is withdrawn as this defect's explanation.
+- σ differs **and** iterations differ ⇒ a direct observation of the named mechanism.
+- σ differs and iterations identical ⇒ the flip is inside `Cv2.MeanStdDev`, a *different* mechanism, and F55 is
+  rewritten to say so. Only then run `--cv-threads 1` as corroboration.
+
+Claims are limited to what the instrument supports: the trace carries **no frame id**, so this is a multiset
+comparison and a per-detection rate, never a per-frame attribution.
+
+---
+
+## Task 5 — Item 2: F57(c) — RULE C, the one-field bisect
+
+On **copies** of `toml999` (F15), `--max-evals 1`, on the **pre-fix** code path or with the harness override
+bypassed, so that the profile is still what supplies the fit inputs — this measures the profile, not the fix.
+
+Synthetic bisect profiles: copy `astrodet`'s `.profile`, give it a fresh GUID (matching the filename and the
+inner `<Id>`) and a distinguishable `Name`, change **one** field, drop it into the profile folder.
+**The user's real profiles are never edited.** Delete the synthetic files afterwards and re-verify
+`profiles_before.txt`'s two real profiles are byte-unchanged apart from `LastUsed`.
+
+**Verify — RULE C:**
+- **C0** `astrodet ⇒ J_astro`, `Default ⇒ J_def`, measured today. If either differs from wave 10's 0.983477 /
+  0.997840, the bisect is void and *that* is the finding.
+- **C1** `astrodet` + `MaxOutlierRejections=1` + `OutlierRejectionConfidence=0.99` == `J_def` to full double
+  precision. A residue means an unenumerated profile read; report it, do not explain it away.
+- **C2** `astrodet` + `MaxOutlierRejections=1` alone — equal to `J_def` ⇒ single-field cause; short of it ⇒ both
+  are load-bearing.
+- **C3 (negative control)** `astrodet` + `OutlierRejectionConfidence=0.99` alone == **exactly `J_astro`**. **Any
+  movement discards C1 and C2.**
+- **C4** every bisect run prints its synthetic profile in `Profile:` and stamps it into `ProfileId`.
+
+**Then ship (b):** add the `--profile-id` rule to `.claude/docs/testapp-cli.md` beside F42's `--settings` rule,
+with F58's reason — the default is LRU-by-last-load, so an unpinned arm is seeded by whatever the previous arm
+pinned.
+
+---
+
+## Task 6 — Item 3: F19's successor, `WingRejectedRatio`
+
+### 6a — Implement the measurement, with the divide-by-zero contract
+
+`WingRejectedRatio` = wing-third ÷ inner-third, computed from the per-frame table the harness already writes.
+Four distinguishable states, and the scorer must be shown a **positive control for each**:
+
+| state | value | meaning |
+|---|---|---|
+| not measured | `UNEVALUATED` | the scorer refuses to present a partial pass as a population verdict |
+| cannot be placed on the wing axis | `NaN` | *"we could not look"* — never 0 |
+| inner third populated, rejects nothing, wings do | `+∞` | the strongest real signal |
+| otherwise | the ratio | — |
+
+`Newtonsoft` writes the middle two as the **strings** `"NaN"` and `"Infinity"`. A scorer that coerces either to a
+number disables its own falsification rule.
+
+**[TEST]** — the four states, each confirmed discriminating by neutralizing.
+
+### 6b — Fix the threshold BEFORE the pass — and the free read says there may be no threshold to fix
+
+W1–W4/W5/W6 are quoted verbatim from wave 10 and are **not** renegotiated. The threshold comes from W1–W4 on
+wave 7's exposure ladder and W5's floor (**above 1.39**), and is written into `wing_pop_w11.sh`'s header before
+the pass runs.
+
+**The ladder is on disk with its per-frame table** — not in wave 7's own aggregates (they predate
+`FrameDiagnostics`) but in **`D:\hf_w9\wing2\`**, the 10-rung probe wave 9 left behind. Read at zero compute:
+
+| dataset | rung | wing | inner | **ratio** |
+|---|---|---|---|---|
+| `D02_rich_135mm` | 0.5 s | 0.6729 | 0.4290 | **1.5683** |
+| | 1 s | 0.2909 | 0.2816 | 1.0329 |
+| | 2 s | 0.3048 | 0.3465 | 0.8798 |
+| | 4 s / 8 s | 0.0000 | 0.0027 / 0.0235 | 0.0000 |
+| `D16_esprit550_ha3` | 0.5 s | 0.0000 | 0.0000 | 1.0000 |
+| | 1 s | 0.0000 | 0.0000 | 1.0000 |
+| | **2 s** | **0.0064** | **0.0000** | **+∞** |
+| | 4 s / 8 s | 0.0000 | 0.0000 | 1.0000 |
+
+> **W2 IS UNSATISFIABLE AT ANY FINITE THRESHOLD.** `D16` at 2 s — the rung where its σ_focus is minimised, and
+> the control the whole statistic exists to pass — has an inner rejected fraction of **exactly 0.000** against a
+> wing fraction of 0.0064, so its ratio is **+∞** and it fires at every threshold. W1 ∧ W5 leaves the window
+> `(1.39, 1.5683]`; **W2 empties it.**
+>
+> **And the mechanism is worse than the arithmetic.** On a clean, well-exposed narrowband run the core rejects
+> *nothing*, so **any** wing rejection at all — 0.64 % here — becomes an infinite ratio. The ratio form is
+> maximally unstable exactly where the statistic is required to be silent. The absolute fraction got this rung
+> **right** (0.0064 ≪ 0.20). On the one control that matters, the successor is not merely no better than its
+> predecessor — it is **strictly worse**.
+>
+> *(W4 does not constrain the threshold: wave 9's table shows the wing probe ALONE failing W4, with the clause
+> satisfied by the accepted-star half's 3.00× through `max(shipped, probe)`. Recorded so W4 is not miscounted as
+> a second contradiction — W2 is sufficient on its own.)*
+
+**But `D:\hf_w9\wing2\` was measured on the v1 binary under an UNRECORDED profile**, which is F58's own hazard,
+and F58 is this wave's headline. So the refutation is not published from it. The table above is instead the
+**pre-registered prediction** for a pinned re-measurement:
+
+**6b(i) — re-run the 10 rungs** on `exe_fixed/` with `--settings pinned_settings_w11.json` **and** `--profile-id`,
+from the frames still at `D:\hf_w7\armE\t{0.5,1,2,4,8}` (**no re-render**). ~20 minutes.
+
+**Verify:** `D16`@2 s reproduces **+∞** (inner third rejects exactly 0) and `D02`@0.5 s reproduces **≈1.57**.
+- Reproduced ⇒ **W2 is unsatisfiable on pinned provenance**, the successor is refuted before implementation, and
+  §6c's population pass is no longer needed *to decide the verdict* — it still runs, for K8 and for the
+  measurement's own population statistics, but it is not what decides.
+- **Not** reproduced ⇒ the ladder moved between binaries or profiles, which is F54's shape and a finding in its
+  own right; the threshold is then fixed from the new ladder and §6c decides as originally planned.
+
+### 6c — The population pass, alone and last
+
+39 runs, both banks, sequential, shipped-default invocation, `--settings` **and** `--profile-id` pinned. Reuse
+`D:\hf_w10\wing_pop.sh`'s **validated** concurrency guard rather than rewriting it. Nothing else may be in flight
+(F15). Check `ConcurrencyCheck` in every landing afterwards regardless.
+
+**Verify — RULE P, unchanged:** P1 (`D10`/`D17` — at least one fires) · **P2 (> 50 % of 39 ⇒ REFUTED)** ·
+P3 (`D16` at its derived exposure must not fire) · P4 (NaN on > 25 % ⇒ the instrument is not connected).
+
+**Named exclusions, never silent:** `lumos` (rc=3 reproducibly, `WingRejectedFraction` NaN) · `astrodet` the
+dataset (frameless, F14) · `Panos` (degenerate sigma fit).
+
+**Expected, and pre-stated so that meeting it is not a surprise:** `D17` fires at 0.59 and cannot fire on a
+ratio ≥ threshold; `D20_m24_bright_control` has an inner fraction of exactly 0.000. **Refutation is the likely
+outcome and is priced in.** If it is refuted, `WingRejectedRatio` follows its predecessor: the **measurement**
+stays, the **action** does not ship, and **`WingRejectedExcess` = wing − inner** is named as the next candidate
+and **barred from this pass's rows**.
+
+---
+
+## Task 7 — Full suite, results, PR
+
+1. **[TEST]** `dotnet.exe test … -c Debug --nologo`. **Verify the COUNT, not the tick** (F37): `develop` is at
+   **3722**; the new total must be 3722 + (tests added), and every added test accounted for by name. Do not pipe
+   to `tail` — it masks the exit code. `SendAsync_WritesOnABackgroundThread` is a known-flaky EAT serial-transport
+   test and is unrelated; re-run it individually rather than chasing it.
+2. Write `docs/synthetic-af-bank-followups-wave11-results.md` with the provenance banner carrying **`BuildId`,
+   `DetectorVersion`, `ProfileId` and `ConcurrencyCheck` as fields** — wave 10 wrote that banner by hand for the
+   last time.
+3. Update `docs/followups.md`: F58 (Task 1, with the intervention result folded in), F55 (narrowed to what
+   survives), F57 ((c) answered, (b) shipped as a run rule), F19 (the successor's verdict), F15 (still open, and
+   still what forces the population pass to run alone).
+4. Commit with the privacy email; push the branch; open the PR. **Never push `develop`.**
+
+---
+
+## What would make this wave wrong, in one place
+
+- The pre-gate probe prints `astrodet` ⇒ §0.1's model is wrong and F58 does not get filed as written.
+- RULE G11 fires ⇒ nothing downstream is readable; stop.
+- **C3 moves** ⇒ the bisect harness is not doing what it claims and C1/C2 are discarded.
+- **K5 fails while the five profiles still differ** ⇒ the fit inputs were not the whole cause and something below
+  the fit is still moving.
+- K5 "passes" but the five `Profile:` lines are identical ⇒ the test stopped exercising the hazard and proves
+  nothing.
+- The suite total is not 3722 + (named new tests) ⇒ an absent check, which is more dangerous than a red one.

--- a/plans/synthetic-af-bank-followups-wave11-plan.md
+++ b/plans/synthetic-af-bank-followups-wave11-plan.md
@@ -334,6 +334,39 @@ and **barred from this pass's rows**.
 
 ---
 
+---
+
+## CLOSED AGAINST WHAT ACTUALLY HAPPENED (2026-08-08)
+
+Results: [`docs/synthetic-af-bank-followups-wave11-results.md`](../docs/synthetic-af-bank-followups-wave11-results.md).
+
+| task | planned | what happened |
+|---|---|---|
+| 0 pre-gate probe | predict `Default` | **as predicted**, and it returned `toml999 = 0.99784` — wave 9's value. An unpinned gate would have reproduced the wrong wave |
+| 1 file F58 | from wave 9's logs | done, and **two** more datasets confirmed it from `ctl_conc_*.log` at zero compute |
+| 2 gate | RULE G11 | **PASS 8/8 to 6 dp**; all eight `BaselineJ` reproduce wave 10 too |
+| 3 `--cv-threads` | flag + printed count | shipped; positive control passes (1→1, 4→4, absent→48). **Never needed** — recorded, not used |
+| 4a confirm | K1–K4 | **all PASS**, and K4 exposed a real limit in wave 10's guard (§3.2) |
+| 4b fix | harness accessor + `FitInputs` | shipped — **and the density test found F59**, a separate defect that dropped five detector knobs from the pinned file for six waves |
+| 4c re-measure | K5, K7, K8, K6 | **K5/K7 PASS**. **K6 was not needed**: no residual divergence exists to explain, so `KappaSigmaNoiseEstimate` is withdrawn as F55's mechanism |
+| 5 bisect | RULE C | **C0/C1/C3 PASS, C2 SINGLE-FIELD** — one integer, residue exactly `0.0` |
+| 6a–6b measurement + threshold | ship, then size | measurement shipped; **the threshold could not be sized — RULE W2 is unsatisfiable** |
+| 6c population pass | 39 runs, ~3 h | **NOT RUN.** Item 3 was refuted first on a necessary clause; the pass could not change the verdict and W6 bars its rows from sizing the next candidate. **K8 was run standalone instead** (8 runs, ~40 min) |
+| 7 suite | count, not tick | **3740 = 3722 + 18**, every added test named |
+
+**Three things went differently from the plan, and all three are recorded in the results rather than absorbed:**
+
+1. **F59 is a defect the plan did not anticipate**, found by a test written for *density* rather than presence.
+   `pinned_settings.json` is missing `MaxDistortion`, `StarCenterTolerance`, `SaturationThreshold`,
+   `HotpixelThreshold` and `Sensitivity`. Waves 5–11 stay internally valid (all used the same file and the same
+   code defaults); what is false is that the file *describes* the detector.
+2. **The 39-run pass was dropped**, and what that costs is stated in the results (§5.6): no population
+   distribution for `WingRejectedRatio`.
+3. **`exe_fix2` exists** because F59 landed after `exe_fixed` was built. Per F53(c) an arm's directory is never
+   rebuilt, so a new one was made and K5/K7 were re-run on it — both reproduced exactly.
+
+---
+
 ## What would make this wave wrong, in one place
 
 - The pre-gate probe prints `astrodet` ⇒ §0.1's model is wrong and F58 does not get filed as written.


### PR DESCRIPTION
Design: `docs/synthetic-af-bank-followups-wave11-design.md` · Plan: `plans/synthetic-af-bank-followups-wave11-plan.md` · Results: `docs/synthetic-af-bank-followups-wave11-results.md`

## The headline, and it cost zero compute

**F55 and F57 are the same defect.** Concurrent `optimize` processes each acquire a **different NINA profile**, and the fit reads four values from it. The two "attractors" F55 chased as a floating-point race for two waves are two values of `AutoFocusOptions.MaxOutlierRejections`.

It was found in a `Profile:` line `optimize` had been printing since before wave 9, sitting in `D:\hf_w9\det\C_*.log`:

- `Profile.Load` holds the `.profile` open (`FileShare.Read`); a second process's load throws, `SelectProfile` returns false, and `TryLoad`'s `SkipWhile` **silently takes the next profile by `LastUsed`**.
- `Profile.Load` also stamps `LastUsed` and saves — so **a pinned run rewrites the default for the next unpinned one**. Measured: an unpinned run today loads `Default` and returns wave 9's `toml999` value, not wave 10's.
- Wave 9's own probe logs partition `J` **5 of 5** on `MaxOutlierRejections`; its four-way concurrent control loaded four different profiles and explains the one anomaly F55 had to hedge about.

## Every pre-registered clause, and all of them returned

| clause | verdict |
|---|---|
| **RULE G11** — the wave's only pass/fail gate | **PASS 8/8** to 6 dp; all eight `BaselineJ` reproduce wave 10 |
| **K1–K4** | **PASS** — 5 concurrent → 5 profiles; `J` splits 2/3 on `MaxOutlierRejections` into wave 9's two attractors to 16 dp; pinned+concurrent fails **loudly** (1 success, 4 hard failures) |
| **K5** | **PASS** — five different profiles, **one** `BaselineJ`. The hazard is intact; it no longer reaches `J` |
| **K7** | **PASS** — two profiles, identical `BaselineJ` to full double precision, where they differed by **0.0144** |
| **RULE C** (C0/C1/C3 PASS, C2 SINGLE-FIELD) | one integer accounts for **100 %** of the 0.0144, **residue exactly `0.0`** — with the negative control passing |
| **RULE W** | **no satisfying threshold.** F19's successor is refuted before implementation |
| **K8** | **PASS 8/8, BIT-IDENTICAL to all 16 digits** on a different binary and settings file |
| suite | **3740 passed, 0 failed** (`develop` 3722 → +18, every one named) |

## What ships

- **`AutoFocusOptions` now reads the HARNESS accessor**, so `--settings` pins the fit as well as the detector. The live wizard and AF engine still read the profile — there these *are* the user's settings.
- **`FitInputs` on every landing** — values, not a hash, so a reader sees *which* one moved.
- **F59 (new, fixed)**: the export dropped every knob whose setter validates. `pinned_settings.json` is missing `MaxDistortion`, `StarCenterTolerance`, `SaturationThreshold`, `HotpixelThreshold`, `Sensitivity`. Waves 5–11 stay internally valid; what is false is that the file *describes* the detector. Found by a test written for **density**, not presence.
- **`WingRejectedRatio`** as a measurement only, four-state (`NaN` / `+∞` / `1.0` / the ratio). No verdict, threshold or action.
- `--cv-threads` with `Cv2.GetNumThreads()` always printed; the `--profile-id` run rule in `testapp-cli.md`.

## Not closed, and not to be read as closed

- **Fan-out is NOT authorised.** K5 is seed-level; F55's landing rate was 44 % and no landing-level fan-out was measured with the fix in.
- **Four other harness runners share F58's defect** — `BankVerifyRunner` (×2, feeds the golden audits), `SynthValidateRunner`, `InspectAlignRunner`, `TiltCalibrationRunner`. Flagged in F58(d), not converted.
- **The 39-run population pass was NOT run.** Item 3 fell to a *necessary* clause first, so it could not change the verdict, and W6 bars its rows from sizing the next candidate. **No 39-run distribution for `WingRejectedRatio` ships** — said here rather than left as a silently smaller pass.
- `KappaSigmaNoiseEstimate` is **withdrawn as F55's mechanism**. Its measured gain stays true; it was never evidence of causation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QTNWdSNar6g3Nj5wXnLZc6