### PR TITLE
Wave 12: fan-out authorised (and worth 25%), F58(d) closed, F19's remainder closed

### DIFF
--- a/.claude/docs/testapp-cli.md
+++ b/.claude/docs/testapp-cli.md
@@ -148,7 +148,29 @@ dir (or each per-run subfolder).
 >
 > Since wave 11 the harness reads the fit inputs from the **pinned settings file**, and every landing records
 > `ProfileId` **and** `FitInputs` (`MaxOutlierRejections=…;OutlierRejectionConfidence=…;…` — values, not a hash,
-> so a reader sees *which* one moved). Check `ConcurrencyCheck` in the landing before reading any arm.
+> so a reader sees *which* one moved). Since wave 12 **every** harness runner does — `bank-verify`,
+> `synth-validate`, `inspect-align` and `tilt` build their fit through
+> `HarnessSettingsStore.BuildFitOptions`, print `FitInputs`, and a unit test fails the build if any `TestApp`
+> source constructs `AutoFocusOptions` from the profile again.
+>
+> **`ConcurrencyCheck` MUST BE READ ACROSS A WHOLE ARM, NOT OFF ONE LANDING.** `WaitOne(0)` is won by exactly one
+> of *N* contenders, so in any fan-out precisely one landing truthfully reports `exclusive`. One `concurrent`
+> anywhere condemns the arm; one `exclusive` proves nothing.
+>
+> ### FAN-OUT: AUTHORISED AT DEGREE 4, UNPINNED ONLY — AND IT BUYS 25 %, NOT 4× (wave 12)
+>
+> Wave 12 ran the eight gate runs at **fan-out 4** with four workers on **four different profiles** split 4/4 on
+> `MaxOutlierRejections`, and all eight landings reproduced the sequential values **bit-identically** (F55's
+> RULE A12). So:
+>
+> - **Fan-out is authorised AT DEGREE 4.** Nothing was measured at 8 or 48.
+> - **UNPINNED only.** `--profile-id` + fan-out still fails loudly, so a fanned-out arm relies on `--settings`
+>   carrying the fit inputs. **An arm that needs a specific profile still runs sequentially.**
+> - **It buys 1.33×, not 4×** (F60). Every run takes 1.45–2.55× longer under contention because `optimize`
+>   already saturates the machine. **Sequential remains the default;** fan-out is for a pass long enough that
+>   25 % of the wall clock is worth losing `--profile-id`.
+> - **Re-snapshot the profile set before any fan-out arm.** The fall-through set is the top *N* by `LastUsed`,
+>   and every pinned run reorders it — including the gate you just ran.
 
 - **Run discovery is attempt-anchored** (pure logic in `OptimizationRunDiscovery`): it recursively finds
   `attempt<NN>` folders (1–4 levels under `--runs`) that contain ≥3 distinct focuser positions, mirroring

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/Harness/HarnessFitSeamTests.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/Harness/HarnessFitSeamTests.cs
@@ -1,0 +1,142 @@
+#region "copyright"
+
+/*
+    Copyright © 2021 - 2026 George Hilios <ghilios+NINA@googlemail.com>
+
+    This Source Code Form is subject to the terms of the Mozilla Public
+    License, v. 2.0. If a copy of the MPL was not distributed with this
+    file, You can obtain one at http://mozilla.org/MPL/2.0/.
+*/
+
+#endregion "copyright"
+
+using NINA.Joko.Plugins.HocusFocus.Interfaces;
+using NINA.Profile.Interfaces;
+using NSubstitute;
+using NUnit.Framework;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text.RegularExpressions;
+using TestApp;
+
+namespace NINA.Joko.Plugins.HocusFocus.Tests.Harness;
+
+/// <summary>
+/// F58(d) — the seam every harness runner must build its AF fit through, and the guard that says they all do.
+///
+/// <para><b>The defect these protect.</b> Each runner built <c>StarDetectionOptions</c> on the harness accessor —
+/// the pinned settings FILE — and then <c>new AutoFocusOptions(profileService)</c> two lines below it, binding the
+/// FIT to whichever NINA profile was ACTIVE. So <c>--settings</c> pinned the detector and left the fit floating.
+/// It is not academic: the machine that produced waves 5–11 holds nine profiles partitioning <b>2 / 7</b> on
+/// <c>MaxOutlierRejections</c>, and that one integer produced the two discrete values of <c>J</c> that were chased
+/// as a floating-point race for two waves.</para>
+///
+/// <para><b>Why a source guard and not only a contract test.</b> Wave 11 fixed <c>optimize</c> and left five call
+/// sites carrying the same defect, each looking locally correct. A rule enforced by remembering it is a rule that
+/// comes back; the ban is on the CONSTRUCTOR, so it holds for a site nobody has written yet.</para>
+/// </summary>
+[TestFixture]
+public class HarnessFitSeamTests {
+
+    /// <summary>
+    /// A single-argument <c>new AutoFocusOptions(x)</c>. The two-argument overload — the accessor-bound one — has
+    /// a comma, which is what separates the banned form from the required one.
+    /// </summary>
+    private const string SingleArgAutoFocusOptions = @"new\s+AutoFocusOptions\s*\(\s*[A-Za-z_][A-Za-z0-9_.]*\s*\)";
+
+    private static DirectoryInfo SolutionDirectory() {
+        var dir = new DirectoryInfo(AppContext.BaseDirectory);
+        while (dir != null && dir.GetDirectories("TestApp").Length == 0) {
+            dir = dir.Parent;
+        }
+        Assert.That(dir, Is.Not.Null, "Could not locate the solution directory from the test binaries.");
+        return dir;
+    }
+
+    private static FileInfo[] TestAppSources() {
+        var files = SolutionDirectory().GetDirectories("TestApp").Single()
+            .GetFiles("*.cs", SearchOption.AllDirectories)
+            .Where(f => !f.FullName.Contains($"{Path.DirectorySeparatorChar}bin{Path.DirectorySeparatorChar}")
+                     && !f.FullName.Contains($"{Path.DirectorySeparatorChar}obj{Path.DirectorySeparatorChar}"))
+            .ToArray();
+        // An ABSENT check is more dangerous than a red one (F37): a path walk that finds nothing must fail here
+        // rather than report a clean sweep of zero files.
+        Assert.That(files, Is.Not.Empty, "Found no sources under TestApp — the path walk is wrong, not the code.");
+        return files;
+    }
+
+    private static string StripComments(string source) {
+        var noBlock = Regex.Replace(source, @"/\*.*?\*/", string.Empty, RegexOptions.Singleline);
+        return Regex.Replace(noBlock, @"//[^\r\n]*", string.Empty);
+    }
+
+    [Test]
+    public void TheGuardsOwnPatternFiresOnTheBannedFormAndNotOnTheRequiredOne() {
+        // "What would this test do if the thing it checks were completely broken?" — wave 10 asked that of a trace
+        // differ and the answer was "exactly the same thing". A source guard whose regex has rotted reports a clean
+        // sweep, which is the most expensive way for a test to pass. So the pattern is exercised in BOTH directions
+        // here, on literals, before it is trusted against the tree.
+        Assert.Multiple(() => {
+            Assert.That(Regex.IsMatch("var o = new AutoFocusOptions(profileService);", SingleArgAutoFocusOptions), Is.True,
+                "the guard's pattern no longer matches the banned single-argument form — it would sweep clean while the defect is present");
+            Assert.That(Regex.IsMatch("var o = new AutoFocusOptions(profileService, accessor);", SingleArgAutoFocusOptions), Is.False,
+                "the guard's pattern matches the REQUIRED accessor-bound form, so it cannot distinguish the fix from the defect");
+            Assert.That(Regex.IsMatch("var o = HarnessSettingsStore.BuildFitOptions(profileService, harnessSettings);", SingleArgAutoFocusOptions), Is.False);
+        });
+    }
+
+    [Test]
+    public void NoHarnessRunnerBuildsItsFitFromTheActiveProfile() {
+        var offenders = TestAppSources()
+            .Where(f => Regex.IsMatch(StripComments(File.ReadAllText(f.FullName)), SingleArgAutoFocusOptions))
+            .Select(f => f.Name)
+            .OrderBy(n => n, StringComparer.Ordinal)
+            .ToArray();
+
+        Assert.That(offenders, Is.Empty,
+            $"{string.Join(", ", offenders)} build AutoFocusOptions from the ACTIVE NINA profile. A harness runner's fit " +
+            "must come from the pinned settings file: call HarnessSettingsStore.BuildFitOptions. (HocusFocusPlugin.cs is " +
+            "NOT in this project and is deliberately exempt — in the live app the profile IS the user's settings.)");
+    }
+
+    // ---- the seam's own contract ------------------------------------------------------------------------------
+
+    private static HarnessSettingsStore.Resolved ResolvedOver(params (string Key, string Value)[] pairs) {
+        var bag = new Dictionary<string, string>();
+        foreach (var (k, v) in pairs) {
+            bag[k] = v;
+        }
+        return new HarnessSettingsStore.Resolved { Accessor = new HarnessSettingsStore.FileOptionsAccessor(bag) };
+    }
+
+    [Test]
+    public void BuildFitOptions_ReadsTheFILE_OnAllFourAxes() {
+        var options = HarnessSettingsStore.BuildFitOptions(Substitute.For<IProfileService>(), ResolvedOver(
+            ("MaxOutlierRejections", "0"),
+            ("OutlierRejectionConfidence", "0.99"),
+            ("WeightedHyperbolicFitEnabled", "False"),
+            ("HyperbolicFitModel", "TiltedHyperbola")));
+
+        var inputs = HarnessFitInputs.From(options);
+        Assert.Multiple(() => {
+            Assert.That(inputs.MaxOutlierRejections, Is.EqualTo(0));
+            Assert.That(inputs.RejectionConfidence, Is.EqualTo(0.99).Within(1e-12));
+            Assert.That(inputs.UseWeights, Is.False);
+            Assert.That(inputs.PreferredModel, Is.EqualTo(HyperbolicFitModel.TiltedHyperbola));
+        });
+    }
+
+    [Test]
+    public void BuildFitOptions_RefusesToFallBackToTheProfile() {
+        // The failure this forbids is the SILENT one: a caller with no resolved settings getting a profile-backed
+        // fit and a run that looks pinned. Throwing is the only reading that cannot be mistaken for a pinned run.
+        Assert.Multiple(() => {
+            Assert.Throws<ArgumentNullException>(() =>
+                HarnessSettingsStore.BuildFitOptions(Substitute.For<IProfileService>(), null));
+            Assert.Throws<ArgumentNullException>(() =>
+                HarnessSettingsStore.BuildFitOptions(Substitute.For<IProfileService>(), new HarnessSettingsStore.Resolved()));
+        });
+    }
+}

--- a/Joko.NINA.Plugins/TestApp/BankVerifyRunner.cs
+++ b/Joko.NINA.Plugins/TestApp/BankVerifyRunner.cs
@@ -157,7 +157,12 @@ namespace TestApp {
             var starDetectionOptions = new StarDetectionOptions(profileService, harnessSettings.Accessor);
             var accessor = harnessSettings.Accessor;
             var inspectorOptions = new InspectorOptions(profileService);
-            var autoFocusOptions = new AutoFocusOptions(profileService);
+            // F58(d): the pinned settings FILE, not the active profile. `bank-verify` fits an AF curve per run and
+            // its recall/precision numbers underpin the golden audits, so two results measured under different
+            // profiles were never comparable -- MaxOutlierRejections alone partitions this machine's profiles 2/7,
+            // and concurrent harness processes each silently acquire a different one.
+            var autoFocusOptions = HarnessSettingsStore.BuildFitOptions(profileService, harnessSettings);
+            var fitInputs = HarnessFitInputs.From(autoFocusOptions);
             const int binning = 1;
             // The pre-V-P1 bank-wide value: one profile-derived scale for every run. Still computed unconditionally
             // because it is both the "profile" mode's value AND the fallback "header" mode falls back to when a
@@ -183,6 +188,11 @@ namespace TestApp {
                 + $"adaptiveBinarize={EffectiveAdaptiveBinarize(adaptiveBinarizeOverride)}"
                 + (adaptiveBinarizeOverride.HasValue ? " (forced)" : " (shipped default)")
                 + $"(block={adaptiveBlockSize})");
+            // F58(d): VALUES, not a hash. A hash says something moved; these say which one. Two bank-verify
+            // results measured under different fit inputs are not comparable, and until this line existed there
+            // was no way to tell from the output that they differed.
+            Console.WriteLine($"Profile: {activeProfile.Name} ({activeProfile.Id})");
+            Console.WriteLine($"FitInputs: {fitInputs}");
 
             var runResults = new List<RunResult>();
             int idx = 0;
@@ -204,7 +214,8 @@ namespace TestApp {
 
             var utc = DateTime.UtcNow.ToString("yyyyMMddTHHmmssZ", CultureInfo.InvariantCulture);
             WriteReport(outDir, utc, commit, ncSweep, runResults,
-                EffectiveAdaptiveBinarize(adaptiveBinarizeOverride), adaptiveBinarizeOverride.HasValue, adaptiveBlockSize, pixelScaleMode);
+                EffectiveAdaptiveBinarize(adaptiveBinarizeOverride), adaptiveBinarizeOverride.HasValue, adaptiveBlockSize, pixelScaleMode,
+                fitInputs.ToString(), $"{activeProfile.Name} ({activeProfile.Id})");
             Console.WriteLine($"bank-verify: wrote verification_{utc}.{{json,md}} to {outDir} ({runResults.Count(r => r.error == null)} ok, {runResults.Count(r => r.error != null)} failed).");
         }
 
@@ -352,7 +363,7 @@ namespace TestApp {
                 }
                 p.AdaptiveNoiseBlockSize = adaptiveBlockSize;
                 var cm = await ScoreConfigAsync($"C0@nc{nc:0.#}", nc, false, p, evalData, loaded, goldenByFocuser, truthByFocuser, effectiveMatchRadius,
-                    inspectorOptions, alglib, profileService, activeProfile, stepSize, detector);
+                    inspectorOptions, alglib, profileService, activeProfile, stepSize, detector, afOptions);
                 rr.configs.Add(cm);
                 Console.WriteLine($"    {cm.config}: recall@high={Fmt(cm.recallHigh)} prec={Fmt(cm.precision)} σ={Fmt(cm.sigmaFocus)} sR²={Fmt(cm.sR2)} aligned={cm.framesAligned}/{loaded.Count}");
             }
@@ -363,7 +374,7 @@ namespace TestApp {
                 var p = BaseDefault();
                 OverlayOptimized(p, aSettings, forceDonutMaster: false);
                 var cm = await ScoreConfigAsync("A", p.NoiseClippingMultiplier, p.DefocusAwareDonutDetection, p, evalData, loaded, goldenByFocuser, truthByFocuser, effectiveMatchRadius,
-                    inspectorOptions, alglib, profileService, activeProfile, stepSize, detector);
+                    inspectorOptions, alglib, profileService, activeProfile, stepSize, detector, afOptions);
                 cm.sensitivity = p.Sensitivity;
                 rr.configs.Add(cm);
                 Console.WriteLine($"    A (opt donutOFF, NC→{Fmt(cm.nc)}): recall@high={Fmt(cm.recallHigh)} prec={Fmt(cm.precision)} σ={Fmt(cm.sigmaFocus)} sR²={Fmt(cm.sR2)}");
@@ -375,7 +386,7 @@ namespace TestApp {
                 var p = BaseDefault();
                 OverlayOptimized(p, bSettings, forceDonutMaster: true);
                 var cm = await ScoreConfigAsync("B", p.NoiseClippingMultiplier, true, p, evalData, loaded, goldenByFocuser, truthByFocuser, effectiveMatchRadius,
-                    inspectorOptions, alglib, profileService, activeProfile, stepSize, detector);
+                    inspectorOptions, alglib, profileService, activeProfile, stepSize, detector, afOptions);
                 cm.sensitivity = p.Sensitivity;
                 rr.configs.Add(cm);
                 Console.WriteLine($"    B (opt donutON, NC→{Fmt(cm.nc)}): recall@high={Fmt(cm.recallHigh)} prec={Fmt(cm.precision)} σ={Fmt(cm.sigmaFocus)} sR²={Fmt(cm.sR2)}");
@@ -398,7 +409,7 @@ namespace TestApp {
             List<(int focuser, string path, IRenderedImage image)> loaded, Dictionary<int, GoldenFrame> goldenByFocuser,
             Dictionary<int, IReadOnlyList<SyntheticStarDisposition>> truthByFocuser, double matchRadius,
             InspectorOptions inspectorOptions, AlglibAPI alglib, ProfileService profileService, NINA.Profile.Interfaces.IProfile activeProfile, int stepSize,
-            StarDetector detector) {
+            StarDetector detector, AutoFocusOptions afOptions) {
 
             // effectiveSensitivity is set HERE, from the same params the config is scored with, so C0/A/B all get it
             // from one place (the A/B call sites re-stamp `sensitivity` afterwards; the effective gate must not
@@ -515,7 +526,10 @@ namespace TestApp {
                 var pixelSize = activeProfile.CameraSettings.PixelSize > 0 ? activeProfile.CameraSettings.PixelSize : 3.76;
                 var sortedFoc = loaded.Select(l => (double)l.focuser).OrderBy(x => x).ToList();
                 var finalFocus = sortedFoc[sortedFoc.Count / 2];
-                var sensorModel = new SensorModel(profileService, inspectorOptions, new AutoFocusOptions(profileService), new AlglibAPI());
+                // F58(d): the run's own pinned fit options, not a second profile-backed instance. This was the
+                // SECOND construction site in this file, and it fed the SENSOR model -- so the tilt fit was taking
+                // its outlier-rejection budget from whichever profile happened to be active.
+                var sensorModel = new SensorModel(profileService, inspectorOptions, afOptions, new AlglibAPI());
                 SensorParaboloidModel fit = null;
                 try {
                     (fit, _) = sensorModel.RegisterStarsAndFit(sensorFrames, imageSize, focuserSizeMicrons, finalFocus, pixelSize,
@@ -597,7 +611,8 @@ namespace TestApp {
         // ---- report ----------------------------------------------------------------------------------------------
 
         private static void WriteReport(string outDir, string utc, string commit, double[] ncSweep, List<RunResult> runs,
-            bool adaptiveBinarizeEffective, bool adaptiveBinarizeForced, int adaptiveBlockSize, string pixelScaleMode) {
+            bool adaptiveBinarizeEffective, bool adaptiveBinarizeForced, int adaptiveBlockSize, string pixelScaleMode,
+            string fitInputs, string profileId) {
             var ok = runs.Where(r => r.error == null && r.configs != null && r.configs.Count > 0).ToList();
             // Read from the product rather than hardcoded — see the json block below for why (9a80324/c59a4b1).
             var noiseClipDefault = HocusFocusStarDetection.BuildDefaultStarDetectorParams().NoiseClippingMultiplier;
@@ -667,6 +682,12 @@ namespace TestApp {
                 c0AdaptiveBinarization = adaptiveBinarizeEffective,
                 c0AdaptiveBinarizationForced = adaptiveBinarizeForced,
                 c0AdaptiveNoiseBlockSize = adaptiveBlockSize,
+                // F58(d): the four values that reach the AF fit, and the profile the run loaded. Recorded as
+                // VALUES so a reader can diff a field rather than infer which machine state produced a number --
+                // the whole class of defect F58 named. `fitInputs` now comes from the pinned settings FILE, so
+                // two reports with the same string are comparable regardless of which profile was active.
+                fitInputs,
+                profileId,
                 ncSweep,
                 runCount = ok.Count,
                 failed = runs.Count(r => r.error != null),

--- a/Joko.NINA.Plugins/TestApp/HarnessSettingsStore.cs
+++ b/Joko.NINA.Plugins/TestApp/HarnessSettingsStore.cs
@@ -237,6 +237,33 @@ namespace TestApp {
         }
 
         /// <summary>
+        /// The ONE place a harness runner builds <see cref="NINA.Joko.Plugins.HocusFocus.AutoFocus.AutoFocusOptions"/>
+        /// — bound to the pinned settings FILE, never to the active NINA profile.
+        ///
+        /// <para><b>F58(d).</b> Every harness runner built <c>StarDetectionOptions</c> on this accessor and then
+        /// <c>new AutoFocusOptions(profileService)</c> two lines below it, so the DETECTOR was pinned by
+        /// <c>--settings</c> and the FIT was not. Four of <c>AutoFocusOptions</c>' values reach the AF fit, this
+        /// machine's nine profiles partition <b>2 / 7</b> on <c>MaxOutlierRejections</c> alone, and because NINA
+        /// holds a <c>.profile</c> open while it is loaded (and <c>TryLoad</c> silently skips a locked one for the
+        /// next by <c>LastUsed</c>), concurrent harness processes each acquire a DIFFERENT profile. Wave 11 fixed
+        /// <c>optimize</c>; the other five call sites kept the defect for a wave because each owed its own
+        /// validation.</para>
+        ///
+        /// <para><b>A helper rather than five copies of one line</b>, for the same reason
+        /// <see cref="HarnessFitInputs"/> is one type used both to build the fit and to render the provenance
+        /// field: a rule enforced in five places is a rule that comes back. The sixth construction site —
+        /// <c>HocusFocusPlugin.cs</c> — deliberately does NOT call this and must not: in the live app the profile
+        /// IS the user's settings.</para>
+        /// </summary>
+        internal static NINA.Joko.Plugins.HocusFocus.AutoFocus.AutoFocusOptions BuildFitOptions(
+            IProfileService profileService, Resolved resolved) {
+            if (resolved?.Accessor == null) {
+                throw new ArgumentNullException(nameof(resolved), "A harness runner must build its fit from RESOLVED settings, not from the active profile (F58(d)).");
+            }
+            return new NINA.Joko.Plugins.HocusFocus.AutoFocus.AutoFocusOptions(profileService, resolved.Accessor);
+        }
+
+        /// <summary>
         /// Stable fingerprint of the settings a run was ACTUALLY driven by (F30): the resolved pixel-scale inputs
         /// plus the settings file's own contents. Hashes the file's SEMANTIC content, not its bytes — a settings
         /// file that is re-exported or re-indented must not make a landing look as though it came from a different

--- a/Joko.NINA.Plugins/TestApp/InspectAlignRunner.cs
+++ b/Joko.NINA.Plugins/TestApp/InspectAlignRunner.cs
@@ -100,7 +100,10 @@ namespace TestApp {
             var harnessSettings = HarnessSettingsStore.Resolve(args, profileService, activeProfile);
             var starDetectionOptions = new StarDetectionOptions(profileService, harnessSettings.Accessor);
             var inspectorOptions = new InspectorOptions(profileService);
-            var autoFocusOptions = new AutoFocusOptions(profileService);
+            // F58(d): the pinned settings FILE, not the active profile -- the detector was pinned one line above
+            // and the FIT was not, which is the asymmetry F58 named in `optimize`.
+            var autoFocusOptions = HarnessSettingsStore.BuildFitOptions(profileService, harnessSettings);
+            Console.WriteLine($"FitInputs: {HarnessFitInputs.From(autoFocusOptions)}");
 
             // Detection params = the inspector's region-6 path: the single options->params source of truth, full
             // sensor (region 6 at SensorROI=1.0), ModelPSF OFF (the AF engine sets isAutoFocus=true). NumberOfAFStars

--- a/Joko.NINA.Plugins/TestApp/SynthValidateRunner.cs
+++ b/Joko.NINA.Plugins/TestApp/SynthValidateRunner.cs
@@ -240,7 +240,9 @@ namespace TestApp.SynthBank {
             // HarnessSettingsStore's remarks) -- the profile is only used for image loading (FITS.Load needs one).
             var harnessSettings = HarnessSettingsStore.Resolve(args, profileService, activeProfile);
             var starDetectionOptions = new StarDetectionOptions(profileService, harnessSettings.Accessor);
-            var afOptions = new AutoFocusOptions(profileService);
+            // F58(d): the pinned settings FILE, not the active profile -- the detector was pinned one line above
+            // and the FIT was not, which is the asymmetry F58 named in `optimize`.
+            var afOptions = HarnessSettingsStore.BuildFitOptions(profileService, harnessSettings);
             var alglibAPI = new AlglibAPI();
             var detection = new HocusFocusStarDetection(
                 imageStatisticsVM: null,
@@ -267,13 +269,18 @@ namespace TestApp.SynthBank {
             Prog($"synth-validate: spec={specPath} (sha256={specSha256.Substring(0, 12)}…) " +
                 $"datasets={selectedDatasets.Count}/{spec.Datasets.Count} scenarios=[{string.Join(",", selectedScenarios.Select(s => s.Id))}] " +
                 $"maxRounds={maxRounds} maxEvals={(maxEvals?.ToString(CultureInfo.InvariantCulture) ?? "default")} out={outRoot}");
+            // F58(d): VALUES, not a hash — a hash says something moved, these say which one.
+            var fitInputs = HarnessFitInputs.From(afOptions).ToString();
+            Prog($"synth-validate: Profile: {activeProfile.Name} ({activeProfile.Id})  FitInputs: {fitInputs}");
 
             var report = new SynthValidationReport {
                 SpecPath = specPath,
                 SpecSha256 = specSha256,
                 OutDir = outRoot,
                 MaxRounds = maxRounds,
-                MaxEvals = maxEvals
+                MaxEvals = maxEvals,
+                FitInputs = fitInputs,
+                ProfileId = $"{activeProfile.Name} ({activeProfile.Id})"
             };
             var jsonPath = Path.Combine(outRoot, "synth_validate_report.json");
             var mdPath = Path.Combine(outRoot, "synth_validate_report.md");

--- a/Joko.NINA.Plugins/TestApp/SynthValidationReport.cs
+++ b/Joko.NINA.Plugins/TestApp/SynthValidationReport.cs
@@ -212,6 +212,17 @@ namespace TestApp.SynthBank {
         [JsonProperty("outDir")] public string OutDir { get; set; }
         [JsonProperty("maxRounds")] public int MaxRounds { get; set; }
         [JsonProperty("maxEvals")] public int? MaxEvals { get; set; }
+
+        /// <summary>
+        /// F58(d) — the four values that reach the AF fit, as VALUES rather than a hash, and the profile the run
+        /// loaded. Until wave 12 this runner built <c>AutoFocusOptions</c> from whichever NINA profile was ACTIVE
+        /// while pinning the detector from the settings file, so two reports could differ on
+        /// <c>MaxOutlierRejections</c> with nothing in either saying so.
+        /// </summary>
+        [JsonProperty("fitInputs")] public string FitInputs { get; set; }
+
+        [JsonProperty("profileId")] public string ProfileId { get; set; }
+
         [JsonProperty("datasets")] public List<DatasetValidationReport> Datasets { get; set; } = new List<DatasetValidationReport>();
     }
 

--- a/Joko.NINA.Plugins/TestApp/TiltCalibrationRunner.cs
+++ b/Joko.NINA.Plugins/TestApp/TiltCalibrationRunner.cs
@@ -175,7 +175,10 @@ namespace TestApp {
             var harnessSettings = HarnessSettingsStore.Resolve(args, profileService, activeProfile);
             var accessor = harnessSettings.Accessor;
             var starDetectionOptions = new StarDetectionOptions(profileService, accessor);
-            var afOptions = new AutoFocusOptions(profileService);
+            // F58(d): the pinned settings FILE, not the active profile -- the detector was pinned one line above
+            // and the FIT was not, which is the asymmetry F58 named in `optimize`.
+            var afOptions = HarnessSettingsStore.BuildFitOptions(profileService, harnessSettings);
+            Console.WriteLine($"FitInputs: {HarnessFitInputs.From(afOptions)}");
             var inspectorOptions = new InspectorOptions(profileService);
             var alglibAPI = new AlglibAPI();
             // The plugin's OWN detection facade, so this harness drives the wizard's split detector (and its

--- a/docs/followups.md
+++ b/docs/followups.md
@@ -658,7 +658,11 @@ recorded as owed, and is WITHDRAWN · AND THE SUCCESSOR IS REFUTED TOO (wave 11)
 RULE W2 on the exposure ladder: `D16` at 2 s has an inner rejected fraction of EXACTLY 0.000, so the ratio is
 INFINITE and fires where more exposure is measurably wrong. NO THRESHOLD SATISFIES RULE W.** The gate-floor
 THEOREM stands; `WingRejectedFraction` AND `WingRejectedRatio` both stay as measurements with no verdict
-attached; `WingRejectedExcess` = wing - inner is named as the next candidate and deliberately not evaluated
+attached ·
+**THE REMAINDER IS CLOSED (wave 12): `WingRejectedExcess` = wing − inner is REFUTED on a fresh ladder it had not
+seen, by W1 AND W2 AND W5, on three datasets independently and in both directions — and it is
+ANTI-CORRELATED with what it exists to predict (Spearman ρ = −0.665 over 13 rungs). NO STATISTIC OVER GATE
+REJECTIONS SEPARATES A STARVED WING FROM A DETECTOR THAT REJECTS NOISE EVERYWHERE.**
 · found 2026-08-02 deriving expected-optimal exposures for the synthetic AF bank
 
 `ExposureRecommender`'s `S_now` is the median, across non-recovery frames, of each frame's
@@ -1030,6 +1034,64 @@ derived-exposure rung on either dataset, this entry REOPENS.**
 > pass: the refutation came on a NECESSARY clause, so the pass could not have changed the verdict, and W6 bars
 > its rows from sizing the next candidate. **This wave therefore publishes no 39-run distribution for the ratio.**
 > Reproduce: `D:\hf_w11\pop\ladder_w11.sh`, `D:\hf_w11\pop\ladder_score.txt`, `D:\hf_w11\pop\score_wing_pop_w11.py`.
+
+> ## THE REMAINDER IS CLOSED (2026-08-09, wave 12). THE THIRD STATISTIC IS REFUTED, AND IT POINTS THE WRONG WAY.
+>
+> `WingRejectedExcess` = wing − inner got its own arm on a ladder neither prior refutation had touched: three
+> datasets the wing statistics had never laddered — `D17_cdk14_oiii5` (genuinely OIII-starved), `D20_m24_bright_control`
+> (a known inner-fraction-exactly-0.000 instance) and `D05_tec140_1000mm` (mid-population) — freshly rendered at
+> **0.5 / 2 / 8 / 30 / 120 s**, pinned provenance, `--max-evals 120`. W6 satisfied: the 39-run population killed
+> the fraction and wave 7's `D02`/`D16` ladder killed the ratio, and neither was used here.
+>
+> **The threshold window is empty by a wide margin, and three datasets empty it independently:**
+>
+> | clause | dataset | measured | implies |
+> |---|---|---|---|
+> | **W1** the most-starved rung must FIRE | `D17`@8 s — σ_focus **19.3× worse** than its own optimum | excess **exactly 0.000000** | **T ≤ 0** |
+> | **W2** SILENT at the σ_focus minimum | `D05`@8 s | excess **0.861389** | T > 0.861 |
+> | **W2** SILENT at the σ_focus minimum | `D20`@0.5 s (σ_focus 0.00823 — the best focus on the ladder) | excess **0.246027** | T > 0.246 |
+> | **W1** | `D05`@2 s — 3.1× worse | excess 0.521251 | T ≤ 0.521 |
+> | **W5** above the excess's own bank median | 39 population runs, recomputed offline | 0.088948 | T > 0.0889 |
+>
+> **`D05` contradicts itself on its own two clauses** (W1 needs T ≤ 0.521, W2 needs T > 0.861), so no threshold
+> works even on a single dataset.
+>
+> ### And the arithmetic is not the finding — the DIRECTION is
+>
+> Over all **13 usable rungs**, against how bad the focus is (σ_focus ÷ that dataset's own best):
+> **Spearman ρ(focus badness, excess) = −0.665.** A statistic meant to say *"your wings are starved, expose
+> longer"* must be POSITIVE. **It is at its maximum where focus is best and exactly zero where focus is 19×
+> worse than it needs to be.**
+>
+> `D17` is the sharpest case and it is this entry's own poster child: a 5 nm OIII field that genuinely IS
+> photon-starved, whose σ_focus improves **19-fold** from 8 s to 120 s. **At 8 s its wings and its core reject at
+> identical rates — both exactly 0.0000.** At 0.5 s and 2 s the detector finds ZERO stars on some frame, so the
+> statistic is `NaN` ("could not look") rather than silent.
+>
+> ### So the remainder closes, and against a FOURTH candidate rather than only the third
+>
+> | statistic | refuted by | on |
+> |---|---|---|
+> | `WingRejectedFraction` (absolute) | RULE P — 76.9 % fire rate | 39-run population (wave 10) |
+> | `WingRejectedRatio` (wing ÷ inner) | RULE W2 — `D16`@2 s is `+∞` at its σ minimum | wave 7's ladder (wave 11) |
+> | `WingRejectedExcess` (wing − inner) | RULE W1 ∧ W2 ∧ W5, three datasets, ρ = −0.665 | a fresh 3×5 ladder (wave 12) |
+>
+> **NO STATISTIC OVER GATE REJECTIONS SEPARATES A STARVED WING FROM A DETECTOR THAT REJECTS NOISE EVERYWHERE**,
+> and ρ = −0.665 says why it is not a property of the arithmetic: **gate rejections count what the detector THREW
+> AWAY, and a starved frame's problem is what it never FOUND.** A fourth function of the same quantity would
+> inherit the same blindness. Anyone re-opening this must bring a different QUANTITY, not a different formula —
+> and the obvious one is what the faint end's SNR distribution does with exposure, which is not a rejection count.
+>
+> **What ships: nothing.** No verdict, threshold, probe factor or action. `WingRejectedFraction` and
+> `WingRejectedRatio` remain measurements with no consumer.
+>
+> **W1 was WEAKENED before the data, not after.** The first draft required firing on EVERY materially-worse rung
+> short of the optimum; wave 9's rule named exactly one per dataset, so the draft would have held the third
+> candidate to a bar neither predecessor had to clear. It was corrected and committed before the ladder rendered
+> a frame — and the excess then failed the WEAKER rule by `T ≤ 0` against `T > 0.861`, so the distinction changed
+> nothing. *Which is the point: that cannot be known in advance, which is why the rule moves before the data.*
+> Reproduce: `D:\hf_w12\ladder_w12.sh`, `D:\hf_w12\score_excess_w12.py`, `D:\hf_w12\ladder_score.txt`,
+> `D:\hf_w12\ladder_corr.txt`.
 
 > ## (c) RESOLVED 2026-08-07 (wave 9): THE FLOOR STAYS, THE CEILING STAYS, AND NOTHING RE-RENDERS
 >
@@ -3507,6 +3569,94 @@ result is the argument against assuming any build-level change helps — the sta
 instruction width, so wider vectors have nothing to recover. Establish the bottleneck by measurement before
 buying or building anything.
 
+### F61 — F58(d)'s real consumer was the SENSOR MODEL, not the AF fit: the per-star paraboloid's rejection budget came from the active profile
+**Status:** **Fixed (wave 12)** for every harness runner · found 2026-08-09 by RULE B12-D, **the control written
+to prove the fix was a no-op** · **the numbers it moved are TILT numbers**
+
+Wave 12 converted the five remaining `new AutoFocusOptions(profileService)` sites
+([F58](#f58--concurrent-optimize-processes-each-acquire-a-different-nina-profile-and-the-profile-decides-the-fit-f55s-two-attractors-are-two-values-of-maxoutlierrejections)(d))
+and then asked the discriminating question: **does switching the profile still move anything?** Three real-bank
+runs, the same pinned settings file, scored under `astrodet` (`MaxOutlierRejections` = 0) and under `Default`
+(= 1), on the pre- and post-conversion binaries:
+
+| binary | scored quantities that MOVED between the two profiles |
+|---|---|
+| pre-conversion | **15 of 24** |
+| post-conversion | **0 of 24** |
+
+**And `sigmaFocus` — the AF fit, the thing everyone assumed was at risk — never moved on any of the three runs.**
+What moved was the sensor model:
+
+| run | quantity | `astrodet` | `Default` | |
+|---|---|---|---|---|
+| `toml999` | `sStars` | 613 | **616** | stars admitted to the paraboloid |
+| | `sR2` | 0.14883143 | **0.14580555** | |
+| `muggsie` | `sTheta` | 0.12407606 | **0.11525545** | **tilt θ, 7.6 % apart** |
+| | `sRMS` | 6.7519583 | **6.7712252** | |
+| `mccomiskey` | `sStars` | 2800 | **2856** | |
+| | `sChi` | 0.11344971 | **0.12177990** | |
+
+**The mechanism is one read.** `SensorModel.cs:714–715` takes `MaxOutlierRejections` and
+`OutlierRejectionConfidence` off `IAutoFocusOptions` for the **PER-STAR** curve fit, so the rejection budget
+decided *which stars produced a `SensorParaboloidDataPoint` at all* — and the surface fit, its R², its RMS and
+its **tilt angle** follow from that population.
+
+### Why this matters beyond the harness
+
+`BankVerifyRunner` was flagged in F58(d) as *"twice"*, and the second instance — the `SensorModel` construction —
+was treated as an afterthought. **It was the one that mattered.** `InspectAlignRunner` and
+`TiltCalibrationRunner` fit sensor models from the same options, so **every tilt number those harnesses produced
+before this commit carries an input nothing recorded**, and two such numbers measured under different active
+profiles were never comparable. The effect is small on R²/RMS and up to **7.6 % on θ** in this sample; it is not
+a claimed error bar on any specific published tilt result, and it is not retro-fitted to one either.
+
+**It also sharpens [F58](#f58--concurrent-optimize-processes-each-acquire-a-different-nina-profile-and-the-profile-decides-the-fit-f55s-two-attractors-are-two-values-of-maxoutlierrejections)'s
+own framing.** F58 called `AutoFocusOptions` "the four values that reach the AF **fit**". They reach the sensor
+model too, through a completely different consumer, and on `bank-verify` that consumer is the only one that was
+sensitive.
+
+### Next step
+
+(a) **When a tilt result must be compared across sessions, the comparison needs `FitInputs`** — now printed by
+every converted runner and stored in `bank-verify`'s and `synth-validate`'s reports.
+(b) **Not done, and priced:** re-running any historical tilt calibration under pinned fit inputs to see whether a
+published θ moves. Nothing currently depends on it, and the honest statement is that those numbers have an
+unrecorded input rather than a known error.
+Reproduce: `D:\hf_w12\bankverify_disc_w12.sh`, `D:\hf_w12\b12d_score.txt`.
+
+### F60 — Fan-out is now SAFE and it is barely worth doing: `optimize` already saturates the machine
+**Status:** Open (recorded as a standing cost fact) · found 2026-08-09 (wave 12) measuring the payoff of the
+authorisation the same arm had just granted
+
+Wave 12's RULE A12 authorised fan-out at degree 4 ([F55](#f55--optimize-is-not-reproducible-when-several-instances-run-at-once-and-the-seed-evaluation-is-what-moves)).
+The arm was justified on the grounds that it would make every future pass **~4× cheaper**. **It does not.**
+
+| | sequential | at fan-out 4 |
+|---|---|---|
+| the same eight runs, wall clock | **43 m 10 s** | **32 m 28 s** |
+| sum of per-run busy time | 43 m 10 s | **76 m 03 s** |
+
+**Speedup 1.33× — 25 % of the wall clock — and every individual run took 1.45–2.55× longer** (`toml999`
+1 m 58 s → 5 m 01 s; `D18` 6 m 36 s → 13 m 49 s). The optimize path is already multi-threaded across the whole
+machine (`Cv2.GetNumThreads()` = 48 here), so four processes **contend** rather than parallelise: the arm spent
+33 extra minutes of busy time to buy 11 minutes of wall clock.
+
+### What follows
+
+- **Sequential remains the DEFAULT.** Fan-out is for a pass long enough that 25 % is worth losing `--profile-id`
+  for (pinning and fan-out are still mutually exclusive — wave 11's K3).
+- **A 39-run population pass costs ~2 ¼ h, not ~45 m.** Any future plan budgeting from "4× cheaper" is wrong;
+  budget from this measurement.
+- **Degree 8 is not obviously better and was not measured.** With per-run inflation already at 1.45–2.55× at
+  degree 4, more workers plausibly buy nothing; if it matters, measure it rather than extrapolating.
+
+**Why it is filed rather than folded into the authorisation.** The two facts point in opposite directions and
+both are true: *fan-out is now safe, and it is barely worth doing.* A wave that records only the half that
+justified the work is how a project acquires a belief it never measured — which is the same failure as
+[F55](#f55--optimize-is-not-reproducible-when-several-instances-run-at-once-and-the-seed-evaluation-is-what-moves)'s
+own "a measured gain is not a measured cause", one level up in the planning rather than the analysis.
+Reproduce: `D:\hf_w12\gate_w12.log`, `D:\hf_w12\fanout_w12.log`.
+
 ### F59 — The settings export drops every knob whose setter VALIDATES, so `pinned_settings.json` has been missing five detector knobs since wave 5
 **Status:** **Fixed (wave 11)** · found 2026-08-08 by a unit test written for
 [F58](#f58--concurrent-optimize-processes-each-acquire-a-different-nina-profile-and-the-profile-decides-the-fit-f55s-two-attractors-are-two-values-of-maxoutlierrejections)'s
@@ -3710,6 +3860,14 @@ returns ONE value **while still loading five different profiles** — a fix that
 pass a weaker test and prove nothing.
 (c) **Then say what is left.** `KappaSigmaNoiseEstimate`'s measured gain (F55) stays as a fact about the
 function; it is withdrawn only as *this* defect's explanation, and only once the residual check has run.
+(d) ~~**FOUR OTHER HARNESS RUNNERS HAVE THE SAME DEFECT AND ARE NOT FIXED HERE**~~ — **DONE 2026-08-09
+(wave 12): all five remaining call sites converted, behind ONE seam
+(`HarnessSettingsStore.BuildFitOptions`) with a source guard on the CONSTRUCTOR so it holds for a site nobody has
+written yet. Validated by RULE B12 (692 leaf values identical) AND its discriminating half RULE B12-D (the
+profile moved 15 of 24 scored quantities BEFORE the conversion and 0 of 24 after). AND IT WAS THE SENSOR MODEL,
+NOT THE AF FIT — see
+[F61](#f61--f58ds-real-consumer-was-the-sensor-model-not-the-af-fit-the-per-star-paraboloids-rejection-budget-came-from-the-active-profile).**
+The original text, for the record:
 (d) **FOUR OTHER HARNESS RUNNERS HAVE THE SAME DEFECT AND ARE NOT FIXED HERE**, flagged rather than swept in
 because each needs its own validation and wave 11's budget went to `optimize`:
 `BankVerifyRunner` (twice — the recall/precision harness whose numbers feed the golden audits),
@@ -3805,6 +3963,10 @@ Reproduce: `D:\hf_w10\crossbuild_probe.sh`, `D:\hf_w10\crossbuild.log`, `D:\hf_w
 ### F55 — `optimize` is NOT reproducible when several instances run at once, and the SEED evaluation is what moves
 **Status:** Open · found 2026-08-07 (wave 9) when the confirmation arm's own pre-registered control fired ·
 **this voids the wave-9 F32 arm and constrains every future arm's design** ·
+**CLOSED AT THE LANDING LEVEL 2026-08-09 (wave 12): eight landings at fan-out 4, with four workers on FOUR
+DIFFERENT PROFILES split 4/4 on `MaxOutlierRejections`, reproduced the sequential values BIT-IDENTICALLY.
+FAN-OUT IS AUTHORISED AT DEGREE 4 — and it buys only 1.33×, see
+[F60](#f60--fan-out-is-now-safe-and-it-is-barely-worth-doing-optimize-already-saturates-the-machine).** ·
 **MECHANISM IDENTIFIED 2026-08-08 (wave 11): the concurrent processes were running under DIFFERENT NINA
 PROFILES, and the two attractors are two values of `AutoFocusOptions.MaxOutlierRejections` —
 [F58](#f58--concurrent-optimize-processes-each-acquire-a-different-nina-profile-and-the-profile-decides-the-fit-f55s-two-attractors-are-two-values-of-maxoutlierrejections).
@@ -4052,6 +4214,35 @@ Reproduce: `D:\hf_w9\f32_arms.log`, `D:\hf_w9\score_f32.py`, `D:\hf_w9\ctl_seq_t
 > `"0\n0"`, the numeric comparison errored, and the guard fell through reporting SAFE unconditionally. It was
 > then re-validated against a positive control — a deliberately-started `optimize` — before being trusted, which
 > is the check the wave-9 lesson asks for and which the first version would have failed.)*
+
+> ### CLOSED AT THE LANDING LEVEL (2026-08-09, wave 12) — RULE A12, and the hazard was fully present
+>
+> Wave 11's K5 proved agreement at the **SEED** level only (`--max-evals 1`). This entry's headline number is a
+> **LANDING** rate of **44 %**, triple the seed rate, and nothing had measured landings under concurrency with
+> the fix in place. Wave 12 ran wave 9's arm A again — the eight gate runs, **at fan-out 4** — and required RULE
+> G12's eight values.
+>
+> | clause | verdict | evidence |
+> |---|---|---|
+> | **A1** the eight values to 6 dp | **PASS** | 8 of 8, and **bit-identical to all sixteen digits** |
+> | **A2** ≥2 profiles spanning both `MaxOutlierRejections` groups | **PASS** | **FOUR** distinct profiles; **4 runs at `MOR`=0, 4 at `MOR`=1** |
+> | **A3** the fan-out actually OVERLAPPED | **PASS** | exactly ONE `exclusive` per batch, three `concurrent` — what `WaitOne(0)` must produce at degree 4 |
+> | **A4** `FitInputs` identical on all eight | **PASS** | one distinct value across four different profiles |
+>
+> **A2 is the clause that makes this mean anything.** Four processes drew four different profiles and split 4/4
+> on the integer that used to decide `J` — **pre-fix these eight landings would have partitioned into two
+> groups.** The hazard was fully present and did not reach a single digit. At the measured 44 % per-run rate,
+> `P(8 of 8 | the defect is live) = 0.56⁸ ≈ 0.0097`.
+>
+> **THE AUTHORISATION AND ITS TWO LIMITS.** Fan-out is authorised **AT DEGREE 4**, and only **UNPINNED**:
+> `--profile-id` + fan-out still fails loudly (wave 11's K3), so a fanned-out arm relies on `--settings`
+> carrying the fit inputs. **An arm that needs a specific profile still runs sequentially.** Nothing here says
+> anything about degree 8 or 48.
+>
+> **And it is worth 1.33×, not 4× — see
+> [F60](#f60--fan-out-is-now-safe-and-it-is-barely-worth-doing-optimize-already-saturates-the-machine).**
+> Reproduce: `D:\hf_w12\fanout_w12.sh`, `D:\hf_w12\score_w12.py`, `D:\hf_w12\fanout_score.txt`,
+> `D:\hf_w12\profiles_before_w12.txt`.
 
 ### F54 — F39(b)'s default flip MOVES a landing at a resolved factor of 1, where it is documented as a no-op
 **Status:** Open · found 2026-08-07 (wave 9) chasing [F53](#f53--wave-8s-arm-x-does-not-reproduce-from-wave-8s-own-exe-because-the-arm-ran-on-an-earlier-build-of-it)'s

--- a/docs/synthetic-af-bank-followups-wave12-design.md
+++ b/docs/synthetic-af-bank-followups-wave12-design.md
@@ -1,0 +1,337 @@
+# Synthetic AF bank — followups wave 12 (design)
+
+Wave 11: [`docs/synthetic-af-bank-followups-wave11-results.md`](synthetic-af-bank-followups-wave11-results.md).
+Register: [`docs/followups.md`](followups.md).
+Plan: [`plans/synthetic-af-bank-followups-wave12-plan.md`](../plans/synthetic-af-bank-followups-wave12-plan.md).
+
+## §0 — What wave 11 settled, and is not re-litigated here
+
+Stated once so no arm re-derives it, and so a reader can tell what this wave is allowed to assume:
+
+- **[F58](followups.md#f58--concurrent-optimize-processes-each-acquire-a-different-nina-profile-and-the-profile-decides-the-fit-f55s-two-attractors-are-two-values-of-maxoutlierrejections):
+  F55 and F57 are ONE defect, and it is profile acquisition.** `Profile.Load` holds the `.profile` open
+  (`FileShare.Read`); a second process's load throws; `SelectProfile` returns `false`; and `TryLoad`'s
+  `SkipWhile` **silently takes the next profile by `LastUsed`**. So *N* concurrent unpinned `optimize` processes
+  ran under *N* different profiles, the fit reads four values from the profile, and this machine's **nine
+  profiles partition 2 / 7 on `MaxOutlierRejections`**. That one integer is F55's "bimodality".
+- **Proven by intervention, not by correlation.** RULE C's C2 gave `MaxOutlierRejections = 1` alone `== J_def`
+  with residue **exactly `0.0`**, and its negative control C3 (`OutlierRejectionConfidence` alone) moved nothing.
+- **`KappaSigmaNoiseEstimate` is WITHDRAWN as the mechanism.** Its measured gain stays true; it was never
+  evidence of causation.
+- **A PINNED run rewrites the default for the next UNPINNED one** (`Profile.Load` stamps `LastUsed` and saves).
+- **`--profile-id` + fan-out FAILS LOUDLY** (1 success, 4 hard failures). That is the right trade and is **not**
+  a fix.
+- **Wave 5's φ table is invalid on THREE axes** — detector version, profile, and the fit inputs. It is not
+  quoted in this wave.
+
+## §1 — The first gate: RULE G12
+
+Wave 11's eight values are the fixed point, and they are now bit-reproducible on **both** the pre-fix and
+post-fix binaries — K8 reproduced them **identically to all sixteen digits** across a different binary and a
+different settings file. So this wave's coordinate system is not a hope; it is a measured invariant, and the only
+thing G12 adds is a **third binary**.
+
+| run | `BestJ` (6 dp) |
+|---|---|
+| `toml999` | **0.995784** |
+| `CWhiteFocus` | **0.996068** |
+| `uneven` | **0.996368** |
+| `muggsie` | **0.997195** |
+| `mccomiskey` | **0.976746** |
+| `D18_m24_deep_shed` | **0.999882** |
+| `D19_cygnus_deep_shed` | **0.999487** |
+| `D20_m24_bright_control` | **0.999738** |
+
+**The invocation.** `D:\hf_w11\pop\k8_gate_on_fixed.sh`'s shape, on a FRESH build from `develop` after PR #189
+(`96f10b3`), `optimize --per-run --max-evals 250`, **sequential**, with BOTH of
+
+- `--settings D:\hf_w11\pinned_settings_w11.json` (md5 `a67ffc06…`), and
+- `--profile-id ce3f3e63-8fd3-4b72-a0ca-d90db9441382` (`astrodet`)
+
+**named in the script header as first-class inputs.** (F57(b): an arm pinned in one dimension and floating in
+another is not pinned. F42: the settings file is the other half.)
+
+> **RULE G12 — ONE pass/fail clause.** All eight `BestJ` must reproduce the table above **to 6 dp**. *A partial
+> reproduction is a failure, not a warning: the eight are one instrument.* Bit-identity to sixteen digits is
+> **reported** as the stronger observation K8 earned, but 6 dp is the clause.
+
+**The free controls are FIELDS now, so they are diffed rather than re-derived** (F53(a), F57(a), F58):
+
+| field | required reading | why |
+|---|---|---|
+| `BuildId` | **MUST DIFFER** from wave 11's `5cb7e474…` | a match means no build happened |
+| `DetectorVersion` | `2` ×8 | the output contract the eight values were measured under |
+| `ProfileId` | `astrodet (ce3f3e63-…)` ×8 | the pin took |
+| `FitInputs` | `MaxOutlierRejections=0;OutlierRejectionConfidence=0.95;WeightedHyperbolicFitEnabled=True;HyperbolicFitModel=Hybrid` ×8 | the fix is live and reading the FILE |
+| `ConcurrencyCheck` | `exclusive` **across all eight** | and see the trap below |
+| `BaselineJ` | wave 11's eight values | F41's free control; *a number agreeing too well is also an instrument failure* |
+
+> **TRAP, and it is this wave's most load-bearing one.** `ConcurrencyCheck == "exclusive"` **on a single landing
+> is not evidence the machine was quiet.** `WaitOne(0)` is won by exactly ONE of *N* contenders, so in any
+> fan-out **precisely one landing truthfully reports `exclusive`**. It must be read **across a whole arm**. In
+> wave 10's two-driver contamination the first driver's landings would ALL have read `exclusive`. This matters
+> most for item 1, which fans out on purpose — there the field is not a hygiene check, it is a **positive
+> control that the fan-out actually overlapped**.
+
+---
+
+## §2 — Item 1: F55 at the LANDING level. Authorise fan-out, or do not.
+
+**This is the only item that pays for itself, and it runs first for that reason.**
+
+### §2.1 What is and is not already known
+
+Wave 11's K5 proved agreement **at the SEED level only**: `--max-evals 1`, five concurrent processes on five
+different profiles, one `BaselineJ`. F55's **LANDING** rate was **44 %** — *triple* its seed rate — and many runs
+had a bit-identical `BaselineJ` and a different landing (`LinwoodFocus` 0.952882 vs 0.917207, a gap of 0.036).
+**Nothing has measured landings under concurrency with the fix in place.** Until that is measured every arm is
+sequential and a 39-run pass costs ~3 h.
+
+### §2.2 The experiment is wave 9's arm A, which is what caught F55 in the first place
+
+Run **the eight RULE G12 runs at fan-out 4** and require the same eight values. Identical invocation to the gate
+except for the concurrency and the profile pinning.
+
+**The hazard must survive the test.** `--profile-id` + fan-out fails loudly (wave 11, K3), so the workers run
+**UNPINNED** — which is now safe *precisely because of the fix*: the detector comes from `--settings` and, since
+wave 11, so do the four fit inputs. **The unpinned fan-out is therefore not a shortcut; it is the experiment.**
+Each worker acquires whichever profile the race gives it, exactly as F58 describes, and the claim under test is
+that this no longer reaches `J`.
+
+*(The fallback, if the race happens not to spread: give each worker its OWN profile copy — fresh GUID, identical
+content — with `D:\hf_w11\bisect\make_bisect_profile.py`, which already does this and refuses if the source
+profile's shape is not what it expects. It is a fallback and not the plan, because it perturbs the machine state
+this arm is trying to observe.)*
+
+### §2.3 RULE A12 — pre-registered, and the FAILURE is what is pre-registered
+
+| clause | requirement |
+|---|---|
+| **A1** *(the pass/fail clause)* | all eight `BestJ` reproduce §1's table to **6 dp** |
+| **A2** *(discriminating — without it A1 means nothing)* | the eight landings record **≥ 2 distinct `ProfileId`s**, spanning **both** `MaxOutlierRejections` groups of the re-snapshotted profile set |
+| **A3** *(the fan-out actually overlapped)* | `ConcurrencyCheck` reads `concurrent` on **at least one landing per batch**; all-`exclusive` means the workers did not overlap and the arm did not run |
+| **A4** *(the crispest statement of the fix)* | `FitInputs` is **IDENTICAL on all eight** despite A2's differing `ProfileId`s |
+
+> **The outcomes, written before the arm runs:**
+>
+> - **A1 ∧ A2 ∧ A3 ∧ A4 ⇒ FAN-OUT IS AUTHORISED AT DEGREE 4**, and *the authorisation names the degree*. It says
+>   nothing about degree 8 or 48.
+> - **ANY miss on A1 ⇒ still sequential**, and the results must say **which run and by how much**.
+> - **A2 or A3 unsatisfied ⇒ NO AUTHORISATION REGARDLESS OF AGREEMENT.** If the workers did not load different
+>   profiles, or did not overlap, the test did not exercise the hazard and its agreement is worth nothing. *That
+>   is K5's discriminating clause, and it is the entire reason K5 means anything.*
+
+**Power.** At F55's measured 44 % per-run landing rate, `P(8 of 8 reproduce | the defect is still live)` is
+`0.56^8 ≈ 0.0097`. So 8/8 is a ~99 %-power test of the landing-level claim, which is why eight runs suffice and
+a 39-run pass is not needed to authorise.
+
+### §2.4 The machine state moves, so it is re-snapshotted first
+
+`D:\hf_w11\profiles_before.txt` is the **wave-11** snapshot (9 profiles, 2 / 7 on `MaxOutlierRejections`). The
+fall-through set is the **top N by `LastUsed`**, and **every pinned run reorders that** — including this wave's
+own gate, which pins `astrodet` eight times immediately before. So the set is re-snapshotted to
+`D:\hf_w12\profiles_before_w12.txt` **after the gate and before the fan-out**, and A2 is evaluated against that
+snapshot rather than against wave 11's.
+
+### §2.5 What this buys, and what it does not
+
+A pass makes every subsequent arm in this and future waves ~4× cheaper. It also **answers the deferred wavelet
+bisect for free in one direction**: an arm that reproduces 8/8 under a deliberately perturbed process environment
+tells you how much the pattern search amplifies an arbitrary perturbation — which is exactly what
+[F57](followups.md#f57--a---settings-pinned-arm-is-not-pinned-the-active-nina-profile-moves-baselinej-by-0014-and-every-cross-wave-comparison-inherits-it)(d)
+and [F8](followups.md#f8--optimizer-landings-are-not-reproducible-across-invocations) want to know. It does
+**not** close F8: F8 is about landings differing across *invocations* generally, and this measures one degree of
+one hazard.
+
+---
+
+## §3 — Item 2: the four harness runners that still have F58's defect (F58(d))
+
+Flagged in wave 11 and deliberately not converted, because each needs its own validation and wave 11's budget
+went to `optimize`:
+
+| site | what it feeds |
+|---|---|
+| `BankVerifyRunner.cs:160` | the AF fit in the recall/precision harness — **and its numbers underpin the golden audits** |
+| `BankVerifyRunner.cs:518` | the `SensorModel` (tilt) fit |
+| `SynthValidateRunner.cs:243` | `synth-validate`'s convergence scoring |
+| `InspectAlignRunner.cs:103` | `inspect-align` |
+| `TiltCalibrationRunner.cs:178` | `tilt` calibration |
+
+Every one builds `new AutoFocusOptions(profileService)` and therefore takes its fit from **whichever profile is
+ACTIVE** — while building `StarDetectionOptions` on the harness accessor two lines above. **That asymmetry is the
+bug**, and it is the same asymmetry F58 named in `optimize`.
+
+**`HocusFocusPlugin.cs:119` also constructs it from the profile and is CORRECT.** In the live app those ARE the
+user's settings. It is listed here so nobody "fixes" it.
+
+### §3.1 The change is small because the seam already exists
+
+`optimize`'s conversion is one line — `new AutoFocusOptions(profileService, accessor)` — plus carrying the keys
+in the settings file, and **`HarnessSettingsStore.ExportFromProfile` already copies the whole `AutoFocusOptions`
+surface** (wave 11), so a file exported today already has them and a file that lacks them falls back to
+documented code defaults. `HarnessFitInputs` and the `FitInputs` provenance string are already written.
+
+So each runner gets: the accessor, and **`FitInputs` rendered into its own output** — the console banner it
+already prints, and the report it already writes where it writes one. *A reader diffs a field; nobody diffs a
+banner* — but a runner with no provenance record at all gets the banner, because that is strictly better than
+nothing and does not require inventing a record format per runner.
+
+### §3.2 `bank-verify` gets its own before/after, because its numbers underpin the golden work
+
+The other three runners are validated by the test suite plus the fact that the conversion is textually identical
+to `optimize`'s. **`bank-verify` is not**, because the golden audits quote its recall/precision.
+
+> **RULE B12, pre-registered.** Run `bank-verify` on the golden-scored real-bank runs **before and after** the
+> conversion, both **pinned** to `astrodet` and to `pinned_settings_w11.json` — whose four fit inputs are
+> `astrodet`'s effective values. Under that pairing the conversion is **behaviour-preserving by construction**,
+> so:
+>
+> - **every scored quantity identical ⇒ PASS**, and the conversion is safe to ship;
+> - **any difference ⇒ FAIL**, and it is a finding: either the fit inputs do not round-trip through the file, or
+>   `bank-verify` reads something from the profile that nobody has audited. The difference is then documented as
+>   a discontinuity at this commit rather than discovered later by someone comparing across it.
+>
+> This is K8's shape applied to `bank-verify`: *the fix must not move the coordinate system it is fixing.*
+
+**And the reason the before/after must be PINNED is F58 itself.** Two `bank-verify` results measured under
+different active profiles are not comparable — which is exactly what this item is fixing, and would be exactly
+how it could be measured wrong.
+
+---
+
+## §4 — Item 3: F19's remainder — and the CLOSE is pre-registered as an outcome
+
+### §4.1 Two wing statistics are already refuted
+
+| statistic | refuted by | how |
+|---|---|---|
+| `WingRejectedFraction` (absolute) | wave 10, **RULE P** | **30 of 39 = 76.9 %** fire rate; the threshold's whole discriminating power over 39 runs was ONE dataset |
+| `WingRejectedRatio` (wing ÷ inner) | wave 11, **RULE W2** | `D16`@2 s has an inner rejected fraction of **EXACTLY 0.000**, so the ratio is **+∞** and it fires at the rung where `D16`'s σ_focus is **MINIMISED**. W1 ∧ W5 leave `(1.39, 1.5683]`; W2 empties it |
+
+`WingRejectedExcess = wing − inner` was **named** in wave 11's design and **deliberately not evaluated
+anywhere**, because by then the exposure ladder was the data that had refuted the ratio, and **W6 applies to the
+ladder exactly as it applied to the 39-run population**. *A statistic tuned on the data that killed the last one
+has been fitted, not tested* — this register has now had to write that sentence three times, so this wave gives
+the excess **its own arm on data it has not seen**.
+
+### §4.2 The arm: a FRESH exposure ladder, on datasets the wing statistics have never laddered
+
+Both prior refutations happened on data that is now barred:
+
+- the **39-run population** (killed the fraction), and
+- **wave 7's `D02` / `D16` exposure ladder** (killed the ratio).
+
+So the arm renders a **new** 5-rung ladder on **three** datasets, with `synth-bank --spec` +
+`exposureSecondsOverride`, exactly as wave 7's arm E did (~1 min per rung for two datasets — the ladder is
+cheap; it is the *thinking* about it that has been expensive):
+
+| dataset | why it is on the ladder | expected role |
+|---|---|---|
+| `D17_cdk14_oiii5` | the register's own poster child: **799 on-frame stars and still asks 40.4 s**, because an OIII filter genuinely starves it. Richness is not the whole story and this is the dataset that proves it | the **W1** anchor — more exposure must demonstrably help |
+| `D20_m24_bright_control` | a **known instance of the hazard class**: in the 39-run population its inner rejected fraction is **exactly 0.000**. That is `D16`@2 s's shape on a dataset the ratio's ladder never saw | the **W2** anchor — silent at its own σ_focus minimum |
+| `D05_tec140_1000mm` | mid-population on every axis (wing fraction 0.600, σ_focus 0.07688); it is on the ladder so the verdict does not rest on two extremes | **W3 / W5** breadth |
+
+Rungs **0.5 / 2 / 8 / 30 / 120 s**, geometric ×4, chosen to bracket both derived exposures (`D20` asks 0.004 s
+and is floor-clamped; `D17` asks 40.4 s and is ceiling-clamped at 30 s). `--max-evals 120`, matching wave 9's and
+wave 11's ladder invocations exactly, so the ladders differ in what is under test and not in the search budget.
+
+### §4.3 RULE W12, fixed before the ladder runs
+
+**W1–W4 are unchanged in FORM**; their anchors are re-derived from **this ladder's own σ_focus**, which is the
+same move wave 9 made when the ladder moved between binaries
+([F54](followups.md#f54--f39bs-default-flip-moves-a-landing-at-a-resolved-factor-of-1-where-it-is-documented-as-a-no-op)).
+σ_focus is the ground truth — *what the user actually gets* — and the statistic is the predictor being scored
+against it.
+
+| clause | requirement |
+|---|---|
+| **W0** *(validity, evaluated first)* | the ladder must be **informative**: each dataset must have a σ_focus minimum and at least one rung **≥ 20 % worse** than it. A dataset that fails W0 cannot anchor W1/W2 and is reported as void rather than scored |
+| **W1** *(fires where it should)* | on every rung **shorter** than the σ_focus-minimising rung and **≥ 20 % worse** than it, the excess must be **≥ T** |
+| **W2** *(silent where it must be)* | at each dataset's σ_focus-**minimising** rung, the excess must be **< T** |
+| **W3** *(converges)* | the firing set must not re-open above the minimising rung |
+| **W4** *(the ask is finite and meaningful)* | at a firing rung the excess must be a finite number in `[−1, 1]`; **`NaN` is "could not look" and must never read as "we looked and nothing was shedding"** |
+| **W5** *(selective)* | T must sit **above the excess's own bank median** — or it is the same defect in a new coordinate |
+| **W6** *(no fitting)* | the excess may **not** be validated on the 39-run population **nor** on wave 7's `D02`/`D16` ladder |
+
+> **THE OUTCOMES, and the close is one of them:**
+>
+> - **W1 ∧ W5 leave a non-empty threshold window and W2/W3/W4 do not empty it ⇒ the excess is a LIVE
+>   CANDIDATE.** It is **not adopted** on this wave's evidence: it would then owe a population validation on data
+>   it has not seen, which is what W6 requires of it too. No verdict, threshold, or action ships this wave either
+>   way.
+> - **The window is empty ⇒ F19's REMAINDER CLOSES**, as: ***no statistic over gate rejections separates a
+>   starved wing from a detector that rejects noise everywhere.*** That is a real answer and a better one than a
+>   fourth candidate — three statistics over one quantity have now failed on the same control, and the honest
+>   reading is that the quantity does not carry the signal, not that the arithmetic over it keeps being unlucky.
+
+### §4.4 Two instruments, both free, and one contract that must NOT be reused
+
+- **W5's median comes off disk at zero compute.** Wave 10's 39-run population landings are still at
+  `D:\hf_w10\pop\`, and `score_wing_pop_w11.py`'s `ratio_offline()` already pools wing and inner exactly as
+  `ExposureRecommender.WingRejectedRatioOf` does. The excess is `wf − inf_` from the same two pools.
+  **W6 permits this**: W5 is a *necessary constraint that only shrinks the threshold window*, so computing it
+  from barred data is **conservative** — it cannot manufacture a pass. (If the excess ever survives everything
+  *and* its survival turns on this median, the verdict must be re-taken on a fresh population, and the results
+  must say so.)
+- **The offline pools validate themselves, for free.** The offline `wf / inf_` must reproduce the **shipped**
+  `WingRejectedRatio` field on every rung. If it does, the offline `wf` and `inf_` are validated — and therefore
+  so is the excess computed from them. *Two routes to one number, at no cost*, which is the control wave 11 got
+  on its ladder.
+- **THE CONTRACT THAT MUST NOT BE REUSED.** Newtonsoft writes `NaN` and `Infinity` as the **strings**
+  `"NaN"`/`"Infinity"`. Wave 10's `score_wing_pop.py` maps **both** to `nan` — correct for its statistic, and
+  **wrong for anything with an infinite state**. Use `score_wing_pop_w11.py`'s `num()`. *A validated instrument
+  validated against a DIFFERENT contract is not validated.*
+
+### §4.5 The excess on the BARRED ladder is a prediction, not a verdict
+
+Wave 11's ladder gives, for free, `D02`@0.5 s excess `0.6729 − 0.4290 = 0.2439` and `D16`@2 s excess
+`0.0064 − 0.0000 = 0.0064` — so on the ratio's own killing ground the excess **survives** the rung that killed
+the ratio. That is written into the arm's script header **as the pre-registered prediction**, exactly as wave 11
+wrote `wing2`'s numbers into `ladder_w11.sh` before it ran. **It is a prediction and not a verdict**: W6 bars the
+verdict coming from there, and a statistic that looks good on the data that killed its predecessor is precisely
+the thing W6 exists to distrust.
+
+---
+
+## §5 — Deferred, with reasons and prices
+
+| deferred | reason, and the price of doing it |
+|---|---|
+| **the landing-level wavelet bisect** (`D:\hf_w10\exe_v1wav`, built wave 10, **still unused**) | the seed-level answer is exact and identical, so this measures only whether the pattern search amplifies it — which is [F8](followups.md#f8--optimizer-landings-are-not-reproducible-across-invocations), not the wavelet. **Item 1 may answer it for free**: an arm that reproduces 8/8 under a perturbed process environment bounds how much the search amplifies *any* perturbation. ~40 min if run standalone |
+| **[F59](followups.md#f59--the-settings-export-drops-every-knob-whose-setter-validates-so-pinned_settingsjson-has-been-missing-five-detector-knobs-since-wave-5)'s five knobs** | `MaxDistortion`, `StarCenterTolerance`, `SaturationThreshold`, `HotpixelThreshold`, `Sensitivity` have been at **code defaults** in `pinned_settings.json` since wave 5. Waves 5–11 are **internally valid** (same file, same defaults throughout); what is false is that the file DESCRIBES the detector. **Re-pinning them at profile values WOULD MOVE THE COORDINATE SYSTEM** and needs a new gate baseline — a full 8-run re-establishment plus every downstream number re-read. **That is a deliberate decision, not a cleanup**, and it is priced here rather than done |
+| **F52(d), F46(b), F54, F50** | nothing depends on them |
+| **[F15](followups.md#f15--optimize---per-run-overwrites-each-runs-stored-settings)** | **still UNFIXED**: `optimize --per-run` rewrites run folders with no suppress flag, so a population pass still cannot run beside an arm. It constrains this wave's scheduling and is not fixed by it |
+| **wave 8/9/10 AF/wizard changes, still UNCONFIRMED IN THE APP** | the csproj PostBuild xcopy **fails silently when NINA is running**. Not this wave's item; not to be claimed as confirmed either |
+
+---
+
+## §6 — Traps this wave carries
+
+1. **`ConcurrencyCheck == "exclusive"` on ONE landing is not evidence the machine was quiet.** Read it across a
+   whole arm. §1's trap box; it is why A3 exists.
+2. **The profile set is machine state and it MOVES.** Re-snapshot before any fan-out arm (§2.4).
+3. **`"NaN"`/`"Infinity"` are STRINGS.** Use `score_wing_pop_w11.py`'s `num()` (§4.4).
+4. **`strings <dll> | grep AtrousWaveletFast`** still distinguishes v1 from v2 retroactively.
+5. **The console `Optimization complete` line is NOT reliably emitted** (`uneven` has none).
+   `aggregate_summary.json` is the instrument.
+6. **`lumos` exits rc=3 reproducibly**; `astrodet` the DATASET is frameless (F14); `Panos` has a degenerate
+   sigma fit.
+7. **Never rebuild an arm's directory mid-wave** (F53(c)). Wave 12 uses `D:\hf_w12\exe` (gate + item 1, the
+   pre-item-2 binary) and `D:\hf_w12\exe2` (post-item-2), and neither is rebuilt.
+8. **On CI: verify the test COUNT, not the tick** (F37). An ABSENT check is more dangerous than a red one.
+
+## §7 — Measurement discipline this wave is held to
+
+- **A measured gain is not a measured cause**, and paying to measure the gain makes the confusion easier.
+- **The cheapest instrument is the one already printed and ignored.** Before building one, grep the logs already
+  on disk. F58 — wave 11's entire headline — came out of a `Profile:` line `optimize` had been printing since
+  before wave 9.
+- **Require the hazard to SURVIVE the fix** (A2/A3).
+- **The negative control is what makes the positive ones readable** (RULE B12's pinned pairing; W0).
+- **Test the property you care about, not the happy path.**
+- **Name the hazard CLASS, not the dataset.** Wave 11 named `D17` and `D20` as the ratio's failure modes; the
+  killer was `D16`@2 s — `D20`'s shape filed under the other clause.
+- **Say what you did NOT run**, including what it would have cost.
+- **Pin `--settings` AND `--profile-id` on every arm** — except item 1, where unpinning is the experiment and is
+  argued for explicitly (§2.2).

--- a/docs/synthetic-af-bank-followups-wave12-design.md
+++ b/docs/synthetic-af-bank-followups-wave12-design.md
@@ -247,12 +247,20 @@ against it.
 | clause | requirement |
 |---|---|
 | **W0** *(validity, evaluated first)* | the ladder must be **informative**: each dataset must have a σ_focus minimum and at least one rung **≥ 20 % worse** than it. A dataset that fails W0 cannot anchor W1/W2 and is reported as void rather than scored |
-| **W1** *(fires where it should)* | on every rung **shorter** than the σ_focus-minimising rung and **≥ 20 % worse** than it, the excess must be **≥ T** |
+| **W1** *(fires where starvation is worst)* | at each dataset's **most-starved rung** — the worst-σ_focus rung among those **shorter** than the minimising rung, provided it is **≥ 20 % worse** — the excess must be **≥ T** |
 | **W2** *(silent where it must be)* | at each dataset's σ_focus-**minimising** rung, the excess must be **< T** |
-| **W3** *(converges)* | the firing set must not re-open above the minimising rung |
-| **W4** *(the ask is finite and meaningful)* | at a firing rung the excess must be a finite number in `[−1, 1]`; **`NaN` is "could not look" and must never read as "we looked and nothing was shedding"** |
+| **W3** *(converges)* | the excess must be **< T at every rung at or above** the minimising rung |
+| **W4** *(the ask is readable)* | wherever W1 requires firing the excess must be a finite number in `[−1, 1]`; **`NaN` is "could not look" and must never read as "we looked and nothing was shedding"** |
 | **W5** *(selective)* | T must sit **above the excess's own bank median** — or it is the same defect in a new coordinate |
 | **W6** *(no fitting)* | the excess may **not** be validated on the 39-run population **nor** on wave 7's `D02`/`D16` ladder |
+
+> **W1 IS ONE RUNG PER DATASET, AND THAT IS DELIBERATE.** Wave 9's rule named exactly two rungs (`D02`@0.5 s must
+> ask, `D16`@0.5 s must ask) — one per dataset, each the most-starved. Writing W1 as *"every materially-worse
+> shorter rung must fire"* would hold the excess to a **stricter** bar than the two statistics it is replacing,
+> and refuting a candidate on a rule its predecessors never had to pass is not a refutation, it is a moved
+> goalpost. **The stricter reading is still measured and reported — as a DESCRIPTIVE column, never as a clause.**
+> Wave 9's adopted statistic fired at `D02` 0.5 / 1 / 2 s and went silent at 4 s, so how many starved rungs a
+> candidate covers is a real quality signal; it is simply not the bar.
 
 > **THE OUTCOMES, and the close is one of them:**
 >
@@ -285,12 +293,21 @@ against it.
 
 ### §4.5 The excess on the BARRED ladder is a prediction, not a verdict
 
-Wave 11's ladder gives, for free, `D02`@0.5 s excess `0.6729 − 0.4290 = 0.2439` and `D16`@2 s excess
-`0.0064 − 0.0000 = 0.0064` — so on the ratio's own killing ground the excess **survives** the rung that killed
-the ratio. That is written into the arm's script header **as the pre-registered prediction**, exactly as wave 11
-wrote `wing2`'s numbers into `ladder_w11.sh` before it ran. **It is a prediction and not a verdict**: W6 bars the
-verdict coming from there, and a statistic that looks good on the data that killed its predecessor is precisely
-the thing W6 exists to distrust.
+Wave 11's ladder gives, for free, `D02`@0.5 s excess `0.6729 − 0.4290 = 0.243823` and `D16`@2 s excess
+`0.0064 − 0.0000 = 0.006410` — so on the ratio's own killing ground the excess **survives** the rung that killed
+the ratio, and RULE W12 would leave the window **(0.0889, 0.2438]**. That is written into the arm's script header
+**as the pre-registered prediction**, exactly as wave 11 wrote `wing2`'s numbers into `ladder_w11.sh` before it
+ran. **It is a prediction and not a verdict**: W6 bars the verdict coming from there, and a statistic that looks
+good on the data that killed its predecessor is precisely the thing W6 exists to distrust.
+
+**This is what makes the arm worth running rather than a formality.** The excess is *not* obviously doomed — on
+the barred ladder it passes every clause — so the fresh ladder is a real test with a real chance of either
+outcome, which is the only kind worth pre-registering.
+
+**And W5's floor is already measured, at zero compute**: the excess's median over wave 10's 39 population
+landings is **0.088948**. The same pooling reproduces wave 11's published median wing/inner **ratio** of 1.39
+(1.3860 over the 29 firing runs with a finite ratio) — *the scorer validated against a number this project
+already published, before it scored anything new.*
 
 ---
 

--- a/docs/synthetic-af-bank-followups-wave12-design.md
+++ b/docs/synthetic-af-bank-followups-wave12-design.md
@@ -246,7 +246,7 @@ against it.
 
 | clause | requirement |
 |---|---|
-| **W0** *(validity, evaluated first)* | the ladder must be **informative**: each dataset must have a σ_focus minimum and at least one rung **≥ 20 % worse** than it. A dataset that fails W0 cannot anchor W1/W2 and is reported as void rather than scored |
+| **W0** *(validity, evaluated first)* | the ladder must be **informative**: each dataset must have a σ_focus minimum and at least one rung **≥ 20 % worse** than it. A dataset that fails W0 cannot anchor W1/W2 and is reported as void rather than scored. **A rung that fails the hard floor is UNEVALUATED and anchors nothing** (below) |
 | **W1** *(fires where starvation is worst)* | at each dataset's **most-starved rung** — the worst-σ_focus rung among those **shorter** than the minimising rung, provided it is **≥ 20 % worse** — the excess must be **≥ T** |
 | **W2** *(silent where it must be)* | at each dataset's σ_focus-**minimising** rung, the excess must be **< T** |
 | **W3** *(converges)* | the excess must be **< T at every rung at or above** the minimising rung |
@@ -254,6 +254,19 @@ against it.
 | **W5** *(selective)* | T must sit **above the excess's own bank median** — or it is the same defect in a new coordinate |
 | **W6** *(no fitting)* | the excess may **not** be validated on the 39-run population **nor** on wave 7's `D02`/`D16` ladder |
 
+> **A HARD-FLOOR FAIL IS "COULD NOT LOOK", AND IT ANCHORS NOTHING — decided from the run's STRUCTURAL fields
+> while the ladder was still rendering, and the only wing value visible at that moment was the `NaN` that
+> prompted the question.** (Said exactly rather than as "before any data": no excess *magnitude* on any rung had
+> been computed, which is what could have biased a threshold.) `D17`@0.5 s came back `HardFloorPassed = false`,
+> `WorstFrameCount = 0`: at 0.5 s behind a 5 nm OIII filter the detector finds **zero stars on some frame**, so
+> `BestJ`, σ_focus and both wing statistics are `NaN` by construction. **No statistic over gate rejections can
+> speak about a frame with no stars in it**, and refuting a candidate because it is silent where nothing was
+> detected would be refuting it for the detector's failure rather than its own. Such rungs are reported as
+> **UNEVALUATED** and excluded from W0–W3 anchoring — the same principle as *NaN-never-0*: "could not look" is a
+> third state, not a quiet zero. **The honest counterpart is stated with it:** if excluding them leaves a dataset
+> with no materially-worse *usable* rung, that dataset has **no W1 anchor** and is reported as having none — not
+> quietly dropped, and not scored as a pass.
+>
 > **W1 IS ONE RUNG PER DATASET, AND THAT IS DELIBERATE.** Wave 9's rule named exactly two rungs (`D02`@0.5 s must
 > ask, `D16`@0.5 s must ask) — one per dataset, each the most-starved. Writing W1 as *"every materially-worse
 > shorter rung must fire"* would hold the excess to a **stricter** bar than the two statistics it is replacing,

--- a/docs/synthetic-af-bank-followups-wave12-results.md
+++ b/docs/synthetic-af-bank-followups-wave12-results.md
@@ -323,6 +323,12 @@ existed precisely to make that visible.*
 **The COUNT was verified, not the tick** (F37: a native test-host crash reports `Failed: 0` while ~2000 tests
 never execute). Nothing was piped to `tail`, which would mask the exit code.
 
+**And CI was verified the same way**, not by its green tick: run `31298430548` on
+[PR #190](https://github.com/ghilios/hocus-focus/pull/190) reports
+`Failed: 0, Passed: 3744, Skipped: 0, Total: 3744` — **the same count as local**, read out of the log. An
+ABSENT check is more dangerous than a red one, and a green one that ran 1389 of 3371 tests is how F37 was
+found.
+
 ### §5.2 What was NOT run, and what it would have cost
 
 - **No 39-run population pass.** Item 3 was refuted on necessary clauses by a 15-run ladder, so a population pass

--- a/docs/synthetic-af-bank-followups-wave12-results.md
+++ b/docs/synthetic-af-bank-followups-wave12-results.md
@@ -1,0 +1,381 @@
+# Synthetic AF bank — followups wave 12 (results)
+
+Design: [`docs/synthetic-af-bank-followups-wave12-design.md`](synthetic-af-bank-followups-wave12-design.md).
+Plan: [`plans/synthetic-af-bank-followups-wave12-plan.md`](../plans/synthetic-af-bank-followups-wave12-plan.md).
+Wave 11: [`docs/synthetic-af-bank-followups-wave11-results.md`](synthetic-af-bank-followups-wave11-results.md).
+Register: [`docs/followups.md`](followups.md).
+
+> ## PROVENANCE — and this wave's banner is three lines, because the fields did the rest
+>
+> | directory | what it is | `TestApp.dll` sha256 | `BuildId` |
+> |---|---|---|---|
+> | `D:\hf_w12\exe` | `develop` @ `96f10b3` (PR #189's merge commit, **verified MERGED**), **pre-item-2** | `f16ccfe3…` | `103d61c4…` |
+> | `D:\hf_w12\exe2` | the same tree **+ item 2** | `5368498b…` | *(stamped per run)* |
+>
+> Settings `D:\hf_w11\pinned_settings_w11.json`, md5 **`a67ffc06…`**, on **every** invocation. Profile
+> `astrodet (ce3f3e63-…)` pinned on every arm **except item 1's fan-out, where unpinning IS the experiment**
+> (§2.2). Neither directory was ever rebuilt (F53(c)).
+>
+> **Everything else a reader would want is a FIELD on every landing** — `BuildId`, `DetectorVersion`,
+> `ProfileId`, `ConcurrencyCheck`, `FitInputs` — and this document diffs them rather than asserting them.
+
+## Status of this document
+
+| item | state |
+|---|---|
+| **RULE G12** — the gate | **PASS, 8 of 8, and BIT-IDENTICAL to K8 on all sixteen digits** on a third binary. See §1 |
+| **item 1** — F55 at the LANDING level | **RULE A12 PASSES ON ALL FOUR CLAUSES. FAN-OUT IS AUTHORISED AT DEGREE 4** — 8 of 8 bit-identical while four workers loaded **four different profiles** spanning both `MaxOutlierRejections` groups. See §2 |
+| **and the authorisation is worth far less than assumed** | **1.33×, not 4×.** Every run takes 1.45–2.55× longer under contention. The plan's cost case was wrong by a factor of three, and it is corrected rather than quietly restated. **New: F60.** See §2.4 |
+| **item 2** — F58(d) | **All five remaining call sites converted. RULE B12 PASS** (692 leaf values identical) **and RULE B12-D PASS** (the profile moved 15 of 24 scored quantities BEFORE and 0 of 24 after). See §3 |
+| **and what it was actually breaking** | **the SENSOR model, not the AF fit.** `bank-verify`'s σ_focus never moved; its tilt θ moved **7.6 %** on `muggsie`. **New: F61.** See §3.3 |
+| **item 3** — F19's remainder | **`WingRejectedExcess` REFUTED on a ladder it had not seen, on THREE datasets independently and in BOTH directions. F19's REMAINDER CLOSES.** See §4 |
+| **the full suite** | see §5 |
+
+---
+
+## §1 — RULE G12: the coordinate system on a third binary
+
+`D:\hf_w12\gate_w12.sh`, 03:56:22–04:39:32Z, sequential, `--per-run --max-evals 250`, both pins named in the
+script header.
+
+| run | `BestJ` (exact) | 6 dp | expected | | bit == K8 | `BaselineJ` | wave 11 |
+|---|---|---|---|---|---|---|---|
+| `toml999` | 0.9957838768299878 | 0.995784 | 0.995784 | **MATCH** | **YES** | 0.983477 | ok |
+| `CWhiteFocus` | 0.9960675916058808 | 0.996068 | 0.996068 | **MATCH** | **YES** | 0.994320 | ok |
+| `uneven` | 0.9963677194179505 | 0.996368 | 0.996368 | **MATCH** | **YES** | 0.991794 | ok |
+| `muggsie` | 0.9971948738498605 | 0.997195 | 0.997195 | **MATCH** | **YES** | 0.993288 | ok |
+| `mccomiskey` | 0.9767460801208465 | 0.976746 | 0.976746 | **MATCH** | **YES** | 0.846082 | ok |
+| `D18_m24_deep_shed` | 0.9998815090506263 | 0.999882 | 0.999882 | **MATCH** | **YES** | 0.997405 | ok |
+| `D19_cygnus_deep_shed` | 0.9994870586135448 | 0.999487 | 0.999487 | **MATCH** | **YES** | 0.999187 | ok |
+| `D20_m24_bright_control` | 0.9997378027339423 | 0.999738 | 0.999738 | **MATCH** | **YES** | 0.999454 | ok |
+
+> **RULE G12: PASS, 8 of 8 to 6 dp — and every one bit-identical to all sixteen digits.** Wave 11's eight values
+> have now reproduced across **three** binaries and two settings files. F41's free control passes 8 of 8 too.
+
+**The controls, diffed rather than asserted:** `BuildId` `103d61c4…` ×8 — **differs** from wave 11's `5cb7e474…`,
+as a fresh build must; `DetectorVersion` 2 ×8 (and `strings … | grep AtrousWaveletFast` hits);
+`ProfileId` `astrodet` ×8; `ConcurrencyCheck` `exclusive` on **all eight, read across the arm**; `FitInputs`
+`MaxOutlierRejections=0;OutlierRejectionConfidence=0.95;WeightedHyperbolicFitEnabled=True;HyperbolicFitModel=Hybrid`
+×8.
+
+---
+
+## §2 — Item 1: F55 at the landing level. RULE A12, and fan-out is authorised at degree 4
+
+### §2.1 The profile set moved, exactly as F58 says it does — and that is why it was re-snapshotted
+
+`D:\hf_w12\profiles_before_w12.txt`, taken **after** the gate and **before** the fan-out. The gate pinned
+`astrodet` eight times, and `astrodet` is now **#1 by `LastUsed`** where wave 11's snapshot had it third.
+**The act of measuring reordered the set that decides what the next measurement draws.** The top four span both
+groups — `astrodet` (0), `AA1600MM` (1), `AA1600MM Copy` (0), `Default-2026-08-05T10:57:42` (1) — which was
+written down as the prediction for A2 **before** the arm ran.
+
+### §2.2 The arm: eight runs, two batches of four, unpinned
+
+| run | profile the worker drew | `MaxOutlierRejections` | `ConcurrencyCheck` | `BestJ` | bit == K8 |
+|---|---|---|---|---|---|
+| `toml999` | `AA1600MM` | **1** | concurrent | 0.9957838768299878 | **YES** |
+| `CWhiteFocus` | `AA1600MM Copy` | **0** | *exclusive* | 0.9960675916058808 | **YES** |
+| `uneven` | `Default-2026-08-05T10:57:42` | **1** | concurrent | 0.9963677194179505 | **YES** |
+| `muggsie` | `astrodet` | **0** | concurrent | 0.9971948738498605 | **YES** |
+| `mccomiskey` | `AA1600MM` | **1** | *exclusive* | 0.9767460801208465 | **YES** |
+| `D18_m24_deep_shed` | `AA1600MM Copy` | **0** | concurrent | 0.9998815090506263 | **YES** |
+| `D19_cygnus_deep_shed` | `astrodet` | **0** | concurrent | 0.9994870586135448 | **YES** |
+| `D20_m24_bright_control` | `Default-2026-08-05T10:57:42` | **1** | concurrent | 0.9997378027339423 | **YES** |
+
+| clause | verdict | evidence |
+|---|---|---|
+| **A1** eight values to 6 dp | **PASS** | 8 of 8 — and **bit-identical on all sixteen digits**, which is stronger than the clause asked for |
+| **A2** ≥2 profiles, both `MaxOutlierRejections` groups | **PASS** | **FOUR** distinct profiles, **4 runs at `MOR`=0 and 4 at `MOR`=1** |
+| **A3** the fan-out actually overlapped | **PASS** | exactly **one `exclusive` per batch** and three `concurrent` — precisely what `WaitOne(0)` must produce at degree 4 |
+| **A4** `FitInputs` identical on all eight | **PASS** | one distinct value across four different profiles |
+
+> ### **FAN-OUT IS AUTHORISED AT DEGREE 4**, and the authorisation names the degree.
+>
+> **A2 is what makes this mean anything.** Four processes drew four different profiles, split 4/4 on the integer
+> that used to decide `J` — **pre-fix, these eight landings would have partitioned into two groups.** The hazard
+> was fully present and it did not reach a single digit. A fix that pinned the profile would have produced one
+> profile, one answer, and no information.
+>
+> **Power:** at F55's measured 44 % per-run landing rate, `P(8 of 8 | the defect is live) = 0.56⁸ ≈ 0.0097`.
+
+### §2.3 Two limits on the authorisation, both load-bearing
+
+- **It is for UNPINNED fan-out only.** `--profile-id` + fan-out still fails loudly (wave 11's K3), so a fanned-out
+  arm cannot also pin its profile — it relies on `--settings` carrying the fit inputs, which is exactly what
+  wave 11 shipped. **An arm that needs a specific profile still runs sequentially.** (That is why item 3's
+  ladder below is sequential: it is pinned, so fan-out was never available to it.)
+- **It names degree 4.** Nothing here says anything about 8 or 48.
+
+### §2.4 AND IT IS WORTH 1.33×, NOT 4× — the cost case was wrong by a factor of three (F60)
+
+| run | sequential | at fan-out 4 | inflation |
+|---|---|---|---|
+| `toml999` | 1 m 58 s | 5 m 01 s | 2.55× |
+| `CWhiteFocus` | 8 m 33 s | 13 m 51 s | 1.62× |
+| `uneven` | 6 m 16 s | 9 m 04 s | 1.45× |
+| `muggsie` | 1 m 08 s | 2 m 29 s | 2.19× |
+| `mccomiskey` | 10 m 28 s | 18 m 36 s | 1.78× |
+| `D18_m24_deep_shed` | 6 m 36 s | 13 m 49 s | 2.09× |
+| `D19_cygnus_deep_shed` | 6 m 00 s | 9 m 23 s | 1.56× |
+| `D20_m24_bright_control` | 2 m 11 s | 3 m 50 s | 1.76× |
+| **the arm** | **43 m 10 s** | **32 m 28 s** | **1.33× speedup — 25 % of the wall clock** |
+
+> **`optimize` already saturates this machine** (48 OpenCV threads), so four processes contend rather than
+> parallelise: the busy-time sum goes from 43 m to 76 m to buy 11 m of wall clock. **The plan said fan-out would
+> make every arm "~4× cheaper". It does not — it makes them ~25 % cheaper**, and a 39-run pass goes from ~3 h to
+> ~2 ¼ h rather than to ~45 m.
+>
+> This is recorded as **[F60](followups.md)** rather than folded into the authorisation, because the two facts
+> point in opposite directions and both are true: *fan-out is now safe, and it is barely worth doing.* The
+> honest consequence is that **"run it sequentially" remains the default**, and fan-out is for the case where a
+> pass is long enough that 25 % is worth the loss of `--profile-id`.
+
+---
+
+## §3 — Item 2: the five remaining F58(d) call sites
+
+### §3.1 What was converted, and the seam that replaced five copies of one line
+
+`HarnessSettingsStore.BuildFitOptions(profileService, resolved)` is now the **only** way a harness runner builds
+`AutoFocusOptions`. Converted: `BankVerifyRunner` (**×2** — the run-level fit *and* the `SensorModel`),
+`SynthValidateRunner`, `InspectAlignRunner`, `TiltCalibrationRunner`. Each renders `FitInputs` into the output it
+already writes.
+
+**`HocusFocusPlugin.cs:119` is untouched and is CORRECT** — in the live app the profile *is* the user's settings.
+It is named in the seam's own doc comment so the next reader does not "fix" it.
+
+**The guard is on the CONSTRUCTOR, not on the five sites**, so it holds for a site nobody has written yet:
+`HarnessFitSeamTests.NoHarnessRunnerBuildsItsFitFromTheActiveProfile` fails if any `TestApp` source calls the
+single-argument `new AutoFocusOptions(x)`. *Wave 11 fixed `optimize` and left five call sites carrying the same
+defect, each locally plausible; a rule enforced by remembering it is a rule that comes back.*
+
+**And the guard checks itself first.** `TheGuardsOwnPatternFiresOnTheBannedFormAndNotOnTheRequiredOne` asserts the
+regex matches the banned form and does **not** match the accessor-bound one, on literals, before it is run
+against the tree — because *"what would this test do if the thing it checks were completely broken?"* has the
+answer "sweep clean" for every source guard whose pattern has rotted.
+
+### §3.2 RULE B12 — and it is the WEAK question, which is why B12-D exists
+
+`bank-verify` over all 19 real-bank runs, `--nc-sweep 4`, both passes pinned to `astrodet` and to
+`pinned_settings_w11.json` (whose four fit inputs **are** `astrodet`'s effective values).
+
+> **RULE B12: PASS. All 692 compared leaf values identical to full double precision** — 453 of them numeric —
+> with `fitInputs`/`profileId`/`generatedUtc`/`detectorCommit` excluded and listed as excluded.
+>
+> **The comparator was checked in the failing direction**: perturbing one `sigmaFocus` by `1e-12` makes it report
+> exactly one difference. *A differ that cannot fail is a differ that always passes.*
+
+**But B12 alone is equally consistent with a conversion that changed nothing.** So the discriminating half:
+
+### §3.3 RULE B12-D — the same runs under a DIFFERENT profile, and what F58(d) was actually breaking
+
+Three runs, same pinned settings file, scored under `astrodet` (`MOR`=0) and under `Default` (`MOR`=1), on both
+binaries.
+
+| binary | scored quantities that MOVED between the two profiles |
+|---|---|
+| `exe` (**pre**-conversion) | **15 of 24** |
+| `exe2` (**post**-conversion) | **0 of 24** |
+
+| run | quantity | `astrodet` | `Default` | |
+|---|---|---|---|---|
+| `toml999` | `sStars` | 613 | **616** | stars in the sensor model |
+| | `sR2` | 0.14883143 | **0.14580555** | |
+| `muggsie` | `sTheta` | 0.12407606 | **0.11525545** | **tilt θ, 7.6 % apart** |
+| | `sRMS` | 6.7519583 | **6.7712252** | |
+| `mccomiskey` | `sStars` | 2800 | **2856** | |
+| | `sChi` | 0.11344971 | **0.12177990** | |
+| all three | `sigmaFocus` | *identical* | *identical* | **the AF fit never moved** |
+
+> **RULE B12-D: PASS — and it found something the plan did not predict.** The profile was reaching
+> `bank-verify` through the **SENSOR model**, not the AF fit. `SensorModel.cs:714–715` takes
+> `MaxOutlierRejections` and `OutlierRejectionConfidence` for the **per-star** curve fit, so *which stars entered
+> the paraboloid* depended on which profile was active — 613 vs 616 on `toml999`, 2800 vs 2856 on `mccomiskey` —
+> and everything downstream moved with them, including **tilt θ by 7.6 % on `muggsie`**.
+>
+> Wave 11 flagged `BankVerifyRunner` as *"×2"* and treated the second site as an afterthought. **It was the one
+> that mattered.** Filed as **[F61](followups.md)**, because `InspectAlignRunner` and `TiltCalibrationRunner`
+> fit sensor models too, and every tilt number produced by those harnesses before this commit carries an input
+> nothing recorded.
+>
+> *This is the clause that makes §3.2 readable. Without it, "692 values identical" is equally good evidence for a
+> working fix and for a no-op.*
+
+---
+
+## §4 — Item 3: `WingRejectedExcess` is refuted, and F19's remainder CLOSES
+
+### §4.1 The ladder, and what it cost
+
+Three datasets the wing statistics had never laddered, freshly rendered at 0.5 / 2 / 8 / 30 / 120 s into
+`D:\hf_w12\ladder` (**never into the bank**), `optimize --max-evals 120`, pinned both ways, sequential
+(pinned ⇒ fan-out unavailable, §2.3). **Render + 15 optimizes: 13 m 51 s total.**
+
+| dataset | rung | wing | inner | **EXCESS** | ratio (shipped) | ratio (offline) | σ_focus |
+|---|---|---|---|---|---|---|---|
+| `D17_cdk14_oiii5` | 0.5 s | — | — | — | NaN | NaN | — | *product DECLINED; 0 stars on every frame* |
+| | 2 s | 1.0000 | 0.6939 | 0.306122 | 1.441176 | 1.441176 | — | *no σ_focus* |
+| | **8 s** | 0.0000 | 0.0000 | **0.000000** | 1.000000 | 1.000000 | **1.86179** |
+| | 30 s | 0.0000 | 0.0000 | 0.000000 | 1.000000 | 1.000000 | 0.81138 |
+| | **120 s** | 0.5361 | 0.4450 | 0.091106 | 1.204744 | 1.204744 | **0.09659** |
+| `D20_m24_bright_control` | **0.5 s** | 0.2460 | 0.0000 | **0.246027** | +∞ | +∞ | **0.00823** |
+| | 2 s | 0.0000 | 0.0000 | 0.000000 | 1.000000 | 1.000000 | 0.03488 |
+| | 8 s | 0.0000 | 0.0000 | 0.000000 | 1.000000 | 1.000000 | 0.02748 |
+| | 30 s | 0.0000 | 0.0000 | 0.000000 | 1.000000 | 1.000000 | 0.03058 |
+| | 120 s | 0.0000 | 0.0000 | 0.000000 | 1.000000 | 1.000000 | 0.03313 |
+| `D05_tec140_1000mm` | 0.5 s | 0.6040 | 0.0841 | 0.519877 | 7.178265 | 7.178265 | 0.07890 |
+| | **2 s** | 0.8936 | 0.3723 | **0.521251** | 2.399931 | 2.399931 | **0.18083** |
+| | **8 s** | 0.8651 | 0.0037 | **0.861389** | 235.470037 | 235.470037 | **0.04412** |
+| | 30 s | 0.8446 | 0.0000 | 0.844577 | +∞ | +∞ | 0.04940 |
+| | 120 s | 0.4987 | 0.0000 | 0.498698 | +∞ | +∞ | 0.12844 |
+
+**The shipped `WingRejectedRatio` field and the independent offline recomputation agree on every rung the product
+could look at** — two routes to one number, for free.
+
+### §4.2 The verdict: three datasets fail independently, in BOTH directions
+
+| clause | dataset | measured | implies |
+|---|---|---|---|
+| **W1** most-starved rung must fire | `D17`@8 s — σ_focus **19.3× worse** than its optimum | excess **exactly 0.000000** | **T ≤ 0** |
+| **W2** silent at the optimum | `D05`@8 s — σ_focus **minimised** | excess **0.861389** | T > 0.861 |
+| **W2** silent at the optimum | `D20`@0.5 s — σ_focus **minimised (0.00823, the best on the ladder)** | excess **0.246027** | T > 0.246 |
+| **W1** most-starved rung must fire | `D05`@2 s — 3.1× worse | excess 0.521251 | T ≤ 0.521 |
+| **W5** above the bank median | 39 population runs | 0.088948 | T > 0.0889 |
+
+> **RULE W12 HAS NO SATISFYING THRESHOLD, and it is not close.** W1 requires `T ≤ 0.000000`; W2 and W5 require
+> `T > 0.861389`. **`D05` contradicts itself on its own two clauses** (W1 needs T ≤ 0.521, W2 needs T > 0.861),
+> so no threshold works even on a single dataset.
+
+### §4.3 And the statistic points the WRONG WAY, which is the finding rather than the arithmetic
+
+Across all **13 usable rungs**, against how bad the focus is (σ_focus ÷ that dataset's own best):
+
+| σ_focus ÷ best | excess |
+|---|---|
+| **19.28** (`D17`@8 s) | **0.000000** |
+| 8.40 (`D17`@30 s) | 0.000000 |
+| 4.24 / 4.03 / 3.72 / 3.34 (`D20`) | 0.000000 ×4 |
+| 4.10 (`D05`@2 s) | 0.521251 |
+| 1.00 (`D05`@8 s — best focus) | **0.861389** |
+| 1.00 (`D20`@0.5 s — best focus) | **0.246027** |
+| 1.00 (`D17`@120 s — best focus) | 0.091106 |
+
+> **Spearman ρ(focus badness, excess) = −0.665.** A statistic meant to say *"your wings are starved, expose
+> longer"* must be **positive** here. **The excess is at its maximum where focus is best and exactly zero where
+> focus is 19× worse than it needs to be.**
+>
+> `D17` is the sharpest case and it is this register's own poster child: a 5 nm OIII field that genuinely IS
+> photon-starved, whose σ_focus improves **19-fold** from 8 s to 120 s. **At 8 s its wings and its core reject at
+> identical rates — both exactly 0.0000.** The detector is not rejecting *more* in the wings of a starved run;
+> on a starved run it is finding so little that there is nothing to reject anywhere.
+
+### §4.4 F19's remainder CLOSES
+
+> **Three statistics over one quantity have now been refuted, each by a rule fixed before it was sized:**
+>
+> | statistic | killed by | on |
+> |---|---|---|
+> | `WingRejectedFraction` (absolute) | RULE P — 76.9 % fire rate | 39-run population (wave 10) |
+> | `WingRejectedRatio` (wing ÷ inner) | RULE W2 — `D16`@2 s is `+∞` at its σ minimum | wave 7's `D02`/`D16` ladder (wave 11) |
+> | `WingRejectedExcess` (wing − inner) | RULE W1 **and** W2 **and** W5, on three datasets | a fresh 3×5 ladder (wave 12) |
+>
+> **F19's remainder closes as: NO STATISTIC OVER GATE REJECTIONS SEPARATES A STARVED WING FROM A DETECTOR THAT
+> REJECTS NOISE EVERYWHERE.** ρ = −0.665 says why, and it is not a property of the arithmetic: *gate rejections
+> count what the detector THREW AWAY, and a starved frame's problem is what it never FOUND.* The quantity does
+> not carry the signal, and a fourth function of it would not either.
+>
+> **What ships: nothing.** No verdict, threshold, probe factor or action. `WingRejectedFraction` and
+> `WingRejectedRatio` remain measurements with no consumer, exactly as wave 11 left them.
+
+### §4.5 The instrument was wrong twice, and the cross-check is what said so
+
+The offline scorer disagreed with the shipped field on one rung, twice, for two different reasons — and **both
+were the scorer's fault, not the product's**:
+
+1. First cut: no fit guard at all, so it produced `0.0` on `D17`@0.5 s where the product correctly returned
+   `NaN` (`WingAxis` declines when `BestFocusPosition` is non-finite).
+2. Second cut: `HardFloorPassed` used as the fit proxy — **wrong**, because `D17`@2 s has
+   `HardFloorPassed = false` and the product *still* produced 1.4412. The `ExposureRecommendation` is computed
+   from the **seed** evaluation, which can fit where the optimizer's ≥3-stars-per-frame floor fails.
+
+The fix was to stop conflating two questions: *did the product look* (shipped ≠ NaN — the only rungs that can
+validate the pooling) and *can this rung anchor a clause* (σ_focus finite — the only rungs W0–W3 can use).
+**Neither exclusion can manufacture a refutation:** `D17`@2 s's excess is 0.306, so admitting it would make the
+excess *easier* to accept. *The temptation both times was to narrow the check until it agreed; the cross-check
+existed precisely to make that visible.*
+
+---
+
+## §5 — The suite, and what this wave did NOT run
+
+### §5.1 The suite
+
+**3744 passed, 0 failed, 0 skipped.** `develop` was **3740**, so **+4**, and every one is named:
+
+| test | what it pins |
+|---|---|
+| `TheGuardsOwnPatternFiresOnTheBannedFormAndNotOnTheRequiredOne` | the source guard's own regex, in **both** directions, on literals — so a rotted pattern fails loudly instead of sweeping clean |
+| `NoHarnessRunnerBuildsItsFitFromTheActiveProfile` | no `TestApp` source may call the single-argument `new AutoFocusOptions(x)` — the ban is on the CONSTRUCTOR, so it covers a site nobody has written yet |
+| `BuildFitOptions_ReadsTheFILE_OnAllFourAxes` | the seam resolves all four fit inputs from the pinned file |
+| `BuildFitOptions_RefusesToFallBackToTheProfile` | it THROWS rather than silently returning a profile-backed fit — the only reading that cannot be mistaken for a pinned run |
+
+**The COUNT was verified, not the tick** (F37: a native test-host crash reports `Failed: 0` while ~2000 tests
+never execute). Nothing was piped to `tail`, which would mask the exit code.
+
+### §5.2 What was NOT run, and what it would have cost
+
+- **No 39-run population pass.** Item 3 was refuted on necessary clauses by a 15-run ladder, so a population pass
+  could not have changed the verdict, and W6 bars its rows from sizing anything. **Now that fan-out is
+  authorised it would cost ~2 ¼ h, not ~45 m** (§2.4) — which is the corrected price, recorded so the next wave
+  budgets from a measurement rather than from the assumption this wave disproved.
+- **No landing-level wavelet bisect** (`D:\hf_w10\exe_v1wav`, built in wave 10, **still unused**). Item 1 bounds
+  it in one direction for free: eight landings survived a deliberately perturbed process environment
+  bit-identically, so the pattern search did not amplify *any* perturbation present there.
+- **F59's five knobs stay at code defaults.** Re-pinning them would move the coordinate system RULE G12 has now
+  reproduced three times; it needs a new baseline and is a decision, not a cleanup.
+- **F15 is still unfixed** — `optimize --per-run` still rewrites run folders with no suppress flag.
+- **Waves 8/9/10's AF/wizard changes are STILL UNCONFIRMED IN THE APP.** The csproj PostBuild xcopy fails
+  silently while NINA is running. Not this wave's item; not to be read as confirmed.
+
+---
+
+## Lessons
+
+**1. A control that cannot fail is not a control — and "identical" is the easiest way for one to hide.**
+RULE B12 compared 692 values and found them identical, which reads as a strong pass and is equally consistent
+with a conversion that did nothing at all. Two things rescued it: perturbing one leaf by `1e-12` to prove the
+differ could speak, and **B12-D**, which asked the opposite question — *does the profile still move anything?* —
+and answered 15 of 24 before, 0 of 24 after. *Wave 11's "require the hazard to survive the fix", run in the
+other direction: require the fix to be VISIBLE, not merely harmless.*
+
+**2. The flagged-but-deferred site was the one that mattered.** Wave 11 recorded `BankVerifyRunner` as *"×2"* and
+the second instance was the `SensorModel` — where `MaxOutlierRejections` decides which stars enter the **per-star**
+paraboloid. `bank-verify`'s σ_focus never moved between profiles; its **tilt θ moved 7.6 %**. The defect was
+found by the arm written to prove the fix was a no-op, on a quantity nobody had thought to check.
+
+**3. Measure the payoff you are buying, not the one you assumed.** Item 1 was justified as making every future
+arm "~4× cheaper". It makes them **1.33×** cheaper, because `optimize` already saturates the machine — the
+busy-time sum went 43 m → 76 m to buy 11 m. The authorisation is still worth having and the cost case that
+motivated it was wrong by a factor of three. *Both halves get written down, because a wave that only records the
+half that justified the work is how a project acquires beliefs it never measured.*
+
+**4. Refute on the bar your predecessors faced, and fix the rule BEFORE the data.** The first draft of W1 required
+firing on *every* materially-worse rung; wave 9's rule named exactly one per dataset. That draft would have
+refuted the excess on a bar neither predecessor had to clear. It was corrected and committed **before the ladder
+rendered a frame** — and in the end the excess failed the weaker rule so decisively (`T ≤ 0` against `T > 0.861`)
+that the distinction changed nothing. *That is the point: you cannot know that in advance, which is why the rule
+moves before the data and not after.*
+
+**5. "Could not look" needs its own state at every level, including the scorer's.** The register has said this
+about `NaN`-never-0 since wave 9. This wave needed it three more times: a rung where the detector found **zero
+stars**; a rung where the product declined but the optimizer had not; and a rung where the optimizer failed but
+the product *had* looked. Two of the scorer's three cuts conflated two of those, and each time the honest fix was
+to split the question rather than to widen the exclusion until the numbers agreed.
+
+**6. The refutation that generalises beats the one that fits.** `WingRejectedExcess` could have been closed on
+"no threshold satisfies RULE W12" and that would have been true. The finding worth keeping is
+**ρ = −0.665**: the statistic is *anti-correlated* with the thing it exists to predict, because gate rejections
+count what the detector **threw away** and a starved frame's problem is what it never **found**. That sentence
+closes F19's remainder against a fourth candidate; an empty threshold window would only have closed it against
+the third.

--- a/docs/wave13-handoff-prompt.md
+++ b/docs/wave13-handoff-prompt.md
@@ -1,0 +1,146 @@
+Continue the HocusFocus synthetic-AF-bank followups. Wave 12 is PR #190 (VERIFY IT MERGED — at handoff it was
+OPEN + MERGEABLE with CI COMPLETED/SUCCESS and the count verified in the log, 3744 of 3744; develop was 3740,
++4 all named). Branch was ghilios/synthetic-af-bank-followups-wave12.
+
+Start by reading docs/synthetic-af-bank-followups-wave12-results.md and the F45, F61, F60, F55, F58, F57, F19,
+F15, F59, F53, F41, F42, F8 entries in docs/followups.md.
+
+WHAT WAVE 12 SETTLED, SO YOU DO NOT RE-LITIGATE IT
+ - FAN-OUT IS AUTHORISED AT DEGREE 4, UNPINNED ONLY. Eight landings, four workers, FOUR different profiles split
+   4/4 on MaxOutlierRejections, all bit-identical to sixteen digits (RULE A12). --profile-id + fan-out STILL
+   fails loudly, so a PINNED arm cannot fan out at all and runs sequentially.
+ - AND IT BUYS 1.33x, NOT 4x (F60). Per-run time inflates 1.45-2.55x; the eight-run arm went 43m->32m while busy
+   time went 43m->76m. BUDGET A 39-RUN PASS AT ~2 1/4 h, NOT ~45 m. Sequential is still the default.
+ - F58(d) IS CLOSED. All five harness sites build AutoFocusOptions through HarnessSettingsStore.BuildFitOptions;
+   a unit test fails the build if any TestApp source constructs it from the profile again. HocusFocusPlugin.cs
+   is deliberately exempt and CORRECT — do not "fix" it.
+ - F61 IS NEW AND IT IS THE INTERESTING ONE: the profile was reaching the harness through the SENSOR MODEL, not
+   the AF fit. SensorModel.cs:714 takes MaxOutlierRejections/OutlierRejectionConfidence for the PER-STAR curve
+   fit, so WHICH STARS entered the paraboloid depended on the active profile — sStars 613 vs 616 on toml999,
+   2800 vs 2856 on mccomiskey, and TILT THETA 7.6% APART ON muggsie. bank-verify's sigmaFocus never moved.
+ - F19's REMAINDER IS CLOSED. Three statistics over gate rejections are now refuted. The third
+   (WingRejectedExcess) is ANTI-CORRELATED with what it predicts: Spearman rho = -0.665 over 13 rungs; on D17,
+   sigma_focus 19x worse at 8s than 120s, wings and core reject at IDENTICAL rates, both exactly 0.0000.
+   DO NOT PROPOSE A FOURTH STATISTIC OVER GATE REJECTIONS. Gate rejections count what the detector THREW AWAY;
+   a starved frame's problem is what it never FOUND. Re-opening needs a different QUANTITY.
+
+THE FIRST GATE
+Wave 11's eight values have now reproduced across THREE binaries and two settings files, bit-identically:
+  toml999 0.995784 | CWhiteFocus 0.996068 | uneven 0.996368 | muggsie 0.997195
+  mccomiskey 0.976746 | D18 0.999882 | D19 0.999487 | D20 0.999738
+Re-run D:\hf_w12\gate_w12.sh shape on a FRESH exe from develop-after-#190, with BOTH
+  --settings D:\hf_w11\pinned_settings_w11.json   (md5 a67ffc06)
+  --profile-id ce3f3e63-8fd3-4b72-a0ca-d90db9441382   (astrodet)
+NAMED IN THE SCRIPT HEADER. ONE pass/fail clause; a partial reproduction is a failure. Score with
+D:\hf_w12\score_w12.py (it already carries the eight values, the wave-11 BaselineJ, and the field checks).
+Free controls, all FIELDS: BuildId (must DIFFER), DetectorVersion, ProfileId, ConcurrencyCheck, FitInputs.
+Wave 5's phi table is invalid on three axes. Do not quote it.
+
+Then, in this order, and do not reorder for convenience:
+
+1. DECIDE MaxOutlierRejections AS A PRODUCT DEFAULT. It is the through-line of waves 9-12 and NOBODY HAS ASKED
+   WHICH VALUE IS RIGHT.
+   One integer has now moved: BaselineJ by 0.0144 (F57), the two "attractors" that cost waves 9-10 (F55/F58),
+   and tilt theta by 7.6% (F61). This machine's nine profiles partition 2/7 on it. NINA's code default is 1;
+   astrodet uses 0. Every wave since 5 has treated it as machine state to be pinned. IT IS ALSO A SHIPPED
+   PRODUCT DEFAULT that decides whether the AF fit may drop one Grubbs outlier — which is exactly F45's
+   complaint (the Grubbs test rejects the IN-FOCUS point of a near-perfect curve, and the blind walk then buys
+   an extra exposure).
+   THE ARM: measure BOTH values over the bank, on the SAME frames, changing nothing else — sigma_focus and J
+   from optimize, recall/precision AND the sensor fit (sStars/sR2/sRMS/sTheta) from bank-verify. Both values
+   supplied via --settings (the fit inputs are pinned there since wave 11), so this is a settings sweep and NOT
+   a profile sweep — do not reintroduce the defect to measure it.
+   PRE-REGISTER THE "NO CHANGE" OUTCOME AS A FIRST-CLASS RESULT: if neither value dominates on the population,
+   the default STAYS and the finding is "a knob that moved every number this project argued about does not
+   decide the product" — which is a real answer. Name in advance what "dominates" means (a rule over the
+   population, not a count of wins) and what would make you SHIP a change.
+   WATCH THE ASYMMETRY F61 FOUND: the AF fit and the SENSOR fit may prefer OPPOSITE values. If they do, say so
+   and do not average them — they are different products.
+
+2. CONFIRM WAVES 8-12's AF/WIZARD CHANGES IN THE APP. THIS HAS BEEN CARRIED FOR FOUR WAVES AND MUST NOT BE
+   CARRIED A FIFTH SILENTLY.
+   The csproj PostBuild xcopy FAILS SILENTLY WHEN NINA IS RUNNING, which is why this keeps slipping. Close NINA,
+   build, verify the plugin DLL timestamp in NINA's plugin folder BEFORE launching, then launch (Start-Process,
+   NOT the MCP launch_executable — see the nina-live-verification-gotchas memory; the Simulator tilt port needs
+   the sim camera connected first).
+   Give it a HARD TIME BOUND and PRE-REGISTER WHAT TO REPORT IF BLOCKED: exactly what was tried, what failed,
+   and which specific changes remain unconfirmed BY NAME. "Not this wave's item" is not an acceptable outcome
+   for the fifth consecutive wave.
+
+3. F15 — the last structural blocker, and it is cheap.
+   `optimize --per-run` still rewrites optimized_settings.json into each run folder with no suppress flag, so a
+   population pass cannot run beside an arm. Now that fan-out is authorised this is the ONLY thing still forcing
+   passes to be serialized against each other. Add the opt-out (write only to --out unless a flag opts in, or
+   snapshot the previous file), and note the interaction F15 already records: bank-verify --opt-a/--opt-b and
+   golden eval --params optimized read the RUN FOLDER copy by default, so a prepass and a later scoring run that
+   were meant to be independent can silently share an arm.
+
+DEFERRED, WITH REASONS
+ - F59's five knobs (MaxDistortion, StarCenterTolerance, SaturationThreshold, HotpixelThreshold, Sensitivity)
+   are at CODE DEFAULTS in the pinned file since wave 5. Waves 5-12 are internally valid; the file does not
+   DESCRIBE the detector. Re-pinning MOVES THE COORDINATE SYSTEM and needs a new gate baseline. Price it.
+ - The landing-level wavelet bisect (D:\hf_w10\exe_v1wav, built wave 10, STILL UNUSED). Now doubly bounded: the
+   seed-level answer is exact and identical, and wave 12's fan-out arm showed the search does not amplify an
+   arbitrary process-level perturbation. Consider CLOSING F57(d) rather than running it.
+ - F61(b): re-running a historical tilt calibration under pinned fit inputs to see whether a published theta
+   moves. Nothing depends on it; the honest statement is "unrecorded input", not "known error".
+ - F52(d), F46(b), F54, F50: nothing depends on them.
+
+TRAPS WAVE 12 CREATED OR CARRIES
+ - ConcurrencyCheck == "exclusive" ON A SINGLE LANDING IS NOT EVIDENCE THE MACHINE WAS QUIET. WaitOne(0) is won
+   by exactly ONE of N contenders, so precisely one landing per batch truthfully reports exclusive. READ IT
+   ACROSS A WHOLE ARM.
+ - THE PROFILE SET IS MACHINE STATE AND IT MOVES. D:\hf_w12\profiles_before_w12.txt is the wave-12 snapshot
+   (astrodet is now #1 by LastUsed because the wave-12 gate pinned it eight times). Re-snapshot with
+   D:\hf_w12\snapshot_profiles_w12.py BEFORE any fan-out arm.
+ - DO NOT BUDGET FAN-OUT AT 4x. It is 1.33x (F60), and a pinned arm cannot fan out at all.
+ - Newtonsoft writes NaN and Infinity as the STRINGS "NaN"/"Infinity". Use score_excess_w12.py's num().
+ - "COULD NOT LOOK" NEEDS ITS OWN STATE AT EVERY LEVEL, INCLUDING THE SCORER'S. Wave 12's scorer was wrong
+   TWICE by conflating "the product declined" (shipped field is NaN) with "this rung can anchor a clause"
+   (sigma_focus is finite). They are different questions and a hard-floor FAIL is not the same as either.
+ - D17_cdk14_oiii5 finds ZERO STARS at 0.5s and 2s (5nm OIII) — hard-floor FAIL, everything NaN. Useful as a
+   starvation extreme; useless as a measurement.
+ - `strings <dll> | grep AtrousWaveletFast` still distinguishes v1 from v2 retroactively.
+ - The console "Optimization complete" line is NOT reliably emitted (uneven has none). aggregate_summary.json is
+   the instrument.
+ - lumos exits rc=3 reproducibly; astrodet the DATASET is frameless (F14); Panos has a degenerate sigma fit.
+ - Never rebuild an arm's directory mid-wave (F53(c)).
+
+MEASUREMENT DISCIPLINE — every line below cost this project real time
+ - A CONTROL THAT CANNOT FAIL IS NOT A CONTROL, AND "IDENTICAL" IS THE EASIEST WAY FOR ONE TO HIDE. Wave 12's
+   RULE B12 compared 692 values and found them identical — equally consistent with a fix and with a no-op. What
+   rescued it was perturbing one leaf by 1e-12 to prove the differ could speak, and B12-D asking the OPPOSITE
+   question (does the profile still move anything? 15 of 24 before, 0 of 24 after). REQUIRE THE FIX TO BE
+   VISIBLE, not merely harmless.
+ - THE FLAGGED-BUT-DEFERRED SITE WAS THE ONE THAT MATTERED. Wave 11 recorded BankVerifyRunner as "x2" and the
+   second instance was an afterthought. It was the sensor model, and it moved tilt theta 7.6%.
+ - MEASURE THE PAYOFF YOU ARE BUYING, NOT THE ONE YOU ASSUMED. Item 1 was justified as "~4x cheaper" and
+   delivers 1.33x. Write down both halves; a wave that records only the half that justified the work is how a
+   project acquires a belief it never measured.
+ - FIX THE RULE BEFORE THE DATA, AND ON THE BAR THE PREDECESSORS FACED. Wave 12's first W1 draft was stricter
+   than the rule its predecessors were held to; it was weakened and committed before the ladder rendered a
+   frame. Refuting on a stricter bar is a moved goalpost, not a refutation.
+ - THE REFUTATION THAT GENERALISES BEATS THE ONE THAT FITS. "No threshold satisfies the rule" closes one
+   candidate; "rho = -0.665, because gate rejections count what was thrown away and starvation is about what was
+   never found" closes the whole family.
+ - THE CHEAPEST INSTRUMENT IS THE ONE ALREADY PRINTED AND IGNORED. Before building one, grep the logs you have.
+ - SAY WHAT YOU DID NOT RUN, and price it.
+ - PIN --settings AND --profile-id ON EVERY ARM (except a deliberate fan-out, which must argue for itself).
+ - On CI: verify the test COUNT, not the tick (F37). An ABSENT check is more dangerous than a red one.
+   develop's baseline is 3744.
+
+Write the spec in docs/<topic>-design.md and the plan in plans/<topic>-plan.md FIRST, and COMMIT THEM BEFORE ANY
+MEASUREMENT so the pre-registration is in git history before the data. FLAG new findings in docs/followups.md.
+Finish with a PR; never push develop.
+
+Build: dotnet.exe build "$(wslpath -w <abs>/Joko.NINA.Plugins/TestApp/TestApp.csproj)" -c Release -o 'D:\hf_w13\exe'
+Tests: dotnet.exe test "$(wslpath -w <abs>/Joko.NINA.Plugins/Joko.NINA.Plugins.sln)" -c Debug --nologo
+Wave-12 artifacts: D:\hf_w12\ (exe [pre-item-2], exe2 [post-item-2], gate\, fanout\, b12d\, ladder\, bv_before\,
+  bv_after\, profiles_before_w12.txt, gate_w12.sh, fanout_w12.sh, ladder_w12.sh, bankverify_w12.sh,
+  bankverify_disc_w12.sh, score_w12.py [the gate scorer — REUSABLE AS IS], score_excess_w12.py [num() + the
+  wing pooling], compare_bv_w12.py, snapshot_profiles_w12.py, gate_score.txt, fanout_score.txt, ladder_score.txt,
+  ladder_corr.txt, b12d_score.txt, bv_compare.txt, suite.log)
+Wave-11: D:\hf_w11\ (pinned_settings_w11.json [a67ffc06], bisect\make_bisect_profile.py, det\, pop\)
+Wave-10: D:\hf_w10\ (pop\ = the 39-run population landings; exe_v1wav)
+Wave-7 that must survive: D:\hf_w7\armE (the exposure ladder), f18arms, golden\
+Banks: D:\SyntheticAutofocusBank (20 datasets), D:\Autofocus Bank (19 runs)

--- a/plans/synthetic-af-bank-followups-wave12-plan.md
+++ b/plans/synthetic-af-bank-followups-wave12-plan.md
@@ -1,0 +1,147 @@
+# Synthetic AF bank — followups wave 12 (plan)
+
+Design: [`docs/synthetic-af-bank-followups-wave12-design.md`](../docs/synthetic-af-bank-followups-wave12-design.md).
+Branch: `ghilios/synthetic-af-bank-followups-wave12` off `develop` @ `96f10b3` (PR #189's merge commit —
+**verified MERGED**).
+Artifacts: `D:\hf_w12\`.
+
+## Standing rules for every step
+
+- **`--settings D:\hf_w11\pinned_settings_w11.json` (md5 `a67ffc06…`) on every `optimize`/`bank-verify`
+  invocation**, and **`--profile-id ce3f3e63-…` (`astrodet`) on every one except item 1's fan-out arm**, whose
+  unpinning is the experiment (design §2.2).
+- **Never rebuild a build directory** (F53(c)). `D:\hf_w12\exe` = gate + item 1. `D:\hf_w12\exe2` = post-item-2.
+- **Every driver script carries its inputs and its pre-registered rule in its header**, before it runs.
+- **Every driver script refuses to start if a `TestApp.exe` is already running** (the `tasklist.exe | grep -c`
+  guard from `k8_gate_on_fixed.sh`, which handles `grep -c`'s exit-1-on-zero correctly) — except item 1's, which
+  fans out on purpose and asserts the opposite.
+- **Long runs are launched from THIS session, not from a subagent** — a subagent's background jobs die with its
+  session.
+
+---
+
+## Step 0 — Spec + plan (this document)
+
+- [x] Verify PR #189 MERGED (`96f10b3`, 2026-08-09T00:34:03Z), `develop` fetched.
+- [x] `docs/synthetic-af-bank-followups-wave12-design.md`.
+- [x] `plans/synthetic-af-bank-followups-wave12-plan.md`.
+- [ ] Commit both before any measurement, so the pre-registration is in git history **before** the data.
+
+## Step 1 — Build, and the gate (RULE G12)
+
+1. `dotnet.exe build TestApp.csproj -c Release -o 'D:\hf_w12\exe'` from the branch tip (which is `develop` plus
+   the spec/plan commit — **no code change yet**, so the gate measures `develop` after #189).
+2. Confirm `strings D:\hf_w12\exe\*.dll | grep AtrousWaveletFast` hits (v2, retroactive check per F53(a)).
+3. `D:\hf_w12\gate_w12.sh` — `k8_gate_on_fixed.sh`'s shape, both pins **named in the header**, sequential,
+   `--per-run --max-evals 250`, out to `D:\hf_w12\gate`.
+4. Score with a small python scorer reading **`aggregate_summary.json`** (NOT the console
+   `Optimization complete` line — `uneven` emits none): `BestJ`, `BaselineJ`, and the five provenance fields.
+
+**Gate:** RULE G12 — 8 of 8 `BestJ` to 6 dp against design §1's table. Report bit-identity separately.
+**Controls:** `BuildId` MUST DIFFER from `5cb7e474…`; `DetectorVersion` 2; `ProfileId` `astrodet`;
+`FitInputs` = the four values; `ConcurrencyCheck` `exclusive` on **all eight**; `BaselineJ` reproduces wave 11.
+
+**If G12 fails: STOP.** Nothing downstream is readable. Report which runs moved and by how much, and diff the
+five fields first — the answer is far more likely to be in a field than in the code.
+
+*Cost: build ~2 min, gate ~40 min.*
+
+## Step 2 — Item 1: the fan-out arm (RULE A12)
+
+1. **Re-snapshot the profile set** to `D:\hf_w12\profiles_before_w12.txt` — same format as wave 11's
+   (`LastUsed` order, id, and the four fit inputs with `*` marking an absent key), **after** the gate has pinned
+   `astrodet` eight times. A2 is scored against THIS snapshot.
+2. `D:\hf_w12\fanout_w12.sh`: the same eight runs, **4 concurrent workers**, `--settings` pinned, **no
+   `--profile-id`**, out to `D:\hf_w12\fanout`. Two batches of 4.
+3. Score the same way, plus: distinct `ProfileId`s, their `MaxOutlierRejections` groups from the snapshot,
+   `ConcurrencyCheck` per batch, and `FitInputs` equality across all eight.
+
+**RULE A12** (design §2.3): A1 eight values to 6 dp · A2 ≥2 distinct profiles spanning both MOR groups ·
+A3 ≥1 `concurrent` per batch · A4 `FitInputs` identical on all eight.
+
+- **All four ⇒ fan-out AUTHORISED AT DEGREE 4** — recorded in `followups.md` under F55 as a run rule naming the
+  degree, and `.claude/docs/testapp-cli.md` updated beside F42's/F57's pinning rules.
+- **A1 misses ⇒ sequential stands**; name the run and the delta.
+- **A2 or A3 unsatisfied ⇒ no authorisation regardless of agreement**; retry once with per-worker profile copies
+  (`make_bisect_profile.py`, fresh GUIDs, deleted afterwards), and if that also fails to spread, say so and stop.
+
+*Cost: ~20 min if authorised-degree parallelism holds; ~40 min worst case.*
+
+## Step 3 — Item 2: convert the four F58(d) runners
+
+Code, on the branch, with the suite run at the end of the step (not after every edit):
+
+1. `BankVerifyRunner.cs:160` → `new AutoFocusOptions(profileService, harnessSettings.Accessor)`.
+2. `BankVerifyRunner.cs:518` (the `SensorModel` construction) → same accessor.
+3. `SynthValidateRunner.cs:243`, `InspectAlignRunner.cs:103`, `TiltCalibrationRunner.cs:178` → same.
+4. Each runner renders `HarnessFitInputs.From(afOptions)` into the banner it already prints; `bank-verify` and
+   `synth-validate` additionally into the report they already write.
+5. **`HocusFocusPlugin.cs:119` is NOT touched** — a comment there says why, so the next reader does not "fix" it.
+6. Tests: extend `HarnessFitInputsTests` with a fixture asserting that **each converted runner's fit inputs come
+   from the FILE and not the profile** — the property, not the happy path (F59's lesson). The cheapest honest
+   form is a test over the shared construction helper each runner now calls.
+
+**RULE B12** (design §3.2) — `bank-verify` before/after on the golden-scored runs, both pinned:
+
+- **before**: `D:\hf_w12\exe` (pre-conversion), out to `D:\hf_w12\bv_before`.
+- **after**: `D:\hf_w12\exe2` (post-conversion), out to `D:\hf_w12\bv_after`.
+- Same `--settings`, same `--profile-id astrodet`, same runs, sequential.
+- **PASS = every scored quantity identical.** Any difference is a finding and gets documented as a discontinuity
+  at this commit.
+
+*Cost: code ~1 h; two `bank-verify` passes over the golden runs.*
+
+## Step 4 — Item 3: the `WingRejectedExcess` arm (RULE W12)
+
+1. Write `D:\hf_w12\ladder\ladder_w12.sh` with **the pre-registered prediction in the header** (design §4.5:
+   `D02`@0.5 s excess 0.2439, `D16`@2 s excess 0.0064 — *prediction, not verdict*), the three datasets, the
+   rungs, and RULE W12 in full.
+2. Render: `synth-bank --spec` with `exposureSecondsOverride` per rung for
+   `D17_cdk14_oiii5,D20_m24_bright_control,D05_tec140_1000mm`, rungs **0.5 / 2 / 8 / 30 / 120 s**, out to
+   `D:\hf_w12\ladder\t<rung>`. **Renders into `D:\hf_w12`, never into the bank** (F15 + the gate's folders).
+3. `optimize --per-run --max-evals 120` per (rung, dataset), pinned both ways, sequential unless step 2
+   authorised fan-out — **in which case this is the first arm to spend the authorisation, at the authorised
+   degree and no higher**.
+4. Score with a wave-12 scorer derived from `score_wing_pop_w11.py` — **its `num()`, not wave 10's** — emitting
+   per rung: σ_focus, wing fraction, inner fraction, **excess**, and the **shipped** `WingRejectedRatio`.
+5. **Instrument validation first**: offline `wf / inf_` must reproduce the shipped `WingRejectedRatio` on every
+   rung. If it does not, the scorer is wrong and no verdict is published from it.
+6. **W5's median**: recompute the excess over wave 10's 39 population landings at `D:\hf_w10\pop\` — zero
+   compute, conservative-only (design §4.4).
+7. Apply W0 → W1–W5 in order.
+
+**Outcomes** (design §4.3): empty window ⇒ **F19's remainder CLOSES**; non-empty ⇒ live candidate, **not
+adopted**, owing a fresh-population validation. Either way **no verdict, threshold, or action ships**.
+
+*Cost: render ~5–10 min; 15 optimizes at 120 evals ~20 min sequential.*
+
+## Step 5 — Suite, docs, PR
+
+1. `dotnet.exe test <sln> -c Debug --nologo` — **verify the COUNT**, not the tick (F37); `develop` is at
+   **3740**, so the delta must be named test by test. Nothing piped to `tail` (it masks the exit code).
+   `SendAsync_WritesOnABackgroundThread` is a known flake and is not chased on a full-suite run.
+2. `docs/synthetic-af-bank-followups-wave12-results.md` — provenance banner (build dirs + sha256 + `BuildId`,
+   settings md5, profile), one section per item, each with its rule and verdict, and a **"what was not run"**
+   section with prices.
+3. `docs/followups.md`: F55 (landing-level verdict + the authorisation or its refusal), F58 (d) closed or
+   narrowed, F19 (closed or the excess's verdict), and any new entry this wave produces.
+4. `.claude/docs/testapp-cli.md` if item 1 authorises fan-out.
+5. Commit with the privacy email, push the branch, open the PR against `develop`. **Never push `develop`.**
+
+## Budget
+
+| step | cost |
+|---|---|
+| build + gate | ~45 min |
+| item 1 fan-out | ~20–40 min |
+| item 2 code + 2 × `bank-verify` | ~1.5–2 h |
+| item 3 render + 15 optimizes | ~30 min |
+| suite | ~10–15 min |
+
+## What this plan deliberately does NOT do
+
+- No 39-run population pass. Item 3's verdict does not need one, and W6 bars its rows from sizing the excess.
+- No re-pin of F59's five knobs (it would move the coordinate system — design §5).
+- No wavelet landing bisect (item 1 bounds it for free — design §5).
+- No F15 fix.
+- No in-app confirmation of waves 8–10's AF/wizard changes.


### PR DESCRIPTION
## RULE G12 — the gate, first

Wave 11's eight values reproduce **bit-identically on a third binary** (`BuildId 103d61c4…`, ≠ wave 11's
`5cb7e474…`). 8 of 8 to sixteen digits, `BaselineJ` 8 of 8, `ConcurrencyCheck` `exclusive` across the whole arm,
`FitInputs` identical. Everything below is readable against a coordinate system that has now survived three
builds and two settings files.

## Item 1 — F55 at the LANDING level. Fan-out is authorised at degree 4.

Wave 11's K5 proved agreement at the **seed** level only (`--max-evals 1`); F55's **landing** rate was **44 %**,
triple that. Wave 12 ran wave 9's arm A again — the eight gate runs, at **fan-out 4**:

| clause | verdict |
|---|---|
| **A1** the eight values to 6 dp | **PASS** — 8 of 8, bit-identical to all sixteen digits |
| **A2** ≥2 profiles spanning both `MaxOutlierRejections` groups | **PASS** — **four** distinct profiles, 4 runs at `MOR`=0 and 4 at `MOR`=1 |
| **A3** the fan-out actually overlapped | **PASS** — exactly one `exclusive` per batch, three `concurrent` |
| **A4** `FitInputs` identical on all eight | **PASS** — one value across four profiles |

**A2 is what makes it mean anything.** Pre-fix, those eight landings would have partitioned into two groups.
At the measured 44 % rate, `P(8 of 8 | the defect is live) = 0.56⁸ ≈ 0.0097`.

**Two limits:** degree 4 only, and **unpinned only** — `--profile-id` + fan-out still fails loudly, so an arm
that needs a specific profile still runs sequentially.

### …and it buys 1.33×, not 4× (new: F60)

| | sequential | fan-out 4 |
|---|---|---|
| the same eight runs, wall clock | 43 m 10 s | **32 m 28 s** |
| sum of per-run busy time | 43 m 10 s | **76 m 03 s** |

Every run took **1.45–2.55× longer** under contention: `optimize` already saturates the machine, so four
processes contend rather than parallelise. **The plan's cost case was wrong by a factor of three**, and a 39-run
pass costs ~2¼ h rather than ~45 m. Filed separately from the authorisation because both facts are true and they
point in opposite directions. **Sequential stays the default.**

## Item 2 — F58(d): the last five call sites, and the one that mattered

All five remaining `new AutoFocusOptions(profileService)` sites (`BankVerifyRunner` ×2, `SynthValidateRunner`,
`InspectAlignRunner`, `TiltCalibrationRunner`) now build their fit from the pinned settings **file**, behind one
seam. The guard is on the **constructor**, not the five sites, so it covers a site nobody has written yet — and
it checks its own regex in both directions first, because a source guard whose pattern has rotted sweeps clean.
`HocusFocusPlugin.cs` is untouched and correct: in the live app the profile **is** the user's settings.

- **RULE B12** — `bank-verify` before/after, both pinned: **692 leaf values identical** to full double precision
  (comparator verified to catch a `1e-12` perturbation).
- **That is the weak question.** It is equally consistent with a conversion that did nothing, so **RULE B12-D**
  scored the same runs under a profile from the other `MaxOutlierRejections` group:

| binary | quantities that moved between profiles |
|---|---|
| pre-conversion | **15 of 24** |
| post-conversion | **0 of 24** |

### And B12-D found what the defect was actually breaking (new: F61)

`bank-verify`'s **`sigmaFocus` never moved.** The **sensor model** did — `SensorModel.cs:714` takes the rejection
budget for the **per-star** curve fit, so *which stars entered the paraboloid* depended on which profile was
active (613 vs 616 on `toml999`, 2800 vs 2856 on `mccomiskey`), and **tilt θ moved 7.6 % on `muggsie`**. Wave 11
recorded `BankVerifyRunner` as "×2" and the second instance was an afterthought; it was the one that mattered.
`inspect-align` and `tilt` fit sensor models from the same options.

## Item 3 — F19's remainder CLOSES

`WingRejectedExcess` = wing − inner got its own arm on a fresh 3 × 5 ladder (`D17_cdk14_oiii5`,
`D20_m24_bright_control`, `D05_tec140_1000mm` at 0.5/2/8/30/120 s) that neither prior refutation had touched.

| clause | dataset | measured | implies |
|---|---|---|---|
| **W1** most-starved rung must FIRE | `D17`@8 s — σ_focus **19.3× worse** than its optimum | excess **0.000000** | **T ≤ 0** |
| **W2** silent at the σ minimum | `D05`@8 s | excess **0.861389** | T > 0.861 |
| **W2** silent at the σ minimum | `D20`@0.5 s (best focus on the ladder) | excess **0.246027** | T > 0.246 |
| **W5** above the excess's bank median | 39 population runs | 0.088948 | T > 0.0889 |

`D05` **contradicts itself on its own two clauses**. But the finding is not the empty window — it is the
direction: **Spearman ρ(focus badness, excess) = −0.665** over 13 rungs. On `D17`, genuinely OIII-starved with
σ_focus 19× worse at 8 s than at 120 s, **wings and core reject at identical rates — both exactly 0.0000.**

> **Gate rejections count what the detector threw AWAY; a starved frame's problem is what it never FOUND.**
> A fourth function of the same quantity inherits the same blindness, so F19's remainder closes as
> *no statistic over gate rejections separates a starved wing from a detector that rejects noise everywhere.*

**Nothing ships from item 3** — no verdict, threshold, probe factor or action.

## Tests

**3744 passed, 0 failed** (`develop` 3740 → **+4**, each named). The **count** was verified, not the tick (F37).

## What this wave did NOT run, and what it would cost

- No 39-run population pass — item 3 fell on necessary clauses, and W6 bars its rows anyway. Now **~2¼ h**, not
  ~45 m (F60).
- No landing-level wavelet bisect. Item 1 bounds it in one direction for free.
- F59's five knobs stay at code defaults; re-pinning them moves the coordinate system.
- F15 unfixed; waves 8–10's AF/wizard changes still unconfirmed in the app.

Spec: `docs/synthetic-af-bank-followups-wave12-design.md` · Plan:
`plans/synthetic-af-bank-followups-wave12-plan.md` · Results:
`docs/synthetic-af-bank-followups-wave12-results.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QTNWdSNar6g3Nj5wXnLZc6