### PR TITLE
F70(b'): delete the 20 dead preset-owned literals from ResetDefaultsImpl

### DIFF
--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/StarDetectionOptions.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/StarDetectionOptions.cs
@@ -336,26 +336,16 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection {
             UseAdvanced = false;
             DebugMode = false;
             ModelPSF = true;
-            PSFFitType = StarDetectorPSFFitType.Moffat_40;
             Simple_NoiseLevel = NoiseLevelEnum.Typical;
             Simple_PixelScale = PixelScaleEnum.Typical;
             Simple_FocusRange = FocusRangeEnum.Typical;
             DetectionBinning = DetectionBinningEnum.Bin1;
-            HotpixelFiltering = true;
             HotpixelThresholdingEnabled = true;
             UseAutoFocusCrop = true;
-            StarMeasurementNoiseReductionEnabled = false;
-            NoiseReductionRadius = 3;
-            NoiseClippingMultiplier = 4.0; // INTERIM revert to v3.0.0.26 (lockstep with the Simple preset + optimizer seed)
-            StarClippingMultiplier = 2.0;
             ContaminationSensitivity = 5.0;
             RejectContaminatedStars = true;
-            StructureLayers = 4;
             DefocusAwareStructure = false;
             StructureLayerBoost = 0;
-            BrightnessSensitivity = 10.0; // INTERIM revert to v3.0.0.26 (lockstep with the Simple preset + optimizer seed)
-            StarPeakResponse = 0.75;
-            MaxDistortion = 0.5;
             DefocusAwareGates = false;
             DefocusDistortionSizeReference = 30.0;
             DefocusDistortionMinFactor = 0.25;
@@ -367,23 +357,13 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection {
             DonutMinAnnularityHoleFraction = 0.15;
             DonutMaxStreakEccentricity = 1.0;
             DonutSaturationBloomRadius = 0.0;
-            StarCenterTolerance = 0.3;
-            StarBackgroundBoxExpansion = 3;
-            MinStarBoundingBoxSize = 5;
-            MinHFR = 1.2;
-            StructureDilationSize = 3;
-            StructureDilationCount = 0;
-            PixelSampleSize = 1.0;
             IntermediateSavePath = Path.Combine(CoreUtil.APPLICATIONTEMPPATH, "HocusFocusIntermediate");
             if (!Directory.Exists(IntermediateSavePath)) {
                 Directory.CreateDirectory(IntermediateSavePath);
             }
             SaveIntermediateImages = false;
             PSFParallelPartitionSize = 100;
-            PSFResolution = 10;
-            PSFFitThreshold = 0.9;
             UsePSFAbsoluteDeviation = false;
-            HotpixelThreshold = 0.001d;
             SaturationThreshold = 0.99d;
             ExcludeSaturatedStarsFromHFR = true;
             MeasurementAverage = MeasurementAverageEnum.Median;
@@ -404,10 +384,21 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection {
             // ConfigureSimpleSettings, and DerivePresetSettings adds the hotpixel compensation at :221-224
             // whenever HotpixelThresholdingEnabled && HotpixelFiltering, which are both on by default.
             //
-            // The preset-owned literals above are retained as documentation of the intended defaults, but the
-            // derivation is the AUTHORITY for the 20 properties the two share — hand-transcribing them is what
-            // drifted in the first place. Pinned by StarDetectionOptionsTests
-            // .ResetDefaults_EqualsFreshConstruction_* (four entry states, every property).
+            // F70(b'). The 20 preset-owned literals that used to sit above have been REMOVED. They assigned a
+            // value and this call overwrote it before the method returned, so they could not affect the result —
+            // but they were not inert text: each ran its setter, which persists to the options accessor and
+            // raises PropertyChanged, and each stated a number that nothing forced to match the derivation.
+            // NoiseReductionRadius is why that matters: the literal said 3 while every constructed object holds
+            // 4 (the Typical base plus the +1 hotpixel compensation at DerivePresetSettings), and hand-
+            // transcribing it is exactly how the two drifted apart. DerivePresetSettings is now the single
+            // authority for those 20; the ~33 defaults that remain above are the ones it does NOT own.
+            //
+            // Do not "restore" any of the 20 for readability. Three of the survivors above are its INPUTS
+            // (Simple_NoiseLevel / Simple_PixelScale / Simple_FocusRange) and HotpixelThresholdingEnabled is READ
+            // by it for the +1 — those four look preset-owned and are not. The membership is pinned at runtime by
+            // StarDetectionOptionsTests.DerivationOwnedProperties_RevertWhenTheDerivationRuns /
+            // NotDerivationOwnedProperties_SurviveWhenTheDerivationRuns, and the removal itself is guarded by
+            // ResetDefaults_EqualsFreshConstruction_* (four entry states, every property).
             ConfigureSimpleSettings();
         }
 

--- a/docs/followups.md
+++ b/docs/followups.md
@@ -4570,10 +4570,23 @@ asserts exactly that over **four entry states and every property**. It is red ag
 unconditional `ConfigureSimpleSettings()`), which is why wave 21 Part 1 added it. **So the deletion is a
 mechanically safe edit behind an existing test** — what is missing is not safety, it is a decision.
 
-**Wave 21 did NOT delete them, deliberately.** `ResetDefaultsImpl:405-407` records an explicit prior decision —
-*"The preset-owned literals above are retained as documentation of the intended defaults, but the derivation is
-the AUTHORITY"* — and overturning a reasoned in-source decision is an owner's call, not a cleanup. Like (a), this
-half of F70 is **not decidable by measurement**: both states pass every test.
+**Wave 21 did NOT delete them, deliberately** — it recorded the choice as an owner's call, because
+`ResetDefaultsImpl` carried an explicit prior decision to keep them *"as documentation of the intended
+defaults"*, both states pass every test, and overturning a reasoned in-source decision is not a cleanup.
+
+> **DECISION TAKEN by the owner, 2026-08-11: delete them.** Proposed on branch
+> `ghilios/f70-remove-dead-preset-literals` as a PR into the wave-13 branch so the diff could be reviewed on its
+> own. All 20 removed; the 33 the derivation does not own remain. The justifying comment was rewritten to record
+> *why* they are gone and to warn against "restoring" any of them for readability — three of the survivors are
+> the derivation's own inputs. Suite **3891, unchanged**, and the guard was demonstrated able to fail: mutant
+> **M-T1** (delete the trap literal `Simple_NoiseLevel`) turns
+> `ResetDefaults_EqualsFreshConstruction_FromNonDefaultSimplePresets` red, 1 of 4.
+
+**F70(a) is untouched by this and remains open.** The other `NoiseReductionRadius = 3` — the Optimization
+Wizard's seed at `HocusFocusStarDetection.cs:428` — is **not** overwritten by any derivation and **does** take
+effect: the wizard starts its search from a radius no constructed object with hotpixel thresholding holds. Its
+own doc comment at `:417` concedes it as *"exactly one named exception"*. Deleting the `ResetDefaultsImpl`
+literals does not change that by one line.
 
 ### Next step
 Two things, and they are independent:


### PR DESCRIPTION
Deletes the 20 dead literals in `ResetDefaultsImpl` that F70 identified. **Two commits: the code change alone (`0793268`), then the register update (`5aeef69`)**, so the diff you actually need to review is one file and 20 deleted lines.

Base is `ghilios/synthetic-af-bank-followups-wave13`, not `develop`.

---

## What these lines were

Not comments — ordinary executable statements. Each ran its setter, which **persists to the options accessor** and **raises `PropertyChanged`**. What made them dead is that `ResetDefaultsImpl`'s last statement is `ConfigureSimpleSettings()`, which re-derives all 20 from the Simple-mode presets and overwrites whatever the literal just wrote.

**`NoiseReductionRadius` is the reason this matters.** The literal said **3**. Every constructed object holds **4** — the Typical preset's base plus the `+1` hotpixel compensation. Two numbers claiming to be the same default, disagreeing, because one was transcribed by hand. That drift *is* F70.

## Why behaviour cannot change

`ConfigureSimpleSettings()` has two early-returns. `ResetDefaultsImpl` sets `UseAdvanced = false` and `UseOptimizedSettings = false` **before** calling it, so neither can be taken and `DerivePresetSettings()` always runs. It assigns all 20 unconditionally — `NoiseLevelEnum` has exactly four members and the `switch` covers all four, so there is no gap where one goes unassigned.

## How the 20 were chosen

By intersecting `ResetDefaultsImpl`'s public-property assignments with `DerivePresetSettings`' — mechanically, not by eye. 53 assigned, **20 owned, 33 live, 0 unaccounted**.

```
BrightnessSensitivity  HotpixelFiltering  HotpixelThreshold  MaxDistortion  MinHFR
MinStarBoundingBoxSize  NoiseClippingMultiplier  NoiseReductionRadius  PSFFitThreshold
PSFFitType  PSFResolution  PixelSampleSize  StarBackgroundBoxExpansion  StarCenterTolerance
StarClippingMultiplier  StarMeasurementNoiseReductionEnabled  StarPeakResponse
StructureDilationCount  StructureDilationSize  StructureLayers
```

**The trap, and the reason not to do this by eye.** Four survivors *look* preset-owned and are not:

| kept | why it looks owned | why it is LIVE |
|---|---|---|
| `Simple_NoiseLevel`, `Simple_PixelScale`, `Simple_FocusRange` | the `Simple_*` prefix | they are the derivation's **INPUTS** |
| `HotpixelThresholdingEnabled` | sits beside `HotpixelFiltering`, which **is** owned | the derivation **reads** it for the `+1` and never assigns it |

A prefix heuristic deletes the three inputs and breaks Restore Defaults.

## Verification

- **Full suite: 3891 passed, 0 failed** — unchanged, no tests added or removed.
- **The guard was shown able to fail.** Mutant **M-T1** — delete the trap literal `Simple_NoiseLevel` — turns `ResetDefaults_EqualsFreshConstruction_FromNonDefaultSimplePresets` **red, 1 failed of 4**. So green here is a measurement, not a vacuous pass. Restored from a byte backup, verified sha-identical.
- Membership is separately pinned at runtime by `DerivationOwnedProperties_RevertWhenTheDerivationRuns` (20 cases) and `NotDerivationOwnedProperties_SurviveWhenTheDerivationRuns` (28), already on the base branch.

Only **1 of the 4** entry states caught M-T1 — the one that perturbs the presets. The guard's power comes from `FromNonDefaultSimplePresets`; the other three would not have noticed.

## What this does NOT do

**F70(a) is untouched and still open.** The *other* `NoiseReductionRadius = 3`, at `HocusFocusStarDetection.cs:428`, is the Optimization Wizard's seed. Nothing overwrites it and it **does** take effect — the wizard starts its search from a radius no constructed object with hotpixel thresholding ever holds. Its own doc comment at `:417` concedes it as *"exactly one named exception"*. This PR does not change that by one line.

## The comment

`ResetDefaultsImpl`'s justifying comment previously said the literals were *"retained as documentation of the intended defaults"*. That is now false, so it is rewritten to record why they are gone and to warn against restoring any of them for readability — with the four traps named.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QTNWdSNar6g3Nj5wXnLZc6
