### PR TITLE
Waves 27-30: audit the truth-protection correction, the wide-field gap, F82's carrier, and which gate binds on D01

### DIFF
--- a/.claude/docs/golden-star-set.md
+++ b/.claude/docs/golden-star-set.md
@@ -61,6 +61,15 @@ audit must not use it.** Measured against the (correct) detector positions on th
    / per-frame) + precision + **FN gate attribution** (`NO CANDIDATE` = structure/candidate-formation gap vs
    `REJECTED:<gate>` = a tunable late gate vs `ACCEPTED-elsewhere`).
 
+   **On the SYNTHETIC bank only**, `golden eval` and `bank-verify` additionally **protect** detections landing on
+   real rendered stars the golden policy dropped (`*.truth.json`, tiers `omitted` / `merged-into`) from the
+   false-positive count, at the match radius — `TestApp/SynthBank/TruthProtection.cs`, [F31](../../docs/followups.md).
+   Real-bank runs have no truth sidecar, so `TruthProtection.LoadForImage` returns null, the path is a no-op, and
+   **real-bank numbers are unaffected**. `bank-verify` announces this (`scoring: golden+truth-protected (N …
+   protected)`); **`golden eval` did not until wave 27**, so for any `golden_eval.txt` produced before then, date
+   the run against **2026-08-03** (`aaf26e8`) to know which metric you are reading. A synthetic-bank precision
+   from before that date is NOT comparable with one from after.
+
 **Donut caveat:** the per-pixel-SNR reference UNDER-counts heavily defocused donuts (their surface brightness is
 spread below the per-pixel threshold), so candidate counts fall toward the focus-sweep extremes. For donut-recall
 on the most-defocused frames, extend the reference with a matched filter (convolve `(img-bg)/σ` with a disk/annulus

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/Golden/TruthDisclosureTests.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/Golden/TruthDisclosureTests.cs
@@ -1,0 +1,447 @@
+#region "copyright"
+
+/*
+    Copyright © 2021 - 2026 George Hilios <ghilios+NINA@googlemail.com>
+
+    This Source Code Form is subject to the terms of the Mozilla Public
+    License, v. 2.0. If a copy of the MPL was not distributed with this
+    file, You can obtain one at http://mozilla.org/MPL/2.0/.
+*/
+
+#endregion "copyright"
+
+using NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization.Review;
+using NUnit.Framework;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Runtime.CompilerServices;
+using TestApp;
+using TestApp.SynthBank;
+
+namespace NINA.Joko.Plugins.HocusFocus.Tests.Golden {
+
+    /// <summary>
+    /// W27 (A). <c>bank-verify</c> carries four truth-related honesty disclosures — <c>scoringMode</c> +
+    /// <c>protectedStars</c>, <c>truthViolations</c>, <c>scoredFraction</c> and <c>precisionNull</c>.
+    /// <c>golden eval</c>, the instrument that produced the published results table, carried NONE of them, so
+    /// every stored report was written by a truth-protected instrument that could not say it was truth-protected,
+    /// could not say what chance alone would have scored, could not say whether any false positive sat on a real
+    /// star, and could not say what fraction of the detections it judged.
+    ///
+    /// <para>These pin the ported computation. Each of the three named mutants must turn one of them red:
+    /// <c>M-S1</c> deletes the <c>protectedStars</c> accumulation, <c>M-S2</c> hard-codes
+    /// <c>scoringMode = "golden"</c>, <c>M-S3</c> returns the unshifted detections from the null path.</para>
+    /// </summary>
+    [TestFixture]
+    public class TruthDisclosureTests {
+
+        private const double MatchRadius = 12.0;
+        private const double Tau = 0.3;
+        private const int FrameWidth = 4000;
+        private const int FrameHeight = 3000;
+
+        private static SyntheticStarDisposition Disp(string tier, double x, double y) =>
+            new SyntheticStarDisposition { Tier = tier, BinnedCenterX = x, BinnedCenterY = y, BinnedHfrPixels = 2.0 };
+
+        private static DetBox Det(double cx, double cy) =>
+            new DetBox(new RectD(cx - 6, cy - 6, 12, 12), cx, cy);
+
+        /// <summary>
+        /// One frame carrying every case the disclosure has to separate, scored through the REAL path
+        /// (<see cref="GoldenMatch.Match"/> then <see cref="GoldenMatch.ExcludeUnresolved"/> then
+        /// <see cref="TruthProtection.ExcludeProtected"/>) so <see cref="TruthDisclosure.Measure"/> is fed exactly
+        /// what <c>GoldenEvalRunner</c> feeds it:
+        /// <list type="bullet">
+        /// <item>a detection on a required golden star  -> true positive</item>
+        /// <item>a detection on an <c>omitted</c> truth star -> protection EXERCISED</item>
+        /// <item>a detection on nothing -> a genuine false positive that must survive</item>
+        /// <item>a detection on the golden's own <c>unresolved</c> box -> excluded before protection is consulted</item>
+        /// </list>
+        /// </summary>
+        private static TruthDisclosureFrame MeasureScenario(bool withTruth) {
+            var truth = withTruth
+                ? new List<SyntheticStarDisposition> { Disp(SyntheticTier.Omitted, 2000, 2000) }
+                : null;
+            var goldenRects = new List<RectD> { new RectD(88, 88, 24, 24) };            // centre (100,100)
+            var unresolvedRects = new List<RectD> { new RectD(1488, 1488, 24, 24) };    // centre (1500,1500)
+            var det = new List<DetBox> {
+                Det(100, 100),      // TP
+                Det(2000, 2000),    // on the omitted truth star
+                Det(3000, 3000),    // on nothing -- a real false positive
+                Det(1500, 1500)     // on the golden's unresolved box
+            };
+
+            var match = GoldenMatch.Match(goldenRects, det, GoldenMatchMode.Centroid, Tau, MatchRadius);
+            var beforeProtection = GoldenMatch.ExcludeUnresolved(match.FalsePositives, det, unresolvedRects);
+            var scoredFps = TruthProtection.ExcludeProtected(
+                beforeProtection, det, TruthProtection.ProtectionCenters(truth), MatchRadius);
+
+            return TruthDisclosure.Measure(truth, goldenRects, unresolvedRects, det,
+                beforeProtection, scoredFps, match.Pairs.Count,
+                GoldenMatchMode.Centroid, Tau, MatchRadius, FrameWidth, FrameHeight);
+        }
+
+        // ---- M-S1: the protectedStars accumulation ------------------------------------------------------------
+
+        /// <summary>
+        /// <b>M-S1 kills this.</b> <c>protectedStars</c> is protection AVAILABLE — how many real-but-unboxed truth
+        /// stars a detection could have been excused by. Deleting the accumulation reads 0, which is
+        /// indistinguishable from "the real bank, no sidecar" and is exactly the silence being repaired.
+        /// </summary>
+        [Test]
+        public void ProtectedStars_CountsEveryRealButUnboxedTruthStar_AndSumsOverFrames() {
+            var truth = new List<SyntheticStarDisposition> {
+                Disp(SyntheticTier.Omitted, 100, 100),
+                Disp(SyntheticTier.MergedInto, 200, 200),
+                Disp(SyntheticTier.Unresolved, 300, 300),    // already boxed in the golden -- not protection
+                Disp(GoldenConfidence.High, 400, 400)        // a required find -- never protected
+            };
+            var frame = TruthDisclosure.Measure(truth, new List<RectD>(), new List<RectD>(), new List<DetBox>(),
+                new List<int>(), new List<int>(), 0, GoldenMatchMode.Centroid, Tau, MatchRadius, FrameWidth, FrameHeight);
+
+            Assert.Multiple(() => {
+                Assert.That(frame.ProtectedStars, Is.EqualTo(2),
+                    "omitted + merged-into are the real-but-unboxed population; unresolved and the tiered stars are not");
+                Assert.That(TruthDisclosure.Aggregate(new[] { frame, frame }).ProtectedStars, Is.EqualTo(4),
+                    "the run total is the sum over frames, exactly as bank-verify accumulates it");
+            });
+        }
+
+        /// <summary>Availability is not exercise, and the report has to be able to tell them apart: this frame
+        /// carries one protected star and exercises it exactly once.</summary>
+        [Test]
+        public void ProtectedDetections_CountsProtectionExercised_NotProtectionAvailable() {
+            var frame = MeasureScenario(withTruth: true);
+            Assert.Multiple(() => {
+                Assert.That(frame.ProtectedStars, Is.EqualTo(1), "one omitted truth star was available to protect");
+                Assert.That(frame.ProtectedDetections, Is.EqualTo(1),
+                    "exactly one detection was removed from the false-positive count by ExcludeProtected");
+                Assert.That(frame.ScoredFp, Is.EqualTo(1),
+                    "the detection on nothing is still a false positive -- protection must not launder junk");
+            });
+        }
+
+        // ---- M-S2: the scoring mode ---------------------------------------------------------------------------
+
+        /// <summary>
+        /// <b>M-S2 kills this.</b> Hard-coding <c>"golden"</c> makes a truth-protected report claim it was scored
+        /// against the golden alone. Reports differing on this are NOT comparable on precision, so a wrong label
+        /// here silently misattributes every stored report — which is the whole of the defect (A) repairs.
+        /// </summary>
+        [Test]
+        public void ScoringMode_SaysTruthProtected_IffAFrameCarriedATruthSidecar() {
+            Assert.Multiple(() => {
+                Assert.That(TruthDisclosure.ScoringMode(0), Is.EqualTo("golden"));
+                Assert.That(TruthDisclosure.ScoringMode(1), Is.EqualTo("golden+truth-protected"));
+                Assert.That(TruthDisclosure.ScoringMode(9), Is.EqualTo("golden+truth-protected"));
+            });
+        }
+
+        /// <summary>The console line is bank-verify's, word for word, so a reader (or a grep across nine wave
+        /// roots) cannot tell the two harnesses apart.</summary>
+        [Test]
+        public void ScoringLine_IsBankVerifysWording_Verbatim_InBothDirections() {
+            Assert.Multiple(() => {
+                Assert.That(TruthDisclosure.ScoringLine(9, 231), Is.EqualTo(
+                    "  scoring: golden+truth-protected (231 real-but-unboxed truth stars protected from FP scoring across 9 frames)"));
+                Assert.That(TruthDisclosure.ScoringLine(0, 0), Is.EqualTo(
+                    "  scoring: golden (no truth sidecars; false positives scored against the golden alone)"));
+            });
+        }
+
+        [Test]
+        public void ReportLines_CarryAllFourDisclosures_PlusTheExercisedCount() {
+            var total = TruthDisclosure.Aggregate(new[] { MeasureScenario(withTruth: true) });
+            var text = string.Join("\n", TruthDisclosure.ReportLines("D09", total, framesWithTruth: 1));
+
+            Assert.Multiple(() => {
+                Assert.That(text, Does.Contain("scoringMode: golden+truth-protected"));
+                Assert.That(text, Does.Contain("protectedStars: 1"));
+                Assert.That(text, Does.Contain("protectedDetections: 1"));
+                Assert.That(text, Does.Contain("truthViolations: 0"));
+                Assert.That(text, Does.Contain("scoredFraction: 0.500"));
+                Assert.That(text, Does.Contain("precisionNull: 0.000"));
+                Assert.That(text.All(c => c < 128), Is.True, "TestApp output must be ASCII (TestAppOutputAsciiTests)");
+            });
+        }
+
+        [Test]
+        public void ReportLines_SayTheModeIsGoldenAlone_WhenNoSidecarExists() {
+            var total = TruthDisclosure.Aggregate(new[] { MeasureScenario(withTruth: false) });
+            var text = string.Join("\n", TruthDisclosure.ReportLines("mccomiskey", total, framesWithTruth: 0));
+
+            Assert.Multiple(() => {
+                Assert.That(text, Does.Contain("scoringMode: golden (no truth sidecars;"));
+                Assert.That(text, Does.Contain("precisionNull: NaN"),
+                    "no truth sidecar means no synthetic null is defined -- NaN, never a 0 a scorer would average in");
+                Assert.That(text, Does.Not.Contain("!!"), "no violation line when there are no violations");
+            });
+        }
+
+        // ---- M-S3: the null control ---------------------------------------------------------------------------
+
+        /// <summary>
+        /// <b>M-S3 kills this.</b> Returning the unshifted detections makes the "null" re-score the LIVE
+        /// correspondence, so it reports the live precision and a saturated metric passes the check that exists to
+        /// fail it. The first cut of the F31 repair read 1.000 on all 17 datasets for exactly that reason, and the
+        /// precision column alone could not show it.
+        /// </summary>
+        [Test]
+        public void PrecisionNull_IsWhatChanceAloneScores_NotTheLivePrecision() {
+            var frame = MeasureScenario(withTruth: true);
+            var livePrecision = (double)frame.ScoredTp / (frame.ScoredTp + frame.ScoredFp);
+
+            Assert.Multiple(() => {
+                Assert.That(livePrecision, Is.EqualTo(0.5).Within(1e-9), "precondition: the live metric is measuring");
+                Assert.That(frame.NullTp, Is.Zero,
+                    "shifted by (317,211) with wraparound, not one detection still lands on its golden star");
+                Assert.That(frame.NullFp, Is.EqualTo(4), "every shifted detection is unmatched");
+                Assert.That(frame.PrecisionNull, Is.EqualTo(0.0).Within(1e-9),
+                    "chance alone earns nothing here -- if this equalled the live precision the null would be measuring "
+                    + "the live correspondence, which is M-S3");
+            });
+        }
+
+        [Test]
+        public void PrecisionNull_IsNaN_WithNoTruthSidecar_SoTheRealBankReportsNoNull() {
+            var frame = MeasureScenario(withTruth: false);
+            Assert.Multiple(() => {
+                Assert.That(frame.HasTruth, Is.False);
+                Assert.That(frame.PrecisionNull, Is.NaN);
+                Assert.That(frame.NullTp + frame.NullFp, Is.Zero, "the null must not run without a truth sidecar");
+            });
+        }
+
+        /// <summary>
+        /// REPORT-ONLY has to be structural, not a promise: <c>S27-4</c> is byte-level over 360 detection
+        /// artifacts. The null works on a copy, so no ordering, membership or coordinate of the live detection
+        /// list can move.
+        /// </summary>
+        [Test]
+        public void Measure_LeavesTheLiveDetectionListExactlyAsItFoundIt() {
+            var truth = new List<SyntheticStarDisposition> { Disp(SyntheticTier.Omitted, 2000, 2000) };
+            var goldenRects = new List<RectD> { new RectD(88, 88, 24, 24) };
+            var det = new List<DetBox> { Det(100, 100), Det(2000, 2000), Det(3000, 3000) };
+            var before = det.Select(d => (d.Cx, d.Cy, d.Box.X, d.Box.Y, d.Box.W, d.Box.H)).ToList();
+
+            TruthDisclosure.Measure(truth, goldenRects, new List<RectD>(), det,
+                new List<int> { 1, 2 }, new List<int> { 2 }, 1,
+                GoldenMatchMode.Centroid, Tau, MatchRadius, FrameWidth, FrameHeight);
+
+            Assert.That(det.Select(d => (d.Cx, d.Cy, d.Box.X, d.Box.Y, d.Box.W, d.Box.H)), Is.EqualTo(before),
+                "the null control must never touch the list the scoring path scored");
+        }
+
+        // ---- truthViolations: has an exact answer, and the answer must be 0 -----------------------------------
+
+        [Test]
+        public void TruthViolations_CountsAScoredFalsePositiveSittingOnARealStar_AndIsZeroUnderTheRepair() {
+            // Truth is complete by construction, so "is there a real star here?" has an exact answer. Charging a
+            // detection of one as a false positive is the F31 signature itself.
+            var truth = new List<SyntheticStarDisposition> { Disp(SyntheticTier.Omitted, 500, 500) };
+            var det = new List<DetBox> { Det(500, 500), Det(3000, 3000) };
+            var match = GoldenMatch.Match(new List<RectD>(), det, GoldenMatchMode.Centroid, Tau, MatchRadius);
+            var beforeProtection = GoldenMatch.ExcludeUnresolved(match.FalsePositives, det, new List<RectD>());
+            var scored = TruthProtection.ExcludeProtected(
+                beforeProtection, det, TruthProtection.ProtectionCenters(truth), MatchRadius);
+
+            var repaired = TruthDisclosure.Measure(truth, new List<RectD>(), new List<RectD>(), det,
+                beforeProtection, scored, match.Pairs.Count,
+                GoldenMatchMode.Centroid, Tau, MatchRadius, FrameWidth, FrameHeight);
+            // The pre-repair path: protection never consulted, so the detection on the real star is charged.
+            var unrepaired = TruthDisclosure.Measure(truth, new List<RectD>(), new List<RectD>(), det,
+                beforeProtection, beforeProtection, match.Pairs.Count,
+                GoldenMatchMode.Centroid, Tau, MatchRadius, FrameWidth, FrameHeight);
+
+            Assert.Multiple(() => {
+                Assert.That(unrepaired.TruthViolations, Is.EqualTo(1), "precondition: the /3 metric charged this real star as junk");
+                Assert.That(repaired.TruthViolations, Is.Zero, "under the repair this has an exact answer and it must be 0");
+                Assert.That(string.Join("\n", TruthDisclosure.ReportLines("D09", unrepaired, 1)),
+                    Does.Contain("!! [D09] 1 scored false positive(s) sit on a REAL rendered star"),
+                    "non-zero must be loud, exactly as bank-verify is");
+            });
+        }
+
+        // ---- scoredFraction, and the aggregation rule ---------------------------------------------------------
+
+        [Test]
+        public void ScoredFraction_IsHowMuchOfTheDetectionSetThePrecisionRatioJudged() {
+            var frame = MeasureScenario(withTruth: true);
+            Assert.Multiple(() => {
+                Assert.That(frame.Detections, Is.EqualTo(4));
+                Assert.That(frame.ScoredTp + frame.ScoredFp, Is.EqualTo(2),
+                    "one detection was protected and one landed on an unresolved box; neither is judgeable");
+                Assert.That(frame.ScoredFraction, Is.EqualTo(0.5).Within(1e-9));
+            });
+        }
+
+        [Test]
+        public void Aggregate_SumsTheCounters_AndRecomputesTheRatiosFromTheSums() {
+            // A mean of per-frame ratios would weight a 2-detection frame like a 900-detection one. The wing
+            // frames of a defocus sweep are exactly where the detection counts diverge most, so this matters.
+            var small = new TruthDisclosureFrame { HasTruth = true, Detections = 2, ScoredTp = 1, ScoredFp = 1, NullTp = 1, NullFp = 0 };
+            var large = new TruthDisclosureFrame { HasTruth = true, Detections = 98, ScoredTp = 0, ScoredFp = 0, NullTp = 0, NullFp = 99 };
+            var total = TruthDisclosure.Aggregate(new[] { small, large });
+
+            Assert.Multiple(() => {
+                Assert.That(total.Detections, Is.EqualTo(100));
+                Assert.That(total.ScoredFraction, Is.EqualTo(0.02).Within(1e-9),
+                    "2 of 100 detections were judged -- not the 0.5 a mean of the two frame ratios would report");
+                Assert.That(total.PrecisionNull, Is.EqualTo(1.0 / 100.0).Within(1e-9));
+                Assert.That(total.HasTruth, Is.True);
+            });
+        }
+
+        [Test]
+        public void Aggregate_OfNothing_IsAllZerosAndNaNRatios_RatherThanThrowing() {
+            var total = TruthDisclosure.Aggregate(null);
+            Assert.Multiple(() => {
+                Assert.That(total.ProtectedStars, Is.Zero);
+                Assert.That(total.ScoredFraction, Is.NaN);
+                Assert.That(total.PrecisionNull, Is.NaN);
+                Assert.That(TruthDisclosure.FramesWithTruth(null), Is.Zero);
+            });
+        }
+
+        // ---- the CSV contract ---------------------------------------------------------------------------------
+
+        [Test]
+        public void CsvHeaderAndRow_AgreeOnFieldCountAndOrder() {
+            var frame = MeasureScenario(withTruth: true);
+            var header = TruthDisclosure.CsvHeaderSuffix.Split(',');
+            var row = TruthDisclosure.CsvRowSuffix(frame).Split(',');
+
+            Assert.Multiple(() => {
+                Assert.That(header, Is.EqualTo(new[] { "protectedStars", "protectedDetections", "scoredFraction", "precisionNull" }));
+                Assert.That(row, Has.Length.EqualTo(header.Length), "a header/row length mismatch silently shifts every cell");
+                Assert.That(row[0], Is.EqualTo("1"));
+                Assert.That(row[1], Is.EqualTo("1"));
+                Assert.That(row[2], Is.EqualTo("0.500"));
+                Assert.That(row[3], Is.EqualTo("0.000"));
+            });
+        }
+
+        [Test]
+        public void CsvRow_WritesNaN_RatherThanAnEmptyCellAScorerWouldReadAsZero() {
+            var row = TruthDisclosure.CsvRowSuffix(MeasureScenario(withTruth: false)).Split(',');
+            Assert.That(row[3], Is.EqualTo("NaN"));
+        }
+    }
+
+    /// <summary>
+    /// The disclosures are only worth anything if the RUNNERS actually emit them, and <c>GoldenEvalRunner</c>
+    /// cannot be linked into this project (it loads NINA rendered images), so the wiring is asserted against its
+    /// SOURCE — the same mechanism <see cref="Harness.TestAppOutputAsciiTests"/> uses, and for the same reason.
+    /// This is what makes <c>M-S2</c> reachable at its real change site: hard-coding the label in the runner
+    /// instead of deriving it turns these red.
+    /// </summary>
+    [TestFixture]
+    public class TruthDisclosureWiringTests {
+
+        /// <summary>The pre-W27 header, character for character. The disclosure columns are APPENDED after it;
+        /// if a future edit inserts one instead, this literal stops matching and the test says so — the
+        /// score_*.py scorers across nine wave roots index this file BY POSITION.</summary>
+        private const string LegacyFramesCsvHeader =
+            "focuser,params,golden,accepted,TP,FP,FN,precision,recall,f1,recallHigh,recallHighMed,recallAll,"
+            + "fnAcceptedElsewhere,fnNoCandidate,fnRejected";
+
+        [Test]
+        public void GoldenEvalRunner_DerivesTheScoringMode_AndNeverHardcodesTheLabel() {
+            var source = ReadTestAppSource("GoldenEvalRunner.cs");
+            var code = StripComments(source);
+
+            Assert.Multiple(() => {
+                Assert.That(code, Does.Contain("TruthDisclosure.ScoringLine("),
+                    "the console must report the mode ACTUALLY used, via the shared helper");
+                Assert.That(code, Does.Contain("TruthDisclosure.ReportLines("),
+                    "golden_eval.txt must carry the disclosure block");
+                Assert.That(code, Does.Not.Contain("\"golden+truth-protected\""),
+                    "a hardcoded label here silently misattributes every stored report (GoldenEvalRunner.cs house rule)");
+                Assert.That(code, Does.Not.Contain("scoringMode = \"golden\""),
+                    "M-S2: the mode must be derived from how many frames carried a sidecar, never assigned a literal");
+            });
+        }
+
+        [Test]
+        public void GoldenEvalRunner_MeasuresEveryScoredFrame_AndPassesTheTruthToTheReport() {
+            var code = StripComments(ReadTestAppSource("GoldenEvalRunner.cs"));
+            Assert.Multiple(() => {
+                Assert.That(code, Does.Contain("TruthDisclosure.Measure("),
+                    "every scored frame must be measured, or the run total is silently partial");
+                Assert.That(code, Does.Contain("fe.Truth ="),
+                    "WriteReports is reached through the frame list, which is how it is now passed the truth dispositions");
+                Assert.That(code, Does.Contain("TruthDisclosure.ViolationLine("),
+                    "a non-zero truthViolations must be loud on the console, exactly as bank-verify is");
+            });
+        }
+
+        [Test]
+        public void GoldenEvalFramesCsv_AppendsTheDisclosureColumns_NeverInsertsThem() {
+            var code = StripComments(ReadTestAppSource("GoldenEvalRunner.cs"));
+            var headerAt = code.IndexOf(LegacyFramesCsvHeader, System.StringComparison.Ordinal);
+
+            Assert.Multiple(() => {
+                Assert.That(headerAt, Is.GreaterThanOrEqualTo(0),
+                    "the pre-W27 column list must survive intact -- an inserted column re-labels every number to its right");
+                Assert.That(code.IndexOf("TruthDisclosure.CsvHeaderSuffix", System.StringComparison.Ordinal),
+                    Is.GreaterThan(headerAt), "the new columns come AFTER the legacy ones");
+                Assert.That(code, Does.Contain("TruthDisclosure.CsvRowSuffix("),
+                    "and the per-frame row must carry their values");
+            });
+        }
+
+        [Test]
+        public void BankVerifyRunner_SharesTheWording_SoTheTwoHarnessesCannotDriftApart() {
+            var code = StripComments(ReadTestAppSource("BankVerifyRunner.cs"));
+            Assert.Multiple(() => {
+                Assert.That(code, Does.Contain("TruthDisclosure.ScoringLine("));
+                Assert.That(code, Does.Contain("TruthDisclosure.ScoringMode("));
+                Assert.That(code, Does.Contain("TruthDisclosure.ViolationLine("));
+                Assert.That(code, Does.Contain("protectedDetections"),
+                    "protection EXERCISED is the number a reader needs, and bank-verify reported only availability");
+                Assert.That(code, Does.Not.Contain("\"golden+truth-protected\""),
+                    "the label lives in TruthDisclosure now; two copies is how the two harnesses came to disagree");
+            });
+        }
+
+        // ---- reading the source: FAIL, never skip -------------------------------------------------------------
+
+        private static string ReadTestAppSource(string fileName, [CallerFilePath] string thisFile = null) {
+            // .../Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/Golden/TruthDisclosureTests.cs -> .../TestApp
+            var goldenDir = Path.GetDirectoryName(thisFile);
+            var solutionDir = Path.GetDirectoryName(Path.GetDirectoryName(goldenDir));
+            var path = Path.Combine(solutionDir ?? string.Empty, "TestApp", fileName);
+            Assert.That(File.Exists(path), Is.True,
+                $"could not look: {path} does not exist (resolved from {thisFile}); a test that cannot look must not pass");
+            var source = File.ReadAllText(path);
+            Assert.That(source, Has.Length.GreaterThan(2000), $"could not look: {path} is suspiciously short");
+            return source;
+        }
+
+        /// <summary>Blanks out <c>//</c> and <c>/* */</c> comments so a doc comment quoting a label is not mistaken
+        /// for code emitting it — the same exemption, and the same reason, as the ASCII guard's comment mask.</summary>
+        private static string StripComments(string source) {
+            var sb = new System.Text.StringBuilder(source.Length);
+            var i = 0;
+            while (i < source.Length) {
+                if (source[i] == '/' && i + 1 < source.Length && source[i + 1] == '/') {
+                    while (i < source.Length && source[i] != '\n') { sb.Append(' '); i++; }
+                    continue;
+                }
+                if (source[i] == '/' && i + 1 < source.Length && source[i + 1] == '*') {
+                    while (i < source.Length && !(source[i] == '*' && i + 1 < source.Length && source[i + 1] == '/')) {
+                        sb.Append(source[i] == '\n' ? '\n' : ' ');
+                        i++;
+                    }
+                    sb.Append("  ");
+                    i = System.Math.Min(i + 2, source.Length);
+                    continue;
+                }
+                sb.Append(source[i]);
+                i++;
+            }
+            return sb.ToString();
+        }
+    }
+}

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/Joko.NINA.Plugins.HocusFocus.Tests.csproj
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/Joko.NINA.Plugins.HocusFocus.Tests.csproj
@@ -35,6 +35,10 @@
     <!-- G5's golden policy (StarTruth to GoldenFrame): pure, no NINA/OpenCV coupling, so it links the same way. -->
     <Compile Include="..\TestApp\SynthBank\GoldenFromTruth.cs" Link="Golden\GoldenFromTruth.cs" />
     <Compile Include="..\TestApp\SynthBank\TruthProtection.cs" Link="Golden\TruthProtection.cs" />
+    <!-- W27 (A): the four truth disclosures `golden eval` owes its reader. GoldenEvalRunner itself loads NINA
+         rendered images and cannot be linked, so the whole computation and every word of its wording live in this
+         one pure file, which the runner only calls. That is what makes the M-S1/M-S2/M-S3 mutants reachable. -->
+    <Compile Include="..\TestApp\SynthBank\TruthDisclosure.cs" Link="Golden\TruthDisclosure.cs" />
     <Compile Include="..\TestApp\SynthBank\ConvergenceBand.cs" Link="Bank\ConvergenceBand.cs" />
     <Compile Include="..\TestApp\SynthBank\ExposureClamp.cs" Link="Bank\ExposureClamp.cs" />
     <!-- W24 P3: the synth-validate report SCHEMA (pure POCOs + Newtonsoft attributes, no NINA/OpenCV coupling), so

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/Utility/DetectionBinningResolverTests.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/Utility/DetectionBinningResolverTests.cs
@@ -128,6 +128,94 @@ namespace NINA.Joko.Plugins.HocusFocus.Tests.Utility {
             });
         }
 
+        // The three band cases, written separately so the BELOW case cannot pass by riding on the IN case. The
+        // clamp floors the recommendation at 1, so both land on `recommended == 1` and an else-branch keyed on the
+        // factor tells a 0.7 px rig it is inside a 2-4 px range. D01/D02/D03 in the synthetic bank render at
+        // exactly 0.700 px in focus, and they are the only three the generator floors.
+
+        [Test]
+        public void DescribeRecommendationDetail_BelowTheBand_SaysSoAndPointsAtTheAxisThatMoves() {
+            var when = new DateTime(2026, 8, 13, 3, 4, 5, DateTimeKind.Utc);
+            var below = DetectionBinningResolver.DescribeRecommendationDetail(1, 0.7, when);
+            Assert.Multiple(() => {
+                Assert.That(below, Does.Not.Contain("already in that range"),
+                    "0.7 px is 4.3x below the 2-4 px band; the product must not assert it satisfies it");
+                Assert.That(below, Does.Contain("0.7 px is below that range"));
+                Assert.That(below, Does.Contain("only divides"), "binning cannot rescue an under-sampled rig");
+                Assert.That(below, Does.Contain("MinHFR"), "it must name the axis that can move (F35 / F43)");
+                // And the row has to be VISIBLE, or the wording above is written for a user who never sees it.
+                Assert.That(DetectionBinningResolver.ShouldShowRecommendation(1, 0.7), Is.True,
+                    "below the band the recommendation asks for something even though the factor agrees");
+            });
+        }
+
+        [Test]
+        public void DescribeRecommendation_BelowTheBand_DoesNotSayTheFactorIsRight() {
+            // The row is what the user READS; the tooltip is what they have to hover for. Making the row visible
+            // below the band is only half the fix if the visible line still reads as all-clear.
+            Assert.Multiple(() => {
+                var below = DetectionBinningResolver.DescribeRecommendation(1, 0.7);
+                Assert.That(below, Is.EqualTo("Measured in-focus HFR 0.7 px - below the 2-4 px range"));
+                Assert.That(below, Does.Not.Contain("is right"));
+                Assert.That(below, Has.Length.LessThan(60), "it shares the dropdown's row - a line, not a paragraph");
+                Assert.That(below, Does.Not.Contain("MinHFR"), "the remedy is the tooltip's job");
+                // Below the band with the WRONG factor still has something to act on, and that keeps the row.
+                Assert.That(DetectionBinningResolver.DescribeRecommendation(2, 0.7),
+                    Is.EqualTo("Measured in-focus HFR 0.7 px - 1x1 recommended"));
+                // In band, unchanged.
+                Assert.That(DetectionBinningResolver.DescribeRecommendation(1, 3.0),
+                    Is.EqualTo("Measured in-focus HFR 3.0 px - 1x1 is right"));
+            });
+        }
+
+        [Test]
+        public void DescribeRecommendationDetail_InTheBand_KeepsTheInRangeWording() {
+            var when = new DateTime(2026, 8, 13, 3, 4, 5, DateTimeKind.Utc);
+            var inBand = DetectionBinningResolver.DescribeRecommendationDetail(1, 3.0, when);
+            Assert.Multiple(() => {
+                Assert.That(inBand, Does.Contain("3.0 px is already in that range"));
+                Assert.That(inBand, Does.Contain("binning is not needed"));
+                Assert.That(inBand, Does.Not.Contain("MinHFR"), "there is nothing to fix at the target HFR");
+                // Nothing to ask for: the setting matches and the measurement is where the knobs are calibrated.
+                Assert.That(DetectionBinningResolver.ShouldShowRecommendation(1, 3.0), Is.False);
+            });
+        }
+
+        [Test]
+        public void DescribeRecommendationDetail_AboveTheBand_DescribesTheDivision() {
+            var when = new DateTime(2026, 8, 13, 3, 4, 5, DateTimeKind.Utc);
+            Assert.That(DetectionBinningResolver.RecommendFromHfr(6.0), Is.EqualTo(2));
+
+            var above = DetectionBinningResolver.DescribeRecommendationDetail(1, 6.0, when);
+            Assert.Multiple(() => {
+                Assert.That(above, Does.Contain("2x2"));
+                Assert.That(above, Does.Contain("3.0 px"), "it must say where the division lands the star size");
+                Assert.That(above, Does.Not.Contain("already in that range"));
+                Assert.That(DetectionBinningResolver.ShouldShowRecommendation(1, 6.0), Is.True);
+            });
+        }
+
+        [Test]
+        public void RecommendFromHfr_IsUnchangedByTheBandWording() {
+            // The band split changes what the user is TOLD and nothing else. RecommendFromHfr is the single source
+            // of truth the options page, the wizard and the documentation all cite, so a moved value here would be
+            // a silent detection-behavior change on upgrade. Pinned across below / in / above the band.
+            var pinned = new (double Hfr, int Factor)[] {
+                (0.3, 1), (0.7, 1), (1.0, 1), (1.5, 1), (1.9, 1),      // below the 2 px lower edge
+                (2.0, 1), (3.0, 1), (3.6, 1), (4.4, 1),                // in band, and the rounding shoulder
+                (4.5, 2), (4.6, 2), (6.0, 2), (7.5, 3), (11.0, 4),     // above
+                (13.5, 4), (40.0, 4),                                  // clamped at the maximum factor
+            };
+            Assert.Multiple(() => {
+                foreach (var (hfr, factor) in pinned) {
+                    Assert.That(DetectionBinningResolver.RecommendFromHfr(hfr), Is.EqualTo(factor), $"HFR {hfr}");
+                }
+                Assert.That(DetectionBinningResolver.RecommendFromHfr(double.NaN), Is.EqualTo(1));
+                Assert.That(DetectionBinningResolver.RecommendFromHfr(0.0), Is.EqualTo(1));
+                Assert.That(DetectionBinningResolver.RecommendFromHfr(-3.0), Is.EqualTo(1));
+            });
+        }
+
         [Test]
         public void DiffersFromRecommendation_IsFalseWithoutAMeasurement() {
             // No measurement means no advice, so nothing to disagree with — the UI must not highlight a mismatch

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/Utility/DetectionBinningResolver.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/Utility/DetectionBinningResolver.cs
@@ -36,12 +36,27 @@ namespace NINA.Joko.Plugins.HocusFocus.Utility {
     /// <para>Nothing here ever CHANGES the setting. The recommendation is text the user acts on, deliberately:
     /// a factor that applied itself would change detection behavior on upgrade and invalidate settings the user
     /// had already tuned.</para>
+    ///
+    /// <para>The band is stated on BOTH sides. ABOVE it binning is the remedy, so the recommendation names a
+    /// factor. BELOW <see cref="MinCalibratedHfrPixels"/> there is no remedy here at all - binning only DIVIDES,
+    /// so no factor makes a star larger - and the recommendation therefore stays at 1x1 while the text says the
+    /// measurement is outside the calibrated range and points at MinHFR, the axis that can move. It must never
+    /// tell a user below the band that they are "already in that range": the clamp floors the factor at 1, which
+    /// is why the two cases look identical to <see cref="RecommendFromHfr"/> and must not look identical to the
+    /// reader.</para>
     /// </summary>
     public static class DetectionBinningResolver {
 
         /// <summary>The in-focus HFR (in binned pixels) the recommendation aims for: the center of the detector's
         /// calibrated 2-4 px band.</summary>
         public const double TargetHfrPixels = 3.0;
+
+        /// <summary>The LOWER edge of that band, in the same captured pixels: <see cref="TargetHfrPixels"/> less the
+        /// band's 1 px half-width, so the two constants cannot say different things about where the band sits.
+        /// Below this the pixel-unit knobs are outside the regime they were calibrated in. Named here rather than
+        /// written as a literal at each site so the tooltip's wording and the visibility rule cannot drift apart.
+        /// </summary>
+        public const double MinCalibratedHfrPixels = TargetHfrPixels - 1.0;
 
         /// <summary>The largest factor the recommendation will suggest (and the largest the options UI offers).</summary>
         public const int MaxBinningFactor = 4;
@@ -69,6 +84,11 @@ namespace NINA.Joko.Plugins.HocusFocus.Utility {
         /// The short recommendation shown beside the setting, built from a MEASURED in-focus HFR. Leads with the
         /// measurement, because that is the fact; the factor follows from it. Short enough to share the dropdown's
         /// row. NaN (nothing measured yet) says how to get one rather than guessing.
+        ///
+        /// <para>This is the line the user READS; the tooltip is the line they have to hover for. So below the
+        /// band it must not settle for "{n}x{n} is right", which reads as all-clear on the one surface that is
+        /// always visible. It states the position and stops there — the remedy belongs in
+        /// <see cref="DescribeRecommendationDetail"/>, which has room for it.</para>
         /// </summary>
         public static string DescribeRecommendation(int currentFactor, double measuredHfrPixels) {
             if (!IsUsableHfr(measuredHfrPixels)) {
@@ -77,9 +97,16 @@ namespace NINA.Joko.Plugins.HocusFocus.Utility {
             var current = Clamp(currentFactor);
             var recommended = RecommendFromHfr(measuredHfrPixels);
             var ci = CultureInfo.CurrentCulture;
-            return current == recommended
-                ? string.Format(ci, "Measured in-focus HFR {0:0.0} px - {1}x{1} is right", measuredHfrPixels, recommended)
-                : string.Format(ci, "Measured in-focus HFR {0:0.0} px - {1}x{1} recommended", measuredHfrPixels, recommended);
+            if (current != recommended) {
+                // A factor to change is the actionable fact on either side of the band, so it keeps the row.
+                return string.Format(ci, "Measured in-focus HFR {0:0.0} px - {1}x{1} recommended", measuredHfrPixels, recommended);
+            }
+            if (IsBelowCalibratedBand(measuredHfrPixels)) {
+                // The factor agrees and is still not the story: below the band no factor helps. Reached through the
+                // SAME helper as the tooltip, so the two surfaces cannot disagree about where the band starts.
+                return string.Format(ci, "Measured in-focus HFR {0:0.0} px - below the 2-4 px range", measuredHfrPixels);
+            }
+            return string.Format(ci, "Measured in-focus HFR {0:0.0} px - {1}x{1} is right", measuredHfrPixels, recommended);
         }
 
         /// <summary>The reasoning behind <see cref="DescribeRecommendation"/>, for its tooltip.</summary>
@@ -97,11 +124,20 @@ namespace NINA.Joko.Plugins.HocusFocus.Utility {
             var when = measuredAtUtc.HasValue
                 ? $"Measured {measuredAtUtc.Value.ToLocalTime():g} from your last auto-focus, in captured pixels."
                 : "Measured from your last auto-focus, in captured pixels.";
-            var reasoning = recommended > 1
-                ? string.Format(ci, " Star detection is calibrated for in-focus stars of roughly 2 to 4 px; at {0:0.0} px, binning {1}x{1} for detection brings that to about {2:0.0} px.",
-                    measuredHfrPixels, recommended, measuredHfrPixels / recommended)
-                : string.Format(ci, " Star detection is calibrated for in-focus stars of roughly 2 to 4 px, and {0:0.0} px is already in that range, so binning is not needed.",
+            // Three cases, not two. RecommendFromHfr clamps to 1 both when the measurement is IN the band and when
+            // it is below it, so an else-branch keyed on the factor alone tells an under-sampled rig it is in a
+            // range it is nowhere near. Split on the measurement instead.
+            string reasoning;
+            if (recommended > 1) {
+                reasoning = string.Format(ci, " Star detection is calibrated for in-focus stars of roughly 2 to 4 px; at {0:0.0} px, binning {1}x{1} for detection brings that to about {2:0.0} px.",
+                    measuredHfrPixels, recommended, measuredHfrPixels / recommended);
+            } else if (IsBelowCalibratedBand(measuredHfrPixels)) {
+                reasoning = string.Format(ci, " Star detection is calibrated for in-focus stars of roughly 2 to 4 px, and {0:0.0} px is below that range. Detection binning cannot help here: it only divides, so no factor makes a star larger. The setting that can is MinHFR - lower it so stars this small are not rejected, or run the Star Detection Optimization wizard, which seeds it from the sweep.",
                     measuredHfrPixels);
+            } else {
+                reasoning = string.Format(ci, " Star detection is calibrated for in-focus stars of roughly 2 to 4 px, and {0:0.0} px is already in that range, so binning is not needed.",
+                    measuredHfrPixels);
+            }
 
             return when + reasoning + " Changing focal length, pixel size or capture binning discards this measurement, so it always describes the current rig.";
         }
@@ -112,13 +148,20 @@ namespace NINA.Joko.Plugins.HocusFocus.Utility {
             => IsUsableHfr(measuredHfrPixels) && Clamp(currentFactor) != RecommendFromHfr(measuredHfrPixels);
 
         /// <summary>
-        /// Whether the recommendation is worth showing at all: only when it asks for something. That is either
-        /// "run an auto-focus so there is something to recommend from", or "the factor you have is not the one
-        /// your measurement calls for". A recommendation that merely confirms the current setting is noise —
-        /// it occupies a row to say nothing, and trains the eye to skip the line that matters.
+        /// Whether the recommendation is worth showing at all: only when it asks for something. That is "run an
+        /// auto-focus so there is something to recommend from", "your stars are below the band the detector is
+        /// calibrated for, and binning is not the fix", or "the factor you have is not the one your measurement
+        /// calls for". A recommendation that merely confirms the current setting is noise — it occupies a row to
+        /// say nothing, and trains the eye to skip the line that matters.
+        ///
+        /// <para>The below-band case is here because the clamp makes it INDISTINGUISHABLE from agreement: the
+        /// recommendation is 1x1 and the setting is 1x1, so a rule written on the factor alone hides the row from
+        /// exactly the users whose rig is outside the calibrated range.</para>
         /// </summary>
         public static bool ShouldShowRecommendation(int currentFactor, double measuredHfrPixels)
-            => !IsUsableHfr(measuredHfrPixels) || DiffersFromRecommendation(currentFactor, measuredHfrPixels);
+            => !IsUsableHfr(measuredHfrPixels)
+                || IsBelowCalibratedBand(measuredHfrPixels)
+                || DiffersFromRecommendation(currentFactor, measuredHfrPixels);
 
         /// <summary>
         /// Re-stamps an already-built parameter bundle onto a different binning factor, keeping
@@ -138,6 +181,15 @@ namespace NINA.Joko.Plugins.HocusFocus.Utility {
 
         private static bool IsUsableHfr(double hfrPixels)
             => !double.IsNaN(hfrPixels) && !double.IsInfinity(hfrPixels) && hfrPixels > 0.0;
+
+        /// <summary>
+        /// Whether a usable measurement falls BELOW <see cref="MinCalibratedHfrPixels"/>. The ONE expression behind
+        /// both the tooltip's below-band wording and the visibility rule, so the row can never be hidden from a
+        /// user the wording was written for. It deliberately does not reach <see cref="RecommendFromHfr"/>: this
+        /// changes what the user is TOLD, never what is recommended.
+        /// </summary>
+        private static bool IsBelowCalibratedBand(double hfrPixels)
+            => IsUsableHfr(hfrPixels) && hfrPixels < MinCalibratedHfrPixels;
 
         private static int Clamp(int factor) => Math.Max(1, Math.Min(MaxBinningFactor, factor));
     }

--- a/Joko.NINA.Plugins/TestApp/BankVerifyRunner.cs
+++ b/Joko.NINA.Plugins/TestApp/BankVerifyRunner.cs
@@ -299,11 +299,11 @@ namespace TestApp {
                     protectedStars += TruthProtection.BuildProtectionBoxes(td, effectiveMatchRadius).Count;
                 }
             }
-            var scoringMode = truthByFocuser.Count > 0 ? "golden+truth-protected" : "golden";
-            Console.WriteLine($"  scoring: {scoringMode}"
-                + (truthByFocuser.Count > 0
-                    ? $" ({protectedStars} real-but-unboxed truth stars protected from FP scoring across {truthByFocuser.Count} frames)"
-                    : " (no truth sidecars; false positives scored against the golden alone)"));
+            // W27 (A): the mode and its wording now come from TruthDisclosure, which `golden eval` also uses. The
+            // emitted string is unchanged -- what changes is that the two harnesses can no longer word the same
+            // disclosure differently, which is how they came to disagree about reporting it at all.
+            var scoringMode = TruthDisclosure.ScoringMode(truthByFocuser.Count);
+            Console.WriteLine(TruthDisclosure.ScoringLine(truthByFocuser.Count, protectedStars));
 
             // RunEvaluationData for the AF fit (mirrors OptimizationDiagnosticRunner.PrepareRunAsync).
             var stepSize = InferStepSize(ordered.Select(f => (double)f.FocuserPosition).ToList());
@@ -429,6 +429,10 @@ namespace TestApp {
             int tp = 0, fp = 0, fn = 0, matchedHigh = 0, totalHigh = 0, matchedAll = 0, totalAll = 0;
             // /5 instrument self-checks — see the header comment on the schema field.
             int detections = 0, truthViolations = 0, nullTp = 0, nullFp = 0;
+            // W27 (A): protection EXERCISED. `protectedStars` on the run is protection AVAILABLE, and this runner
+            // reported only that -- a run can carry hundreds of protected stars and exercise none of them, so
+            // availability alone cannot be read as the size of the correction.
+            int protectedDetections = 0;
             var sensorFrames = new List<SensorDetectedStars>();
             DrawingSize imageSize = DrawingSize.Empty;
             foreach (var (focuser, path, image) in loaded) {
@@ -461,11 +465,13 @@ namespace TestApp {
                     truthByFocuser.TryGetValue(focuser, out var td);
                     var unresolvedRects = (gf.Unresolved ?? new List<GoldenStarBox>())
                         .Select(b => new RectD(b.X, b.Y, b.W, b.H)).ToList();
+                    var falsePositivesBeforeProtection = GoldenMatch.ExcludeUnresolved(match.FalsePositives, det, unresolvedRects);
                     var falsePositives = TruthProtection.ExcludeProtected(
-                        GoldenMatch.ExcludeUnresolved(match.FalsePositives, det, unresolvedRects),
+                        falsePositivesBeforeProtection,
                         det, TruthProtection.ProtectionCenters(td), matchRadius);
                     tp += match.Pairs.Count; fp += falsePositives.Count; fn += match.FalseNegatives.Count;
                     detections += det.Count;
+                    protectedDetections += falsePositivesBeforeProtection.Count - falsePositives.Count;
 
                     // The F31 signature, counted rather than reasoned about: a scored false positive that sits on
                     // a REAL rendered star. Complete by construction, so this has an exact answer and the answer
@@ -505,6 +511,7 @@ namespace TestApp {
             cm.recallHigh = totalHigh > 0 ? (double)matchedHigh / totalHigh : double.NaN;
             cm.detections = detections;
             cm.truthViolations = truthViolations;
+            cm.protectedDetections = protectedDetections;
             // How much of the detection set the precision ratio actually saw. Protection removes a detection from
             // BOTH sides rather than crediting it, so a low value does not bias precision — but it does mean the
             // number rests on a smaller sample, and at Sensitivity 0 that reaches ~57% on D17. Reported so a reader
@@ -513,12 +520,12 @@ namespace TestApp {
             cm.precisionNull = (nullTp + nullFp) > 0 ? (double)nullTp / (nullTp + nullFp) : double.NaN;
 
             // Sensor-model paraboloid fit (reuses SensorModel.RegisterStarsAndFit, like inspect-align).
-            Prog($"  [{label}] golden done (P={cm.precision:F3} null={cm.precisionNull:F3} viol={cm.truthViolations} R@hi={cm.recallHigh:F3}); sensor fit start");
+            Prog($"  [{label}] golden done (P={cm.precision:F3} null={cm.precisionNull:F3} viol={cm.truthViolations} protDet={cm.protectedDetections} R@hi={cm.recallHigh:F3}); sensor fit start");
             if (cm.truthViolations > 0) {
                 // Loud on purpose. This is the exact shape of F31, and four harness-calibration bugs have now
-                // been found by someone happening to look rather than by anything failing.
-                Console.WriteLine($"    !! [{label}] {cm.truthViolations} scored false positive(s) sit on a REAL rendered star "
-                    + "-- the precision metric is charging for correct detections again (F31). Precision from this run is not trustworthy.");
+                // been found by someone happening to look rather than by anything failing. The wording is shared
+                // with `golden eval` (TruthDisclosure) so the same defect reads the same way in both harnesses.
+                Console.WriteLine(TruthDisclosure.ViolationLine(label, cm.truthViolations));
                 Logger.Warning($"bank-verify {label}: {cm.truthViolations} scored false positives land within the match radius of a truth star (F31 regression)");
             }
             try {
@@ -668,9 +675,10 @@ namespace TestApp {
                 pixelScaleMode,
                 // Aggregate of the per-run scoringMode: "golden+truth-protected" iff every scored run had a
                 // truth sidecar, "golden" iff none did, "mixed" otherwise (a bank holding both kinds).
-                scoringMode = (runs.Count(r => r.scoringMode == "golden+truth-protected"), runs.Count(r => r.scoringMode == "golden")) switch {
-                    (> 0, 0) => "golden+truth-protected",
-                    (0, > 0) => "golden",
+                scoringMode = (runs.Count(r => r.scoringMode == TruthDisclosure.ModeTruthProtected),
+                               runs.Count(r => r.scoringMode == TruthDisclosure.ModeGolden)) switch {
+                    (> 0, 0) => TruthDisclosure.ModeTruthProtected,
+                    (0, > 0) => TruthDisclosure.ModeGolden,
                     (0, 0) => "none",
                     _ => "mixed"
                 },
@@ -821,6 +829,13 @@ namespace TestApp {
             /// correct whatever tier the golden policy gave it. Non-zero means F31 has regressed and this run's
             /// precision is not trustworthy. Always 0 on the real bank, which has no truth sidecar.</summary>
             public int truthViolations { get; set; }
+            /// <summary>Protection EXERCISED: how many detections <c>TruthProtection.ExcludeProtected</c> actually
+            /// removed from this config's false-positive count. The run-level <c>protectedStars</c> is protection
+            /// AVAILABLE and was, until W27, the only one of the pair reported — a run can carry hundreds of
+            /// protected stars and exercise none of them, so availability alone does not tell a reader how big
+            /// the correction to precision was. ADDITIVE and derived, so the <c>afbank-verify</c> schema is
+            /// deliberately NOT bumped: no number changes and every prior report stays comparable.</summary>
+            public int protectedDetections { get; set; }
             /// <summary>Fraction of <see cref="detections"/> that entered the precision ratio (the rest landed on
             /// protected or unresolved reference objects and are unjudgeable). Not a bias — protection removes a
             /// detection from both numerator and denominator — but precision rests on a smaller sample as this

--- a/Joko.NINA.Plugins/TestApp/GoldenEvalRunner.cs
+++ b/Joko.NINA.Plugins/TestApp/GoldenEvalRunner.cs
@@ -88,6 +88,12 @@ namespace TestApp {
             public int MatchedHigh, TotalHigh, MatchedHighMed, TotalHighMed, MatchedAll, TotalAll;
             public Dictionary<int, PrecisionRecall> PerRegion = new Dictionary<int, PrecisionRecall>();
             public double DefocusOffset; // |focuser - best| in steps (filled later)
+
+            /// <summary>W27 (A): this frame's truth-related disclosures — scoringMode's input, protectedStars,
+            /// protectedDetections, truthViolations, scoredFraction and precisionNull. Carried on the frame so
+            /// <see cref="WriteReports"/> is passed the truth dispositions it previously was not: every stored
+            /// golden_eval report was written by a truth-protected instrument that could not say so.</summary>
+            public TruthDisclosureFrame Truth = new TruthDisclosureFrame();
         }
 
         public static async Task Run(string[] args) {
@@ -302,8 +308,13 @@ namespace TestApp {
                 var unresolvedRects = (gf.Unresolved ?? new List<GoldenStarBox>())
                     .Select(b => new RectD(b.X, b.Y, b.W, b.H)).ToList();
                 var match = GoldenMatch.Match(goldenRects, det, matchMode, tau, effectiveMatchRadius);
+                // W27 (A): the unresolved-excluded list is NAMED rather than inlined, so `protectedDetections` —
+                // how much protection was actually EXERCISED — is the difference between it and the scored list
+                // instead of something a reader has to re-derive. Identical call, identical arguments, identical
+                // result: this is a rename, and the scored numbers below are byte-for-byte what they were.
+                var falsePositivesBeforeProtection = GoldenMatch.ExcludeUnresolved(match.FalsePositives, det, unresolvedRects);
                 var falsePositives = TruthProtection.ExcludeProtected(
-                    GoldenMatch.ExcludeUnresolved(match.FalsePositives, det, unresolvedRects),
+                    falsePositivesBeforeProtection,
                     det, TruthProtection.ProtectionCenters(truthDispositions), effectiveMatchRadius);
 
                 var fe = new FrameEval {
@@ -318,6 +329,14 @@ namespace TestApp {
                         ? Math.Abs(frame.FocuserPosition - bestFocuser.Value) / (double)stepSize
                         : double.NaN
                 };
+
+                // W27 (A): the four disclosures bank-verify carries and this harness did not. REPORT-ONLY by
+                // construction — Measure is handed the results the scoring path already produced and never
+                // re-runs, re-orders or re-filters them, and its null control works on a copy of `det`.
+                fe.Truth = TruthDisclosure.Measure(
+                    truthDispositions, goldenRects, unresolvedRects, det,
+                    falsePositivesBeforeProtection, falsePositives, match.Pairs.Count,
+                    matchMode, tau, effectiveMatchRadius, fullW, fullH);
 
                 // Per-confidence recall (cuts: high; high+med; all). A golden box is "matched" iff it is in a TP pair.
                 var matchedGolden = new HashSet<int>(match.Pairs.Select(x => x.Golden));
@@ -400,6 +419,22 @@ namespace TestApp {
                 Console.WriteLine($"  run '{run.RunId}': no per-image golden sidecars found; nothing scored.");
                 return;
             }
+
+            // W27 (A): say, on the console and before the report, what this run was actually scored under. The
+            // wording is BankVerifyRunner's verbatim, so the two harnesses cannot drift apart and a grep for
+            // `scoring:` finds both. The mode is DERIVED from how many frames carried a sidecar -- a hardcoded
+            // label here would silently misattribute every stored report, which is the defect being repaired.
+            var truthTotal = TruthDisclosure.Aggregate(frameEvals.Select(f => f.Truth));
+            var framesWithTruth = TruthDisclosure.FramesWithTruth(frameEvals.Select(f => f.Truth));
+            Console.WriteLine(TruthDisclosure.ScoringLine(framesWithTruth, truthTotal.ProtectedStars));
+            Console.WriteLine(TruthDisclosure.ProtectedDetectionsLine(truthTotal.ProtectedDetections, truthTotal.ProtectedStars));
+            if (truthTotal.TruthViolations > 0) {
+                // Loud on purpose, exactly as bank-verify is: truth is complete by construction, so this has an
+                // exact answer and the answer must be 0.
+                Console.WriteLine(TruthDisclosure.ViolationLine(run.RunId, truthTotal.TruthViolations));
+                Logger.Warning($"golden eval {run.RunId}: {truthTotal.TruthViolations} scored false positives land within the match radius of a truth star (F31 regression)");
+            }
+
             WriteReports(runOut, run.RunId, paramsLabel, sourceLabel, p, frameEvals, matchMode, tau, effectiveMatchRadius,
                 effectivePixelScale, pixelScaleSource, matchRadiusSource);
         }
@@ -632,9 +667,12 @@ namespace TestApp {
             StarDetectorParams p, List<FrameEval> frames, GoldenMatchMode matchMode, double tau, double matchRadius,
             double pixelScale, string pixelScaleSource, string matchRadiusSource) {
 
-            // CSV (per-frame).
+            // CSV (per-frame). W27 (A): the truth disclosures are APPENDED at the end and never inserted -- the
+            // score_*.py scorers across nine wave roots index this file BY POSITION, so an inserted column
+            // silently re-labels every number to its right.
             var csv = new StringBuilder();
-            csv.AppendLine("focuser,params,golden,accepted,TP,FP,FN,precision,recall,f1,recallHigh,recallHighMed,recallAll,fnAcceptedElsewhere,fnNoCandidate,fnRejected");
+            csv.AppendLine("focuser,params,golden,accepted,TP,FP,FN,precision,recall,f1,recallHigh,recallHighMed,recallAll,fnAcceptedElsewhere,fnNoCandidate,fnRejected"
+                + "," + TruthDisclosure.CsvHeaderSuffix);
             foreach (var f in frames.OrderBy(f => f.FocuserPosition)) {
                 var pr = PrecisionRecall.Compute(f.TP, f.FP, f.FN);
                 var fnRej = f.FnByGate.Values.Sum();
@@ -642,7 +680,8 @@ namespace TestApp {
                     f.FocuserPosition, Csv(paramsLabel), f.GoldenCount, f.Accepted, f.TP, f.FP, f.FN,
                     Fmt(pr.Precision), Fmt(pr.Recall), Fmt(pr.F1),
                     Ratio(f.MatchedHigh, f.TotalHigh), Ratio(f.MatchedHighMed, f.TotalHighMed), Ratio(f.MatchedAll, f.TotalAll),
-                    f.FnAcceptedElsewhere, f.FnNoCandidate, fnRej));
+                    f.FnAcceptedElsewhere, f.FnNoCandidate, fnRej,
+                    TruthDisclosure.CsvRowSuffix(f.Truth)));
             }
             File.WriteAllText(Path.Combine(runOut, "golden_eval_frames.csv"), csv.ToString());
 
@@ -689,6 +728,16 @@ namespace TestApp {
             sb.AppendLine($"  recall@high={Ratio(frames.Sum(f => f.MatchedHigh), frames.Sum(f => f.TotalHigh))}  " +
                 $"recall@high+med={Ratio(frames.Sum(f => f.MatchedHighMed), frames.Sum(f => f.TotalHighMed))}  " +
                 $"recall@all={Ratio(frames.Sum(f => f.MatchedAll), frames.Sum(f => f.TotalAll))}");
+            sb.AppendLine();
+
+            // W27 (A): the four honesty disclosures bank-verify has always carried and this harness -- the one
+            // that produced the published results table -- carried none of. Placed directly under OVERALL because
+            // it is what the precision on that line was scored under, not a footnote to it. The mode is DERIVED
+            // from the frames, never hardcoded: see the identical rule on `matchLabel` above.
+            var truthTotal = TruthDisclosure.Aggregate(frames.Select(f => f.Truth));
+            foreach (var line in TruthDisclosure.ReportLines(runId, truthTotal, TruthDisclosure.FramesWithTruth(frames.Select(f => f.Truth)))) {
+                sb.AppendLine(line);
+            }
             sb.AppendLine();
 
             sb.AppendLine("PER-FRAME (sorted by focuser):");

--- a/Joko.NINA.Plugins/TestApp/SynthBank/GoldenFromTruth.cs
+++ b/Joko.NINA.Plugins/TestApp/SynthBank/GoldenFromTruth.cs
@@ -31,8 +31,28 @@ namespace TestApp.SynthBank {
         /// required-find and false-positive sets — see <see cref="GoldenFrame.Unresolved"/>.</summary>
         public const string Unresolved = "unresolved";
 
-        /// <summary>The star was dropped entirely: it produces no box anywhere in <see cref="GoldenFrame"/>,
-        /// so a detector reporting something at its location should be scored as a false positive.</summary>
+        /// <summary>
+        /// The star was dropped entirely: it produces no box anywhere in <see cref="GoldenFrame"/>. It is
+        /// nevertheless a REAL rendered star, so a detector reporting something at its location must NOT be
+        /// scored as a false positive — see <see cref="TruthProtection"/>, which recovers these from the truth
+        /// sidecar and excludes detections of them from false-positive scoring (F31).
+        ///
+        /// <para><b>This comment previously said the opposite</b> ("a detection here should count as a false
+        /// positive"), contradicting <see cref="GoldenTierThresholds.UnresolvedSnr"/> one screen away, whose
+        /// reasoning is the correct one: below ~3.5 sigma the reference's own peak-pixel test cannot certify
+        /// visibility either way, and charging a detector for finding something the reference cannot judge is
+        /// punishment, not measurement. The implementation followed the harsher sentence, so the LESS certifiable
+        /// a star was, the HARSHER the detector was judged for finding it; measured on the F23 wave-1 arms, 96%
+        /// of the bank's reported false positives were real rendered stars.</para>
+        ///
+        /// <para><b>The stale sentence is still on disk.</b> The <c>Reason</c> string generated for an omitted
+        /// component (see <c>GoldenFromTruth</c>'s bucketing) carries the pre-repair wording, and it is written
+        /// into all 180 <c>*.golden.json</c> sidecars in the bank. It is deliberately NOT regenerated: nothing
+        /// reads <c>Reason</c> programmatically, whereas regenerating the sidecars would invalidate every
+        /// precision/recall number this series has published. Read a sidecar's <c>Reason</c> as a record of the
+        /// policy at generation time, not as the scoring rule — the scoring rule is this comment and
+        /// <see cref="TruthProtection"/>.</para>
+        /// </summary>
         public const string Omitted = "omitted";
 
         /// <summary>The star is a non-representative member of a merged component; its own light was folded
@@ -80,6 +100,13 @@ namespace TestApp.SynthBank {
         /// filter and no local background estimate, so below ~3.5σ its own peak-pixel test cannot vouch for
         /// visibility with any confidence; scoring a detection there as a false positive would be punishing a
         /// detector for something the reference itself cannot certify either way.
+        ///
+        /// <para><b>Both sides of this floor are therefore protected from false-positive scoring, and by the same
+        /// argument.</b> <see cref="SyntheticTier.Unresolved"/> gets a box the scorer excludes;
+        /// <see cref="SyntheticTier.Omitted"/> gets no box at all and is instead recovered from the truth sidecar
+        /// by <see cref="TruthProtection"/>. The mechanisms differ because the golden schema differs, not because
+        /// the policy does — an omitted star is not "more false" than an unresolved one, it is less certifiable,
+        /// and this comment's reasoning is the one both tiers follow (F31).</para>
         /// </summary>
         public double UnresolvedSnr { get; init; } = 3.5;
 

--- a/Joko.NINA.Plugins/TestApp/SynthBank/TruthDisclosure.cs
+++ b/Joko.NINA.Plugins/TestApp/SynthBank/TruthDisclosure.cs
@@ -1,0 +1,271 @@
+#region "copyright"
+
+/*
+    Copyright © 2021 - 2026 George Hilios <ghilios+NINA@googlemail.com>
+
+    This Source Code Form is subject to the terms of the Mozilla Public
+    License, v. 2.0. If a copy of the MPL was not distributed with this
+    file, You can obtain one at http://mozilla.org/MPL/2.0/.
+*/
+
+#endregion "copyright"
+
+using NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization.Review;
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+
+namespace TestApp.SynthBank {
+
+    /// <summary>
+    /// One scored frame's truth-related disclosure numbers. Pure counters plus the two ratios derived from them,
+    /// so a run total is the element-wise sum of its frames and the ratios are recomputed from the summed
+    /// counters rather than averaged (see <see cref="TruthDisclosure.Aggregate"/>).
+    /// </summary>
+    public sealed class TruthDisclosureFrame {
+
+        /// <summary>True iff a per-frame truth sidecar was found for this frame. Drives
+        /// <see cref="TruthDisclosure.ScoringMode"/> and gates the null control, exactly as
+        /// <c>BankVerifyRunner</c>'s <c>td != null</c> does.</summary>
+        public bool HasTruth { get; init; }
+
+        /// <summary>Protection AVAILABLE: <c>TruthProtection.BuildProtectionBoxes(...).Count</c> — the
+        /// real-but-unboxed truth stars (<c>omitted</c> / <c>merged-into</c>) a detection COULD have been
+        /// protected by. Says how large the correction could be, not how large it was.</summary>
+        public int ProtectedStars { get; init; }
+
+        /// <summary>Protection EXERCISED: how many detections <c>TruthProtection.ExcludeProtected</c> actually
+        /// removed from the false-positive count. <c>bank-verify</c> reports only <see cref="ProtectedStars"/>,
+        /// which is the availability, and a reader weighing a precision figure needs this one instead: a run can
+        /// carry hundreds of protected stars and exercise none of them.</summary>
+        public int ProtectedDetections { get; init; }
+
+        /// <summary>Scored false positives sitting within the match radius of a REAL rendered truth star. Truth
+        /// is complete by construction, so this has an exact answer and the answer must be 0; non-zero is the F31
+        /// signature and the precision from that run is not trustworthy.</summary>
+        public int TruthViolations { get; init; }
+
+        /// <summary>Accepted stars this frame's detector run produced — the denominator
+        /// <see cref="ScoredFraction"/> is a fraction of.</summary>
+        public int Detections { get; init; }
+
+        /// <summary>True positives that entered the precision ratio.</summary>
+        public int ScoredTp { get; init; }
+
+        /// <summary>False positives that entered the precision ratio, i.e. AFTER unresolved+truth exclusion.</summary>
+        public int ScoredFp { get; init; }
+
+        /// <summary>Null-control true positives (the shifted detections re-scored against the unshifted
+        /// reference). 0 when no truth sidecar exists, in which case no null is defined.</summary>
+        public int NullTp { get; init; }
+
+        /// <summary>Null-control false positives — see <see cref="NullTp"/>.</summary>
+        public int NullFp { get; init; }
+
+        /// <summary>Fraction of <see cref="Detections"/> that entered the precision ratio (the rest landed on
+        /// protected or unresolved reference objects and are unjudgeable). Not a bias — protection removes a
+        /// detection from both numerator and denominator — but precision rests on a smaller sample as this
+        /// falls, and at Sensitivity 0 it reaches ~0.57.</summary>
+        public double ScoredFraction => Detections > 0 ? (double)(ScoredTp + ScoredFp) / Detections : double.NaN;
+
+        /// <summary>NULL CONTROL: precision after translating every detection with wraparound, destroying
+        /// correspondence with the frame while preserving count and clustering. This is the score chance alone
+        /// earns, and therefore the floor the metric cannot read below. A precision of 1.000 means something only
+        /// when this is near 0 — the first cut of the F31 repair read 1.000 everywhere BECAUSE it was saturated,
+        /// which the precision column alone cannot distinguish. NaN on the real bank (no truth sidecar, so no
+        /// synthetic null is defined).</summary>
+        public double PrecisionNull => (NullTp + NullFp) > 0 ? (double)NullTp / (NullTp + NullFp) : double.NaN;
+    }
+
+    /// <summary>
+    /// The four truth-related honesty disclosures a golden-scored report owes its reader, computed once and
+    /// worded once so the two harnesses that score against the golden cannot drift apart.
+    ///
+    /// <para><b>Why this exists.</b> <c>bank-verify</c> reports <c>scoringMode</c> + <c>protectedStars</c>,
+    /// <c>truthViolations</c>, <c>scoredFraction</c> and <c>precisionNull</c>. <c>golden eval</c> — the instrument
+    /// that produced the published results table — reported NONE of them, so every stored
+    /// <c>golden_eval.txt</c> was written by a truth-protected instrument that could not say it was
+    /// truth-protected, could not say what chance alone would have scored, could not say whether any false
+    /// positive sat on a real star, and could not say what fraction of the detections it judged. The wording
+    /// below is <c>BankVerifyRunner</c>'s, verbatim, for exactly that reason.</para>
+    ///
+    /// <para><b>REPORT-ONLY, structurally.</b> <see cref="Measure"/> is handed the live scoring path's ALREADY
+    /// COMPUTED results (the match, the false positives before and after protection) and never re-runs or
+    /// re-orders them, so it cannot move a scored number. The null control runs on a defensive COPY of the
+    /// detection list for the same reason.</para>
+    /// </summary>
+    public static class TruthDisclosure {
+
+        /// <summary>Scoring mode when at least one per-frame truth sidecar was found and its real-but-unboxed
+        /// stars were excluded from false-positive scoring. Reports differing here are NOT comparable on
+        /// precision.</summary>
+        public const string ModeTruthProtected = "golden+truth-protected";
+
+        /// <summary>Scoring mode with no truth sidecar (the real bank, and every report written before F31).</summary>
+        public const string ModeGolden = "golden";
+
+        /// <summary>
+        /// The mode ACTUALLY used, derived from how many frames carried a truth sidecar. Never hardcode a label
+        /// at a call site: a hardcoded one silently misattributes every stored report, which is the whole defect
+        /// this class repairs.
+        /// </summary>
+        public static string ScoringMode(int framesWithTruth) =>
+            framesWithTruth > 0 ? ModeTruthProtected : ModeGolden;
+
+        /// <summary>The parenthetical that follows the mode. Verbatim from <c>BankVerifyRunner</c> so a reader
+        /// (or a grep) cannot tell the two harnesses apart.</summary>
+        public static string ScoringSuffix(int framesWithTruth, int protectedStars) =>
+            framesWithTruth > 0
+                ? $" ({protectedStars} real-but-unboxed truth stars protected from FP scoring across {framesWithTruth} frames)"
+                : " (no truth sidecars; false positives scored against the golden alone)";
+
+        /// <summary>The console line, verbatim from <c>BankVerifyRunner</c>'s "scoring:" line.</summary>
+        public static string ScoringLine(int framesWithTruth, int protectedStars) =>
+            $"  scoring: {ScoringMode(framesWithTruth)}{ScoringSuffix(framesWithTruth, protectedStars)}";
+
+        /// <summary>Protection EXERCISED, on its own line so <see cref="ScoringLine"/> stays verbatim. Availability
+        /// (<c>protectedStars</c>) without exercise is not readable as a correction size.</summary>
+        public static string ProtectedDetectionsLine(int protectedDetections, int protectedStars) =>
+            $"  protectedDetections: {protectedDetections} (detections excluded from false-positive scoring; "
+            + $"protection EXERCISED, against {protectedStars} available)";
+
+        /// <summary>Loud on purpose, and verbatim from <c>BankVerifyRunner</c>. This is the exact shape of F31,
+        /// and four harness-calibration bugs have now been found by someone happening to look rather than by
+        /// anything failing.</summary>
+        public static string ViolationLine(string label, int truthViolations) =>
+            $"    !! [{label}] {truthViolations} scored false positive(s) sit on a REAL rendered star "
+            + "-- the precision metric is charging for correct detections again (F31). Precision from this run is not trustworthy.";
+
+        /// <summary>
+        /// Measures one frame's disclosure. Everything the live scoring path already produced is passed IN —
+        /// nothing here recomputes a scored number.
+        /// </summary>
+        /// <param name="truthDispositions">The frame's truth sidecar, or null when none exists (the real bank).</param>
+        /// <param name="goldenRects">The golden's required-find boxes, exactly as the live path built them.</param>
+        /// <param name="unresolvedRects">The golden's own <c>unresolved</c> boxes, exactly as the live path built them.</param>
+        /// <param name="detected">The live detection list. Treated as read-only; the null runs on a copy.</param>
+        /// <param name="falsePositivesBeforeProtection">False positives after <c>ExcludeUnresolved</c> but before
+        /// <c>ExcludeProtected</c> — the difference against <paramref name="falsePositivesScored"/> IS
+        /// <c>protectedDetections</c>.</param>
+        /// <param name="falsePositivesScored">The false positives that were actually charged.</param>
+        /// <param name="truePositives">The matched pairs that were actually credited.</param>
+        /// <param name="matchMode">The run's OWN match mode — the null must be scored the way the live path was,
+        /// or it is a null for a different metric.</param>
+        public static TruthDisclosureFrame Measure(
+                IReadOnlyList<SyntheticStarDisposition> truthDispositions,
+                IReadOnlyList<RectD> goldenRects,
+                IReadOnlyList<RectD> unresolvedRects,
+                IReadOnlyList<DetBox> detected,
+                IReadOnlyList<int> falsePositivesBeforeProtection,
+                IReadOnlyList<int> falsePositivesScored,
+                int truePositives,
+                GoldenMatchMode matchMode,
+                double tau,
+                double matchRadius,
+                int frameWidth,
+                int frameHeight) {
+
+            // Protection AVAILABLE. Same call, same radius, as the exclusion itself uses.
+            var protectedStars = TruthProtection.BuildProtectionBoxes(truthDispositions, matchRadius).Count;
+
+            // Protection EXERCISED. ExcludeProtected only ever removes, so this is a count, not a difference of
+            // two unrelated quantities; Max(0, ..) is belt-and-braces against a caller passing them swapped.
+            var beforeCount = falsePositivesBeforeProtection?.Count ?? 0;
+            var scoredFp = falsePositivesScored?.Count ?? 0;
+            var protectedDetections = Math.Max(0, beforeCount - scoredFp);
+
+            // The F31 signature, counted rather than reasoned about: a scored false positive that sits on a REAL
+            // rendered star. Complete by construction, so this has an exact answer and the answer must be 0.
+            var truthViolations = TruthProtection.CountWithinRadius(
+                falsePositivesScored, detected, TruthProtection.AllCenters(truthDispositions), matchRadius);
+
+            // The NULL CONTROL. Same detections, translated with wraparound: whatever precision survives is
+            // chance coincidence. A metric reading 1.000 with a null near 0 is measuring; one reading 1.000 with a
+            // high null is saturated, which is how the first cut of the F31 repair failed.
+            //
+            // The shift runs on a COPY of the live detection list. ShiftForNullControl already allocates its own
+            // output, but this is a report-only path bolted onto a scoring loop whose bytes are under a
+            // do-no-harm gate: the copy makes "the null cannot touch the live list" a property of the call site
+            // rather than a fact about the callee that a future edit could quietly break.
+            int nullTp = 0, nullFp = 0;
+            if (truthDispositions != null) {
+                var liveCopy = detected == null ? new List<DetBox>() : new List<DetBox>(detected);
+                var shifted = TruthProtection.ShiftForNullControl(liveCopy, frameWidth, frameHeight);
+                var nullMatch = GoldenMatch.Match(goldenRects, shifted, matchMode, tau, matchRadius);
+                var nullFalsePositives = TruthProtection.ExcludeProtected(
+                    GoldenMatch.ExcludeUnresolved(nullMatch.FalsePositives, shifted, unresolvedRects),
+                    shifted, TruthProtection.ProtectionCenters(truthDispositions), matchRadius);
+                nullTp = nullMatch.Pairs.Count;
+                nullFp = nullFalsePositives.Count;
+            }
+
+            return new TruthDisclosureFrame {
+                HasTruth = truthDispositions != null,
+                ProtectedStars = protectedStars,
+                ProtectedDetections = protectedDetections,
+                TruthViolations = truthViolations,
+                Detections = detected?.Count ?? 0,
+                ScoredTp = truePositives,
+                ScoredFp = scoredFp,
+                NullTp = nullTp,
+                NullFp = nullFp
+            };
+        }
+
+        /// <summary>The run total: counters summed element-wise, ratios recomputed from the summed counters (a
+        /// mean of per-frame ratios would weight a 3-detection frame like a 900-detection one).</summary>
+        public static TruthDisclosureFrame Aggregate(IEnumerable<TruthDisclosureFrame> frames) {
+            var list = frames?.Where(f => f != null).ToList() ?? new List<TruthDisclosureFrame>();
+            return new TruthDisclosureFrame {
+                HasTruth = list.Any(f => f.HasTruth),
+                ProtectedStars = list.Sum(f => f.ProtectedStars),
+                ProtectedDetections = list.Sum(f => f.ProtectedDetections),
+                TruthViolations = list.Sum(f => f.TruthViolations),
+                Detections = list.Sum(f => f.Detections),
+                ScoredTp = list.Sum(f => f.ScoredTp),
+                ScoredFp = list.Sum(f => f.ScoredFp),
+                NullTp = list.Sum(f => f.NullTp),
+                NullFp = list.Sum(f => f.NullFp)
+            };
+        }
+
+        /// <summary>How many of the scored frames carried a truth sidecar — the input to
+        /// <see cref="ScoringMode"/> and to the "across N frames" clause.</summary>
+        public static int FramesWithTruth(IEnumerable<TruthDisclosureFrame> frames) =>
+            frames?.Count(f => f != null && f.HasTruth) ?? 0;
+
+        /// <summary>The header of the appended <c>golden_eval_frames.csv</c> columns. APPENDED at the end, never
+        /// inserted: the scorers across nine wave roots index this file BY POSITION, so an inserted column
+        /// silently re-labels every number to their right.</summary>
+        public const string CsvHeaderSuffix = "protectedStars,protectedDetections,scoredFraction,precisionNull";
+
+        /// <summary>One frame's appended CSV cells, in <see cref="CsvHeaderSuffix"/> order.</summary>
+        public static string CsvRowSuffix(TruthDisclosureFrame f) =>
+            $"{f.ProtectedStars},{f.ProtectedDetections},{Fmt(f.ScoredFraction)},{Fmt(f.PrecisionNull)}";
+
+        /// <summary>The stored-report block. Every one of the four disclosures, plus the exercised-protection
+        /// count bank-verify omits, so a reader of a stored <c>golden_eval.txt</c> can weigh its precision
+        /// figure without re-deriving anything or knowing this class exists.</summary>
+        public static IReadOnlyList<string> ReportLines(string label, TruthDisclosureFrame total, int framesWithTruth) {
+            var lines = new List<string> {
+                "TRUTH PROTECTION (F31) -- what the precision above was scored under:",
+                $"  scoringMode: {ScoringMode(framesWithTruth)}{ScoringSuffix(framesWithTruth, total.ProtectedStars)}",
+                $"  protectedStars: {total.ProtectedStars} (protection AVAILABLE: real-but-unboxed truth stars, summed over frames)",
+                ProtectedDetectionsLine(total.ProtectedDetections, total.ProtectedStars),
+                $"  truthViolations: {total.TruthViolations} (scored false positives sitting on a REAL rendered star -- must be 0)",
+                $"  scoredFraction: {Fmt(total.ScoredFraction)} ({total.ScoredTp + total.ScoredFp} of {total.Detections} detections entered the precision ratio)",
+                $"  precisionNull: {Fmt(total.PrecisionNull)} (precision chance alone earns: the same detections shifted by "
+                    + $"({TruthProtection.NullShiftX},{TruthProtection.NullShiftY}) px with wraparound, re-scored against the UNSHIFTED reference)"
+            };
+            if (total.TruthViolations > 0) {
+                lines.Add(ViolationLine(label, total.TruthViolations));
+            }
+            return lines;
+        }
+
+        /// <summary>Same formatting as the surrounding reports: 3 decimals, invariant, and a literal "NaN" for an
+        /// undefined ratio rather than an empty cell a scorer would read as 0.</summary>
+        private static string Fmt(double v) => double.IsNaN(v) ? "NaN" : v.ToString("F3", CultureInfo.InvariantCulture);
+    }
+}

--- a/docs/f82-fix-choice-decision.md
+++ b/docs/f82-fix-choice-decision.md
@@ -1,0 +1,337 @@
+# F82 — the fix choice, decided
+
+**DECISION: candidate (3), the requested-span lower bound, in the explicit-parameter form `(3′)` specified in §4.**
+**And wave 26's standing pre-registered choice — fix (1), the monotone floor — is REFUTED, not merely out-ranked:
+at `D01`'s own published numbers it produces `halfWidth 12.0 → step 3`, the same step that stalled, so it changes
+zero recommended steps anywhere in the bank.**
+
+One-sentence reason: `12.0 / 3.5 = 3.43 → 3` and `18.0 / 3.5 = 5.14 → 5`, so the only candidate that moves `D01`
+off its stall is the one that bounds `maxHalfWidth` by the span the sweep **requested** — and of the two that do
+that, (3) is the one that touches a single round out of thirty-seven while (2) redefines a quantity with four
+consumers.
+
+This document commits a decision. **It ships no code and therefore owes no gate.** The gate it *will* owe when
+the code is written is priced in §5.
+
+---
+
+## 1. What is settled, and is not re-opened here
+
+- **F82 is a real product defect on a real product path.** `RULE W29-S` = `S-CARRIER-EXISTS`. Verified again here
+  at `HEAD`: `CaptureNewSweepAsync` (`StarDetectionOptimizerWizardVM.cs:5012`) takes a **fresh** sweep per run
+  (`RunLiveAttemptAsync`, `:5071`), calls `BuildSummaryAsync` at `:5098`, and carries the previous round's
+  recommendation forward through the instance field `recaptureStepSize` (`:2608`, assigned `:5037`, consumed
+  `:3236` via `ApplyRecaptureGeometry`, `:3294`).
+- **It is rare.** `RULE W29-R` = `R-STANDS`: `k = 18`, `c = 1`, `c_blind = 0`; the one qualifying cell is `D01`,
+  which is burned (F97).
+- **The harness's bar is a fixed point of the code under test.** F96: `SynthValidateRunner.ComputeStepBehavioral`
+  (`:1213-1270`) calls `StepSizeRecommender.Recommend` at `:1262` and loops to `rec.StepSize == step`.
+- **`RULE D20`'s fence forbids choosing a fix in the wave that proposes it.** Candidate (3) was proposed by
+  wave 29 §4.4 and correctly not chosen there. That fence does not bind this document, which is not that wave.
+
+---
+
+## 2. Four facts I verified myself, which change the picture
+
+Every line number below was read at `HEAD` in this session, not inherited.
+
+### 2.1 `SearchSpan` has one docstring and four consumers, and the docstring names only one of them
+
+`StepSizeRecommender.SearchSpan` (`:554-571`) is `max(x) − min(x)` over `bestFit.Inputs`. Its own summary
+(`:553`) says it is *"used to bound the outward half-width search."* It is in fact read four times:
+
+| read at | what it sets |
+|---|---|
+| `:313` → `:314-315` | the outward search budget, `MaxSearchSpanMultiple (4.0) × searchSpan` (`:578-581`) |
+| `:320` | `maxHalfWidth = 1.5 × 0.5 × searchSpan` — the cap (`:347-350`) **and** F81's floor (`:332`, `:363-366`) |
+| `:373` | `minHalfWidth = 0.5 × 0.5 × searchSpan` — the floor under F18's detectability bound |
+| `:395` → `:441-450` | `CappedGrowthRatio`, which is **quoted to the user** in `StepSizeText` (`:390-391`) |
+
+And the *public* documentation of the constant the cap is built from (`:210-212`) reads *"How far past the
+**sampled sweep** the recommended half-width may reach, as a multiple of the sampled HALF-span"*, while the
+inline comment at `:345` reads *"the data it was **fitted to**."* **F82 is the gap between those two sentences.**
+`bestFit.Inputs` is post-dropout and post-outlier-rejection: `RunEvaluationData` keeps a position out of the fit
+when its pooled HFR is non-finite (`:750-753`), keeps recovery positions out entirely on the un-weighted path
+(`:793-794`), and `SelectBestModel` (`:825-829`) removes consensus outliers — while `FrameFocuserPositions`
+(`:815`) retains **every** frame. Candidate (3) splits the overloaded quantity along the line the docstrings
+already draw. Candidate (2) redefines it for all four consumers at once.
+
+### 2.2 Fix (1) does not fix `D01` — arithmetic, from the published report
+
+`/mnt/d/hf_w25/after/D01_ultrawide_40mm__S1/synth_validate_report.json`, read this session:
+
+| round | requested span | `halfWidth` | branch | `step = round(halfWidth / 3.5)` |
+|---|---|---|---|---|
+| r0 | `2 × 4 × 2 = 16` | **12.0** | `wasBandFloored` | `12/3.5 = 3.43 → 3` |
+| r1 | `2 × 4 × 3 = 24` | **9.0** | `wasCapped` | `9/3.5 = 2.57 → 3` — **stall** |
+
+Fix (1) carries r0's floored `12.0` forward as a lower bound on r1's `maxHalfWidth`. Both the cap (`:347-350`)
+and the floor (`:363-366`) clamp `halfWidth` **to** `maxHalfWidth`, so under fix (1) r1's `halfWidth` is `12.0`
+whichever branch is taken — and `round(12.0 / 3.5, AwayFromZero) = 3`. **Step 3 again.** The alternate reading
+("a lower bound on `halfWidth`" rather than on `maxHalfWidth`) gives `max(9.0, 12.0) = 12.0` and the same 3.
+
+Candidate (3) instead sets r1's `maxHalfWidth` to `1.5 × 0.5 × 24 = 18.0`. The raw fitted half-width is
+unknown, and **it does not need to be known**: if it exceeds 18 the cap clamps to 18; if it is below 18 the
+`BandDemonstrablyUnsampled` floor (`sampledHfrRange = 1.4587 < 3.0`) raises it to 18. Either way
+`halfWidth = 18.0` and `round(18/3.5) = 5`. **`D01` r1 moves 3 → 5.**
+
+F82's own entry describes fix (1) as *"simple, fixes `D01` directly."* On the numbers in F82's own table, it
+does not.
+
+### 2.3 On the measured population, (2) and (3) are indistinguishable, and both touch ONE round in thirty-seven
+
+Computed this session over the 18 addressable paired S1 cells under `/mnt/d/hf_w25/after`, using
+`impliedSearchSpan = halfWidth / 0.75` (the `W29-R` inversion, valid because all 37 rounds are capped-or-floored
+and none detect-bounded) against `requested = 2 × offsetSteps × stepSize`:
+
+```
+rounds: 37   cells: 18
+rounds where the band was demonstrably unsampled (sampledHfrRange < 3): 37
+rounds where implied SearchSpan < requested span:                        1
+candidate-3 firing rounds:                                               1   (D01_ultrawide_40mm r1)
+```
+
+**On 36 of 37 rounds the fitted span EQUALS the requested span exactly.** So:
+
+- Wave 29 design §1's inference — *"37 of 37 rounds are capped-or-floored, so fix (2) moves every round of every
+  cell"* — **does not follow and is false on the artifacts.** Capped-or-floored means `maxHalfWidth` is
+  load-bearing on all 37; it does not mean redefining its input *changes* it. Fix (2) is bit-inert on 36 of 37.
+- Which means **the blast-radius axis does not separate (2) from (3) on this bank at all.** They separate only on
+  rounds this bank never produced: rounds where the band *was* reached and the fit lost points (there (3) is
+  inert by its guard and (2) fires), and rounds where `FindHalfWidth` returns `NaN` under the fitted span but
+  resolves under a larger one (there (2) flips a *branch*, not a value — `:578-581`).
+- The separation that remains is a **contract** separation, not a measured one, and it is §2.1's: (2) changes the
+  detectability floor at `:373` and the growth ratio quoted to the user at `:390-391`; (3) does not.
+
+**Blindness burn, recorded rather than glossed:** producing the table above read `sampledHfrRange` on the 15
+formerly-blind cells, extending F100's burn (which covered `halfWidth`, `bootstrap` and the implied span). The
+consequence is written into §6: the do-no-harm arm is a **predicted-answer** rule, not a blind one.
+
+### 2.4 F82's entire evidence was produced with F18's detectability bound DISABLED, and the product always enables it
+
+`SynthValidateRunner` builds `stepDetectability` only when `--step-detect-bound` or
+`--step-size-for-executed-sweep` was passed (`:783-793`); wave 25's S1 arm passed neither, which is why `D01`'s
+rounds carry `maxUsefulHalfSpan: NaN`, `detectHalfWidth: NaN`, `wasDetectBounded: false`.
+
+**The product supplies it unconditionally.** `BuildSummaryAsync` constructs `representativeDetectability` at
+`:4073-4079` from `bestEval.Metrics` on every round and passes it at `:4117-4118`. `Recommend` applies the F18
+bound **after** the floor (`:368-379`) and it *only ever tightens*.
+
+So the ordering `floor → detect-bound` is the shipped order, and on a star-poor sweep like `D01`'s the detect
+bound may already be the binding constraint — in which case candidate (3)'s widening is discarded at `:375-378`
+before it reaches the step. **This is a precondition, not an objection**: `MeasureMaxUsefulHalfSpan` returns
+`NaN` (no bound) unless at least one non-recovery frame is starved **and** ≥ 3 qualify **and** the furthest is
+positive (`:496`). It is the single largest implementation risk and §6 makes it clause `V-0`, run first.
+
+It also means something the register should carry: **F82's published arithmetic is from a configuration the
+product does not run**, and `S-CARRIER-EXISTS` established that a carrier exists without checking that the
+carrier's own configuration reproduces the numbers.
+
+---
+
+## 3. The three candidates, scored on the same axes
+
+| axis | **(1) monotone floor** | **(2) redefine `SearchSpan`** | **(3) requested-span lower bound** |
+|---|---|---|---|
+| **fixes the defect it was written for** | **NO** (§2.2): `D01` r1 → step 3, unchanged | yes: → step 5 | yes: → step 5 |
+| **reaches a user** | yes, via `CaptureNewSweepAsync` — but delivers nothing | yes | yes |
+| **rounds changed, measured** | **1 of 37** (a reported `halfWidth`), **0 recommended steps** | **1 of 37** (§2.3) | **1 of 37** (§2.3) |
+| **consumers of `SearchSpan` disturbed** | none (bounds `maxHalfWidth` only) | **all four** (§2.1): search budget, cap/floor, F18 floor, user-quoted growth ratio | one (`maxHalfWidth`), and only under `BandDemonstrablyUnsampled` |
+| **can flip a branch** | no | **yes** — a larger budget at `:578-581` can resolve a half-width that was `NaN`, moving a round out of the floor branch | no: `Math.Max` against an existing ceiling, one-sided by construction (F81's shape) |
+| **moves the truth model (F96)** | no — inert in `ComputeStepBehavioral` (see below) | no — inert, same reason | no — inert, same reason, and provably |
+| **new state, and where it lives** | **the only one that needs any.** Within a session: an instance field mirroring `recaptureStepSize` (`:2608`) plus a `HalfWidth` on `OptimizationSummary` (`:98`), which has none. Across sessions: `OptimizedStarDetectionSettings` (`:69` carries `RecommendedStepSize` and no half-width) + migration | none | none |
+| **testability** | needs a two-round fixture and a carrier | unit-testable, but every existing `SearchSpan`-dependent expectation must be re-derived | unit-testable in one file: `StepSizeRecommenderTests` already builds fits from truth curves (`:82`) and position arrays (`:366-378`); a sweep whose outer points are withheld from the fit is a ~10-line fixture |
+| **migration / upgrade** | cross-session variant needs settings migration; within-session variant needs none | none | none |
+| **owes an option → owes XAML** | within-session: **no** (`recaptureStepSize` is an un-optioned instance field). Cross-session: **yes**, and then a control in `Resources/OptionsDataTemplates.xaml` per `CLAUDE.md` | no | **no** |
+| **verification cost** | 3-cell re-run; but with nothing to detect | **a full paired 18-cell arm (~2 h 40 m)** — it is the only one that can move a round the guard would have excluded | 3-cell re-run + the do-no-harm prediction of §6 |
+
+**On F96, stated precisely rather than inherited.** The coupling is real: `ComputeStepBehavioral` consumes the
+same `Recommend`. But none of the three moves it, and the reason is structural: `ComputeStepBehavioral` fits
+**all** `2·offsetSteps+1` synthesized points (`:1224-1240`, no `SelectBestModel`, no rejection, all finite by the
+pixelization floor at `:1237`) and populates `FrameFocuserPositions` from the *same* expression (`:1250` vs
+`:1226`). So requested span ≡ fitted span at every iterate, and both (2) and (3) reduce to identity there. (1) is
+inert too, because its carry only exists after a floored round and the truth-curve walk widens monotonically, so
+the previous iterate's bound is always the smaller one. **Wave 29's fourth reason for (1) — "(2) moves the truth
+model" — is true as a coupling and false as an effect.** §6 turns this from an argument into an assertion.
+
+**On wave 26's "fix the assertion, not the product".** Wave 26 rejected (2) partly because it *"would make the
+harness and the product agree by moving the PRODUCT to the harness's model."* That objection has force against
+(2) and not against (3), and the distinction is the guard: (3) uses the requested span **only as a lower bound**,
+**only** when the sweep's own HFRs prove the band was never sampled. On every round that reached the band the cap
+still refuses to trust the model past the points that survived fitting — the property the cap exists for is
+untouched. That assertion `A4` (whose boundary is already computed from the requested sweep) would flip from FAIL
+to PASS on `D01` r1 is **corroboration and is labelled as such**; it is not the reason.
+
+---
+
+## 4. `(3′)` — the form that is chosen, and how it differs from the registration
+
+Wave 29 §4.4 registered candidate (3) sourcing the requested positions from
+`SweepDetectability.FrameFocuserPositions` (`StepSizeRecommender.cs:160`). **Take the mechanism; change the input
+plumbing.** Three reasons, all from source:
+
+1. **`SweepDetectability` is optional and null on the harness's default arm** (`SynthValidateRunner.cs:783-793`).
+   Candidate (3) as registered would be **inert in the very re-run that must score it** — a 3-cell arm would
+   report "nothing changed" and the fix would look dead when it is not.
+2. **`FrameFocuserPositions` includes recovery frames** (`FrameIsRecovery`, `:167`), which are deliberately far
+   from focus. Reading the span off it unfiltered inflates the bound on exactly the runs F81's own scope note
+   was careful about.
+3. `MeasureMaxUsefulHalfSpan` (`:471-500`) already reads that array under a *different* contract (outermost
+   starved-bounded position; `NaN` when nothing starved). Two rules reading one array with two meanings is the
+   overload §2.1 is trying to undo.
+
+**`(3′)`:** `Recommend` takes an optional `double requestedSpan = double.NaN`. When it is finite **and**
+`BandDemonstrablyUnsampled(sampledHfrRange)` is true, `maxHalfWidth = Math.Max(maxHalfWidth,
+MaxHalfWidthSampledHalfSpanMultiple × 0.5 × requestedSpan)` — inserted at `:320`, before both the cap and the
+floor, so both clamp to the same raised value. `NaN` ⇒ byte-identical to today, which is what keeps the four
+non-wizard call sites (`OptimizationDiagnosticRunner` ×4, `TiltCalibrationRunner`) inert without touching them.
+
+Callers supply it as **`2 × offsetSteps × stepSize` of the sweep actually taken**, excluding the recovery wing:
+
+- product — `StarDetectionOptimizerWizardVM.cs:4115-4118`, from `runs[0].AfOptions`, which
+  `RunEvaluationLoader` reads back off the saved attempt (`:170`, `:251`);
+- harness — `SynthValidateRunner.cs:792`, from the round's `bootstrap`.
+
+**Companion change, or the fix is dishonest:** `CappedGrowthRatioOf` (`:441-450`) computes the factor quoted to
+the user from `searchSpan`. If the cap fires at a bound derived from a *different* span, the quoted ratio is no
+longer the exact factor. It must be handed the same span the bound used.
+
+**New observable, per F76's rule that a fix which cannot report whether it engaged is not finished:** a field on
+`StepSizeRecommendation` naming which span set the bound, mirrored into `OptimizationSummary` and the report
+snapshot. **Do not overload `WasCapped` or `WasBandFloored`** — F81 kept those two separable on purpose
+(`:56-59`) and `A4` reads `WasCapped` alone.
+
+**Two traps, both named before anyone writes code:**
+
+- `ApplyFocusRecovery` (`:3301-3313`) *adds* the recovery steps to `AutoFocusInitialOffsetSteps` on the captured
+  options, so a requested span computed from `AfOptions` on a recovery-enabled run **includes the recovery
+  wing**. Subtract it (`capturedRecoveryStepsPerSide` is already on the VM, `:2582`).
+- On a `CaptureNewSweepAsync` round the sweep is taken at `recaptureStepSize`, not the profile's step. Assert
+  that `runs[0].AfOptions.AutoFocusStepSize` reads back the **executed** step, not the profile's — if it does
+  not, the fix reads the wrong span on the one path that makes F82 a product defect.
+
+---
+
+## 5. Price, as a band
+
+| line item | est |
+|---|---|
+| `(3′)` in `StepSizeRecommender.cs` — the optional parameter, the guarded `Math.Max`, the `CappedGrowthRatioOf` companion, the new observable | 25–40 m |
+| wizard wiring (`:4115-4118`) + recovery-wing subtraction + the `AfOptions` assertion | 15–25 m |
+| harness wiring (`SynthValidateRunner.cs:792`) + report snapshot field | 10–15 m |
+| unit tests — inert-when-equal, fires-when-larger-and-band-unsampled, inert-when-band-reached, recovery excluded, the `D01` r0→r1 replication fixture, growth-ratio consistency | 30–45 m |
+| **code + tests subtotal** | **1 h 20 m – 2 h 05 m** |
+| unit suite, **by COUNT** (F37) against the **3997** baseline — not "green", the count | ~4 m |
+| **the `optimize` gate — OWED, certainly** | **42 m** |
+| targeted 3-cell `synth-validate` re-run, **run twice**: without and with `--step-detect-bound` (§2.4) | ~20 m |
+| **total** | **2 h 25 m – 3 h 10 m** |
+
+**Why the gate is certain and there is no argument to have.** `Q27-V1`'s reachable set is the literal directory
+prefix `^Joko\.NINA\.Plugins/Joko\.NINA\.Plugins\.HocusFocus/…`, and its **FAIL end was run** against a diff
+whose two files were `StarDetectionOptimizerWizardVM.cs` and `StepSizeRecommender.cs` —
+`/mnt/d/hf_w27/q27_v1.txt`, quoted in wave 27 results §5.2. **That diff is `(3′)`'s own file set.** Measured cost
+42 m 43 s (wave 25), ~5.2 m/run over eight consecutive waves. **Predicted verdict: `G-PASS`, 8 of 8 `FinalJ`
+bit-identical to K8**, on wave 25's precedent that a `StepSizeRecommender` change contributes nothing to the
+objective — every `Recommend` call site is strictly downstream of `OptimizeAsync` returning. A gate with a
+predicted answer is the only kind that can be wrong; if it is not 8 of 8, the shipped code is not the designed
+code.
+
+**Wave 29's published price for fix (1) in the product — "a BAND, and it is one: ~2–4 h … new persisted
+half-width surviving between wizard sessions … migration … whether it is an *option*" — is priced against the
+wrong carrier and should be corrected in the register.** It was written under the pre-`CORRECTION` belief that
+the only cross-round path was session-to-session. `S-CARRIER-EXISTS` found a **within-session** carrier, and
+within a session the state is an ordinary instance field like `recaptureStepSize` — no persistence, no
+migration, no option, no XAML. Fix (1) scoped to the wizard's re-capture loop is ~1 h, not 2–4 h. **It is still
+not chosen, because §2.2 says it does nothing.**
+
+---
+
+## 6. How the fix will be VERIFIED — pre-registered, before anyone writes it
+
+**The trap, named explicitly.** The obvious population is the three published stall cells `D01`/`D02`/`D03`.
+**It is not available.** Their rounds are printed in F82's own table, `D01` is the cell the candidate was
+designed against, and F14/`RULE S16`/`RULE D20` all say the same thing in three costumes: *a repaired clause
+scored against the data that motivated the repair is not a measurement.* Those three cells may be used as a
+**reproduction control with a predicted answer** — a number computed here, in advance, from the shipped
+arithmetic — and never as efficacy.
+
+**The legitimate populations are three, and they are different kinds of evidence.**
+
+| | population | statistic | bar, fixed now | refutes if |
+|---|---|---|---|---|
+| **`V-0`** *(validity, first)* | `D01`/S1, 3-cell arm run **with `--step-detect-bound`** — the product's configuration | `wasDetectBounded`, `maxUsefulHalfSpan`, final step | report both values; **no bar** | if the detect bound (`:368-379`) already clamps `D01` below the requested-span floor, `(3′)` cannot fix `D01` **in the product** and the finding is an F18-vs-F81 conflict, not F82. **Then this decision is void and the entry is re-scoped.** |
+| **`V-1`** *(reproduction, predicted answer)* | `D01`/S1 r0→r1, unit fixture and 3-cell re-run, detect bound OFF | r1 `halfWidth`, r1 step | **`halfWidth == 18.0` exactly; step `3 → 5`**, computed in §2.2 before any code exists | any other value ⇒ the shipped code is not the designed code |
+| **`V-2`** *(do-no-harm, the real bar)* | the **15 non-burned** S1 cells, all **36** non-`D01` rounds | per-round `halfWidth`, `stepSize`, `wasCapped`, `wasBandFloored`, `degenerateReason` | **36 of 36 bit-identical**, and `stepBehavioral` **18 of 18** bit-identical across arms per cell | **one** changed round refutes the guard, because §2.3 measured `implied == requested` on all 36 — a change there means the requested span was read wrong (recovery wing, or the profile's step instead of the executed one) |
+| **`V-3`** *(efficacy, and it is honest about being unmeasurable)* | none on this bank | — | **`c_blind = 0` (F97): there is no blind cell that exhibits the defect, so no efficacy rate is measurable here.** Say so; do not manufacture one from `D01` | — |
+
+`V-2` is the bar and it is a **predicted-answer** rule rather than a blind one, because §2.3 burned
+`sampledHfrRange` on those cells to produce the prediction. That is the correct trade and it is declared: a rule
+whose answer is derivable from the code *before* the arm runs is `RULE R24`'s virtue — it can be unambiguously
+wrong — and it is the only form still available after the burn.
+
+**The `stepBehavioral` clause in `V-2` is what discharges F96 for this change**, and no prior wave has run it: it
+asserts that the bar did not move while the measurement did. §3 predicts `18 of 18` identical, from the structure
+of `ComputeStepBehavioral`; if any cell's `stepBehavioral` moves, `(3′)` has moved the truth model and the
+comparison is a self-consistency check, exactly as F96 warns.
+
+**One paragraph, for the implementer.** Run `V-0` first and stop if it fires. Then write the unit fixture for
+`V-1` — `StepSizeRecommenderTests` already has everything: `FitTruthSweep` (`:82`) to build a curve, and the
+`Detectability`/`F18Positions` helpers (`:366-378`) to supply a position array; construct the shrink-while-
+widening condition directly by fitting a *subset* of the swept positions while passing the full requested span,
+which is deterministic, costs no bank time, and is not any published cell's data. Then ship, run the suite by
+count against 3997, run the 42 m gate expecting 8 of 8, and run the 3-cell arm scoring `V-1` and `V-2` together
+— `V-2` on the 15 cells is the clause that can fail, and it must be scored before `V-1` is reported.
+
+---
+
+## 7. What would change this decision
+
+Stated now, in wave 26's style, so it cannot be written after the data:
+
+1. **`V-0` fires.** If the product's always-on detectability bound (`:368-379`, supplied at `:4073-4079`) already
+   clamps `D01` below `1.5 × 0.5 × requested`, then no requested-span bound can fix it in the product, `(3′)` is
+   the wrong entry, and the right one is the ordering conflict between F18's measured bound and F81's floor.
+2. **`V-2` shows any harm.** One changed round among the 36 that §2.3 predicts unchanged means the requested span
+   is being read wrong — the recovery wing, or the profile's step instead of the executed one — and the decision
+   reverts to **won't fix** until that is corrected, not to fix (1).
+3. **`stepBehavioral` moves on any cell.** Then `(3′)` moves the bar as well as the measurement, F96 binds, and
+   the change must not be scored against `A3` at all until a spec-derived truth model exists (backlog item 4).
+4. **A round is found where the band was REACHED and the fitted span still lost points.** `(3′)`'s guard makes it
+   inert there by design; if that shape turns out to be the common one in the field, the guard is wrong and (2) —
+   redefining `SearchSpan` outright, with its full four-consumer blast radius and its 18-cell arm — becomes
+   correct. Nothing in the 37 measured rounds is of that shape.
+5. **New data.** The 1.4–19.4 ″/px render (wave 30 §12.1) is the only route to a blind population that could
+   raise `c` above 1 of 18. If it does not, the honest long-run position is that this is a defect worth fixing on
+   its *severity* — an unbounded stall costing 30–120 minutes of sky per round, the F49/F51 failure mode — and
+   never on its *rate*.
+
+**And the case for doing nothing, weighed rather than dismissed.** `c = 1` of 18, `c_blind = 0`, and the one cell
+is burned; goal-2 efficacy is unmeasurable on this bank; the price is ~2.5–3 h including a 42 m gate. That is a
+live option and it was taken seriously. **It loses on one point:** the register currently records fix (1) as
+F82's chosen remedy, and §2.2 proves fix (1) changes zero recommended steps. Leaving that in place is strictly
+worse than either alternative, because it records a remedy that does nothing as the answer to a real defect on a
+real product path. **So the minimum obligation of this document is discharged either way: fix (1) is retired.**
+If the 42 m gate is not to be spent, the correct entry is *"won't fix, and here is the arithmetic showing why the
+pre-registered fix would not have worked"* — not fix (1). The recommendation is to spend it: `(3′)` is one
+`Math.Max` behind an existing predicate, provably inert on 36 of 37 measured rounds, and it is the only candidate
+that moves the number the entry is about.
+
+---
+
+## 8. Register deltas this document owes
+
+- **F82** — status → *fix chosen: candidate (3), in the `(3′)` form*. Append §2.2 (fix (1) is refuted by
+  arithmetic on F82's own table), §2.3 (the 1-of-37 blast radius, and that wave 29 §1's "moves every round of
+  every cell" does not follow), §2.4 (the evidence was taken with `--step-detect-bound` off while the product
+  always supplies detectability), and the corrected price for fix (1) in the product (~1 h within-session, not
+  2–4 h; no option, no XAML).
+- **F96** — append: the coupling binds none of the three candidates, with the structural reason
+  (`ComputeStepBehavioral` fits every synthesized point and derives positions from the same expression), and
+  `V-2`'s cross-arm `stepBehavioral` clause is the assertion that discharges it for this change.
+- **F97** — append: the transition census is 1 of 18 *cells*; the within-round census is **1 of 37 rounds**, and
+  it is the same round.
+- **F81** — append: `SearchSpan`'s docstring (`:553`) declares one consumer and the code has four, and the
+  constant's public doc (`:210-212`) says *"sampled sweep"* where the implementation reads *"fitted inputs"*.
+- **New entry** — F82's published evidence was produced in a harness configuration the product does not run
+  (`--step-detect-bound` off vs. `representativeDetectability` always supplied), and `S-CARRIER-EXISTS`
+  established a carrier without checking that the carrier's configuration reproduces the numbers.

--- a/docs/followups.md
+++ b/docs/followups.md
@@ -429,6 +429,353 @@ shape for this space.
 > three where the search **also** drove `StarClippingMultiplier` down, twice to the axis's own 0.25 floor.
 > Reproduce: `/mnt/d/hf_w26/q26_score.txt`; `docs/synthetic-af-bank-followups-wave26-results.md` §4.3, §7.
 
+### F104 — `D01`'s two candidate gates release 36 660 high-tier candidates and re-capture takes 92 %: the joint is material and ADDITIVE, so F99's joint-recovery claim is refuted at a pre-registered bar
+
+**Status:** Closed — the product question is answered, and answered negatively · found 2026-08-13, wave 30,
+`RULE W30-G` = **`G-NOT-RECOVERABLE`** · `/mnt/d/hf_w30/w30g_score.txt`, `w30g_manifest.tsv`
+
+**[F22](#f22) FENCE, inline and mandatory:** on `D01_ultrawide_40mm` the detector's HFR over-reads by a large
+factor below ~1.1 px measured HFR and its autofocus already lands at `BestJ 0.994825`. **No count in this entry
+may be quoted as a recall or focus improvement for a user.** The only frame in which it may be read is goal 3 —
+*is a landed knob sitting at an extreme against the physics?*
+
+A 2×2 factorial on `MaxDistortion` (0.5 → 0.3) and `BrightnessSensitivity` (36.333 → 32.333, four axis steps
+**computed** from the product's own declaration), five run cells and two imported from wave 29, on
+`D01_ultrawide_40mm`, 9 frames per cell, on the B15 binary already on disk.
+
+| quantity | value |
+|---|---|
+| `Σ R_g` over all single-knob cells | **36 660** |
+| `Σ capture_g` | **33 884** |
+| `recapture` (pooled) | **0.9243** — bar 0.90 → **`G-2` True** |
+| `recapture` excluding the fenced `M4` | 0.9288 (agrees) |
+| `FN_total(M0)` | **50 249** |
+| material bar, **computed** as `0.01 × FN_total(M0)` | **502.5** |
+| `ΔTP(M3)`, the joint | **+1 572** |
+| `Σ ΔTP` over the unfenced singles `M1`+`M2` | **+1 480** |
+| `ΔTP(joint) ≥ 502.5` | **True** |
+| `ΔTP(joint) ≥ 2 × 1 480 = 2 960` | **False** → **`G-3` False** |
+
+**The joint IS material** (3.1× the bar; 3.1 % of all misses) **and it is essentially additive**: the
+interaction term is **+92**, a multiple of **1.06×** against a pre-registered bar of 2×.
+
+**Re-capture dominates, and the mechanism is one column of the published matrix.** `TooDistorted` at 0.3
+releases **12 090** candidates and **`LowSensitivity` absorbs 9 676 of them — 80.0 %.** Relaxing
+`LowSensitivity` by 11 % on top converts **92** of those 9 676 — **0.95 %**. A 36 σ bar relaxed by 11 % does not
+turn a low-fill blob into a detection, which is exactly the mechanism the pre-registration gave for predicting
+this outcome.
+
+**Goal-3 answer, and it is a negative.** No landed knob on `D01` is pinned against the physics in a recoverable
+way. `MinStarBoundingBoxSize` at 6 (against a shipped default of 5) is the one knob at an extreme, and its flow
+releases 9 537 candidates of which **3** reach acceptance. `MaxDistortion` landed mid-axis. **40.4 % of the
+misses live upstream of both gates** — `NO CANDIDATE (structure gap)` 8 931 and `TooSmall` 11 372 — where no
+setting of either gate can reach them. `D01`'s recall gap is the physics of a 19.4 ″/px rig with a ~0.7 px
+kernel.
+
+**Two rival predictions were registered before the data**, in the same pre-registration section, attached to
+two distinct terminal verdicts of the same 36-region tree: `G-JOINTLY-BOUND` (F99's) and `G-NOT-RECOVERABLE`
+(the design's). The data landed in the second. **Neither document could have claimed a hit it did not call**,
+and this is the strongest evidential form the series has produced.
+
+**Not measured, and owed by any ship that acts on this:** precision at the opened settings. 23–25 % of the
+distortion gate's acceptances were `ACCEPTED-elsewhere` — accepted but not matched to the star they were
+released from — against 5–10 % for the sensitivity gate. That is a signal, not a measurement; the pre-registered
+statistic reads only the false-negative attribution block. ~5 m to resolve.
+
+*(Design §16 assigned F104 to this verdict; the assignment holds.)*
+
+---
+
+### F105 — `golden_eval`'s first-rejection-wins attribution CONSERVES on real data, 5 of 5 cells, integer-exact — so waves 28's and 29's gate-count differences are safe to read
+
+**Status:** Closed — the model is checked · found 2026-08-13, wave 30, `RULE W30-G` clause `G-1` = HOLDS ·
+`/mnt/d/hf_w30/w30g_score.txt`
+
+Relaxing exactly one gate `g` changes no other threshold, so the report's attribution must satisfy, **exactly,
+in integers**:
+
+> `ΔNO-CANDIDATE = 0`; `ΔFN_h = 0` for every `h` strictly upstream of `g`; and
+> `R_g = Σ_{h downstream of g} ΔFN_h + ΔContaminated + ΔACCEPTED-elsewhere + ΔTP`
+
+**Five single-knob cells, five exact balances, no tolerance**, with every upstream invariant and the pre-chain
+`BloomSuppressed` stage returning zero:
+
+| cell | gate (position of 11) | `R_g` | balance |
+|---|---|---|---|
+| `M1` | `TooDistorted` (4) | 12 090 | ✓ |
+| `M2` | `LowSensitivity` (6) | 486 | ✓ |
+| `M4` | `TooDistorted` (4) | 14 425 | ✓ |
+| `L1` | `TooSmall` (1) | 9 537 | ✓ |
+| `L3` | `LowSensitivity` (6) | 122 | ✓ |
+
+Two of these (`L1`, `L3`) were pre-computed from wave 29's published artifacts before the pre-registration and
+balanced then. **Three (`M1`, `M2`, `M4`) were blind by design §8 and balanced on first contact.**
+
+**What it licenses.** The `G-MODEL-BROKEN` branch of the tree read: *"the report's first-rejection-wins
+attribution does not conserve, and **every gate-count difference in waves 28 and 29 is unsafe.**"* It did not
+fire. **First-rejection-wins is the correct model of the `FALSE-NEGATIVE ATTRIBUTION` block, and every
+Δ-on-a-bucket waves 28 and 29 published can be read as a flow rather than as a coincidence.** This is the first
+checked model of these reports in eleven waves, and it was granted by measurement, not by argument.
+
+**It can fail, and the failure is exercised.** Self-test `[2]` moves one bucket by one on a live fixture and the
+balance breaks; `[9]` drives a non-conserving cell to `G-MODEL-BROKEN` with a non-zero exit.
+
+**A design difference the instrument reported rather than repaired.** The design's hand-typed §4.1(c) chain had
+**7** gates; the arm's run-time extraction found **11** (`…, TooFlat, HFRAnalysisFailed, TooLowHFR,
+Contaminated`) plus the pre-chain `BloomSuppressed`. The design's formula named contamination as a separate
+terminal **and** the chain contains it as the last gate; counted twice it would have doubled. The scorer
+partitioned once, printed the difference, and **the five exact balances are themselves the proof that the
+11-gate partition is right** — the 7-gate one could not have balanced.
+
+---
+
+### F106 — A hand-carried debt ledger rots in BOTH directions, and the rot is measured: `P-D08` was published seven hours before the wave that listed it as owed
+
+**Status:** Open — the class is structural · found 2026-08-13, wave 30, `RULE W30-D` = **`D-STALE`** ·
+`/mnt/d/hf_w30/w30d_score.txt`
+
+`RULE W30-D` parsed wave 29's §11 *"WHAT WAS NOT RUN"* table out of the committed document (sha256 re-asserted
+at scoring time), resolved each of **14** rows to exactly one predicate with a declared **scope**, and searched
+six roots plus the docs directory. `D-0` held (14 parsed, heading matched once, 0 unresolvable, 6 of 6 roots
+present). `D-1` returned **False**: 6 of 10 debt-claiming rows have a satisfying artifact.
+
+**Two rows are genuinely stale**, and one of them is why the rule exists:
+
+- **`P-D08` at `n = 3`** — measured 09:06–09:08Z, published under a heading *"`# RESULT — P-D08 is REFUTED at
+  n = 3`"*, committed `e42e2df` at 09:09:37Z, artifacts at `/mnt/d/hf_w26/pd08/`. Wave 29's ledger listed it
+  **owed** at 18:05Z the same day. **Seven hours, inside a single day's run.** The cause: the search was for an
+  artifact *under the wave's own root* rather than for the measurement wherever it lives.
+- **the closing `V29`** — `vdrift_w29_CLOSING.txt`, 18:18:01Z, fourteen minutes **after** wave 29's roll call.
+  The ledger was true when written and stale by the time it was read.
+
+**This is [F85](#f85)'s class recurring** — a closed, shipped correction re-measured as an open defect — **and
+the gap is now under twelve hours.** The remedy is not to fix a row. It is to stop inheriting the list: resolve
+each row to a **checkable predicate with a declared scope**, where a **per-wave obligation** is discharged only
+under the ledger wave's own root and a **measurement** is discharged wherever its artifact lives. Applying the
+per-wave scope to a measurement row is the exact error that produced this stale debt, and the scope distinction
+is what found it.
+
+**Wave 30's own §10 ledger is written in that form** — one literal search command per row — and **withdraws
+four rows** rather than carrying them a further wave.
+
+*(Design §16 assigned F106 to the stale debt; the assignment holds. See F107 for the rule's own defect.)*
+
+---
+
+### F107 — A ledger checker whose row predicates are FILENAME globs converts a false "owed" into a false "already paid", which is the worse error: 3 of 6 on its first run
+
+**Status:** Open — diagnosed, unrepaired by design · found 2026-08-13, wave 30, verifying `RULE W30-D`'s own
+output · `/mnt/d/hf_w30/w30d_score.txt`, `/mnt/d/hf_w29/l/opt/L0/attempt01/optimize_summary.txt`,
+`/mnt/d/hf_w25/s1_arm_w25.sh`, `/mnt/d/hf_w27/s27_*`
+
+`RULE W30-D` named **six** already-paid rows. Checked against what each ledger row actually claimed:
+**two genuine, one true-but-circular, three false.**
+
+| row | matched | verdict on the match |
+|---|---|---|
+| **the 42 m `optimize` gate** | `hf_w29/l/opt/L{0..4}/…/optimize_summary.txt` | **FALSE.** Each is *"Runs root: `D01_ultrawide_40mm`; **Runs: 1**"* — a per-cell optimize from wave 29's own arm, not the 8-dataset `Q27-V1` gate. **And the row's own text reads "NOT OWED this wave"** — a row that disclaims the debt was scored as claiming one |
+| a full paired 18-cell S1 arm | `hf_w25/s1_arm_w25.sh` | **FALSE, twice.** The match is a **shell script**, not a run record; and the row's own text says *"a **second** arm buys a second `SAME 13`"* — wave 25's arm is the row's premise, not its discharge |
+| `S27-1` and wave 27's three mutants | `hf_w27/s27_*` (6 files) | **FALSE.** The glob matched wave 27's **`S27-4`** do-no-harm arm. The debt is `S27-1`'s **route agreement** (wave 27 §7.3: *"not adjudicated, by the scorer's own printed statement"*) and the **`M-S1`/`M-S2a`/`M-S2b`** records (§7.4: *"remain testimony"*). The one evidenced mutant, `M-S3`, was **never the debt**. One of the six matches, `s27_score.txt`, is a file the series has already annotated as unquotable |
+| localising `D01` | `hf_w30/w30g_manifest.tsv` | **TRUE BUT CIRCULAR.** Written by **wave 30's own arm** at 19:52:10Z and scored "already paid" at 19:53:49Z — **99 seconds later** |
+
+**Three defects, in increasing order of transferability.**
+
+1. **The specs are hand-typed filename regexes** — `^.*optimize.*\.(txt|log)$`, `^s1_arm.*$`, `^s27.*$`. The
+   rule replaced a hand-carried *list* with a hand-carried *regex*. **It rots the same way and it rots
+   silently**, because a glob that matches too much produces a confident wrong answer where a glob that matches
+   nothing produces a visible "not satisfied."
+
+2. **`D-1` has no time ordering.** A row paid seven hours *before* the ledger, a row paid fourteen minutes
+   *after* it, and a row paid *by the checking wave itself* all score identically. `paid_at <
+   ledger_written_at` is the missing comparison, and **both timestamps are already in the rule's own
+   manifest.** Without it, a wave that discharges an inherited debt will report itself as evidence that the
+   ledger rotted.
+
+3. **The validity clause cannot see any of this, by construction.** `D-0` asserts every row resolves to
+   **exactly one** predicate — 14 of 14, unresolvable 0, correctly. **A validity clause that checks a row
+   resolves *uniquely* cannot check that it resolves *correctly*.** This is the same shape as [F108](#f108):
+   asserting a key is *present* is not asserting it is the *right* key.
+
+**The direction of the error is what makes this high severity.** A false "owed" costs a re-run. **A false
+"already paid" retires an obligation nobody met** — row 1 would have retired the 42 m gate, row 6 a control
+open four waves that two wave-27 ship-clauses relied upon.
+
+**What works and should be kept:** the **scope distinction**. Every *unsatisfied* result the rule produced is
+correct — the wave-29 BEFORE fingerprint and the three scorer self-test captures were both scoped `ledger` and
+both correctly reported not satisfied — and the scope is what found `P-D08`. **The rule is not repaired and not
+re-scored**; `D-STALE` stands on its two genuine rows.
+
+---
+
+### F108 — A stale literal passed to `split()` silently widened a self-test's slice to the whole document, and no checker in this apparatus can see it: a stale ordinal used as a KEY is not printed output
+
+**Status:** Closed in the instrument (fixed and the fix asserted) · Open as a class · found 2026-08-13, wave 30
+· `/mnt/d/hf_w30/score_w30g.py:1176-1192`, `instrumentcheck/score_g_selftest.txt` (57) vs
+`w30g_selftest.txt` (59)
+
+`score_w30g.py`'s self-test clause `[6]` — the [F84](#f84) / `RULE S16` sensitivity fence, one of two fences the
+design declared load-bearing — sliced the artifact with the needle **`"READING: more than a tenth"`**. **The
+emitter stopped producing that text when the material bar became computed**: the `G-SINGLE-BINDS` reading line
+is now formatted from `G2_BAR` (`:857`, *"READING: more than %.0f%% of the released mass reached acceptance…"*)
+and the literal *"a tenth"* appears nowhere in the output.
+
+**`str.split()` on an absent needle returns a ONE-ELEMENT list**, so `[-1]` handed back **the whole document**.
+The assertion below it — *"the fenced name appears in no verdict sentence"* — stopped being about a verdict
+sentence and became a document-wide absence check that passes trivially. **It would have passed forever while
+asserting nothing.**
+
+**What caught it, and what structurally could not:**
+
+- the **blocking pre-flight** flagged the stale phrase **only where it was printed** — it found the emitter's
+  copy, not the self-test's;
+- **`V30-C` cannot see this copy at all.** `V30-C` scans **printing lines** for typed ordinals and counts; its
+  population this wave was **667** (*"printing lines 980, of which 273 carry a format slot and are skipped"*).
+  **A needle passed to `split()` is not printed output**, so it is outside `V30-C`'s population by construction.
+
+> **A checker that looks for typed ordinals in output cannot find a stale ordinal used as a KEY.**
+
+**The remedy is local and permanent:** assert the anchor is **present**, and assert the slice is a **proper**
+substring so it can never widen to the whole text again. The anchor was shortened to the stable prefix
+`"READING: more than "`. **Self-test `57 of 57` → `59 of 59`.**
+
+**Class and generalisation.** This is [F102](#f102)'s class — *a clause whose population quietly went empty
+while still printing a pass* — recurring **in the wave that built F102's remedy**, in a form that remedy does
+not cover: F102 makes populations printable and refusable, which works for populations the instrument
+**computes**, and **this slice was a population nothing ever counted.** The general rule: **`split()`,
+`partition()`, `find()`, `re.search(...).group()` and every other locate-by-literal idiom degrades silently to a
+no-op or to the identity when its literal goes stale, and a population counter on the *output* cannot observe
+the *key*.** Every such call needs its key asserted present and its result asserted a proper part.
+
+---
+
+### F109 — Waves 27–30 ship as ONE PR at the owner's instruction, and the design's stacked-base prescription was overruled: only the PR base prevents accretion, but consolidation is the owner's call
+
+**Status:** Closed — decided by the owner · 2026-08-13, wave 30 · `gh pr list`, `git merge-base`
+
+**Measured at wave 30's pre-registration:** #196 (`…wave27`) and #197 (`…wave29`) both targeted **`develop`**,
+so #197's own diff carried waves 27, 28 **and** 29 plus wave 27's C# ship — **25 files.** Wave 29 had opened a
+fresh branch specifically so *"#196 does not carry a third section"* and succeeded at that; **it did not stop
+the accretion, it moved it.** The design's diagnosis was that the mechanism is the PR **base**, not the branch.
+
+**The diagnosis was acted on; the prescription was rejected.** The design pre-registered a fourth branch with
+`--base ghilios/…wave29`, to make *"the first PR in this family whose diff is one wave."* **The owner instructed
+one PR instead.** #197 was re-targeted to `…wave27` (the design's own §0 recommendation, which it had declined
+to perform itself) and **merged**; **#199 was closed**; the branch was **rebased onto `develop @ ec06bec` and
+force-pushed** with `--force-with-lease`. Waves 27–30 now sit on `ghilios/synthetic-af-bank-followups-wave27` =
+**PR #196**, base `develop`, titled *"Waves 27-30: …"*.
+
+**Design §0's goal of a one-wave PR diff was not achieved and will not be.** Recorded as an overrule, not as a
+design success.
+
+**One measured consequence for the gate check.** Design §9's reversal check is
+`git diff --name-only <base> HEAD -- '*.cs'`. Against the **PR's** base it returns **7 C# files** from waves
+27's and 28's ships. Against **wave 30's own** base (`0b86a2e`) it is **empty**, as is
+`git ls-files --others --exclude-standard -- '*.cs'`. **Wave 30 changed no C# and owes no gate** — but `<base>`
+was written assuming one wave per PR, and a later reader running the check literally against the PR base would
+conclude otherwise. **From here on the check must name the wave's base explicitly.**
+
+---
+
+### AMENDMENTS TO EXISTING ENTRIES
+
+**[F99](#f99) — AMEND IN PLACE.** Append:
+
+> **AMENDED 2026-08-13, wave 30, `RULE W30-G` = `G-NOT-RECOVERABLE`
+> (`/mnt/d/hf_w30/w30g_score.txt`).**
+>
+> **The mechanism holds and is now quantified on the gate this entry named.** `TooDistorted` at
+> `MaxDistortion` 0.3 releases **12 090** high-tier candidates on `D01` and **`LowSensitivity` re-captures
+> 9 676 of them — 80.0 %.** At 0.2: 14 425 released, 11 652 re-captured. **This entry's central observation —
+> that a gate's entire yield can be absorbed one and two gates downstream, and that a `FN_total` difference
+> cannot see it — is confirmed on a second knob and a second gate.** Its methodological half, *"wave 30's rule
+> over sequential gates must read the per-gate flow, not the net,"* is **vindicated and superseded**: the flow
+> is now a conservation identity that balances exactly and can fail ([F105](#f105)).
+>
+> **The substantive hypothesis is REFUTED at the pre-registered bar.** This entry claimed *"`D01`'s binding
+> constraint is `TooDistorted`, **jointly with** `LowSensitivity`, and no single-knob change recovers it."*
+> Measured on the 2×2: `ΔTP(joint) = +1 572` against `Σ ΔTP(singles) = +1 480` — an interaction of **+92**, a
+> multiple of **1.06×** against the pre-registered bar of **2×**. **The pair does not bind jointly; the joint
+> is essentially additive.** It *is* material (1 572 ≥ the computed bar of 502.5) — so the second half of the
+> claim, *"no single-knob change recovers it,"* is also wrong in the direction that matters: `M1` alone
+> delivers 1 096, itself above the material bar. **[F22](#f22) fence: none of these counts may be quoted as a
+> recall or focus benefit; the frame is goal 3 only.**
+>
+> **Status → Closed.** The hypothesis was stated so it could be wrong, it was pre-registered as `PREDICTION A`
+> against a rival `PREDICTION B` in wave 30's design §4.6, and the data chose. That is the entry working as
+> intended.
+
+**[F98](#f98) — APPEND.** Wave 30 is the **first measurement of the low end** of the `MaxDistortion` axis.
+Measured at 0.3 and 0.2 on `D01`: no collapse, `R_g` = 12 090 and 14 425, pass-through 9.1 % and 8.3 %, marginal
+pass-through on the second dose **4.1 %**. **Part 1 (the instrument finding) is untouched.** **Part 2 (bound the
+axis at ~π/4 and rename) gains support at the top and gains a NEW precondition at the bottom**: 23–25 % of the
+distortion gate's acceptances at the opened settings were `ACCEPTED-elsewhere` (accepted, not matched to the
+star they were released from) against 5–10 % for the sensitivity gate. **A ship that bounds the axis at the top
+is supported; a ship that lowers the default at the bottom is not yet supported and owes a ~5 m precision
+measurement** (§10 row 7). The axis has 10 steps and wave 30 measured 3 of them.
+
+**[F103](#f103) — APPEND.** **The forward prediction hit 4 of 4, second consecutive wave.** Predicted at wave
+29 and measured at wave 30 (`vdrift_selftest_w30.txt` `[5b]`, 19:26:49Z): `/mnt/d/hf_w28` expired from **100
+`-B` findings to 0**; `/mnt/d/hf_w29` became the live `-B` fixture at **311**; `/mnt/d/hf_w24` held as the
+durable `-C` fixture at **2**, fourth wave running; `/mnt/d/hf_w26` and `/mnt/d/hf_w27` stayed silent at
+**0**. **A pinned per-clause fixture goes silent exactly one wave later, on schedule.** The expired roots are
+kept and asserted silent, so the expiry is demonstrated rather than described. **Wave 31's prediction, if there
+is one:** `/mnt/d/hf_w29` expires to 0 and `/mnt/d/hf_w30` becomes the live `-B` fixture.
+
+**[F94](#f94) — APPEND.** The `None` enumeration plus the **realized-tuple membership assertion** ran in **four**
+instruments this wave (`W30-G` 36 regions, `W30-D` 6, `V30` 12, `W30-FP` 18), every one printing `uncovered: 0`
+**and** its own realized tuple **and** `member of the enumerated set: True`. **It caught nothing this wave** —
+every tuple was inside its domain — and that is the honest report. What it *did* demonstrate is that the
+assertion can discriminate: `score_w30g.py`'s self-test `[13]` shows a tuple carrying `None` **is** a member and
+a tuple outside the declared domains **is not**, so the assertion can fail. **A check that cannot fire in a
+given wave is still worth its cost only if its firing end is exercised, and it was.**
+
+**[F102](#f102) — APPEND.** Every clause in every wave-30 instrument printed `candidates: N   findings: M`.
+**No clause printed an unexpected `N = 0` and no instrument refused with `POPULATION-EMPTY`** — the populations
+were 5/7/8/3/4/4/2 (`G-0`'s seven), 5 (`G-1`), 36 660 (`G-2`), 2 (`G-3`), 14 and 10 (`W30-D`), 12/5 026/667
+(`V30`), 1 230 (`W30-FP`). **But F102's class recurred anyway, in a place populations cannot reach** — see
+[F108](#f108). **F102's remedy covers populations the instrument computes; it does not cover a literal used as
+a key, which nothing counts.** The remedy is not weakened, it is bounded, and the bound should be written into
+it.
+
+**[F95](#f95) — APPEND.** Wave 30 ran the pre-flight **over a populated root** (7 files, 12 `-A` candidates,
+5 026 `-B`, 667 `-C`) **and at the close**, both from the pre-registration rather than from a debt, and the two
+runs are **byte-identical**. **Both halves of the remedy, from the start, for the first time.** One deviation
+against F95's neighbour requirement is recorded in §7.4: the `W30-FP` BEFORE sweep ran **26 minutes after**
+`V30`'s five fixture probes read `/mnt/d/hf_w29`, against design §6's bolded ordering. Consequence measured:
+none (`PRESERVED`, 0 moved). **The ordering must be enforced by the driver, not by intent.**
+
+**[F21](#f21) — APPEND.** Estimate vs actual, wave 30, sixth consecutive wave under on the analysis halves:
+
+| step | est | actual |
+|---|---|---|
+| 1 — write all 7 instruments | 60 m | **~39 m** (18:54:08 → 19:33:44Z) |
+| 2 — `W30-FP` BEFORE | 5 m | **≤ 60 s** |
+| 3 — `V30` pre-flight + 5 fixture probes | 15 m | **~7 m** |
+| 4 — the 5-cell arm | 25 m wall / ~15 m compute | **17 m 37 s wall / 1 057 s compute** |
+| 5 — `W30-G` scoring | 12 m | **~15 s** to emit |
+| 6 — `W30-D` | 15 m | **~2 m** |
+| 7 — the `K` column | 12 m | **NOT RUN** (§10 withdraws it) |
+| 8 — AFTER + closing `V30` | 8 m | **~2 m** |
+| **Steps 1–8 excluding 7** | **~140 m** | **~62 m — 56 % under** |
+
+**Two figures were priced from a measured rate and one of them was mildly optimistic.** The arm was priced at
+~950 s from wave 29's 145–198 s per cell and came in at **1 057 s, 11 % over** — because wave 29's two fastest
+cells were its two *dead* ones, so the reference rate was biased low. **A rate measured over an arm containing
+dead cells under-prices an arm with none.** The sweep price (3 m/side, from 61 MB/s over a trimmed 2.4 GB root
+set) was **generous by ~3×**: both sides completed in ≲ 2 minutes. **New constant handed forward:** 1 230 files
+across 6 declared roots sweep in **under a minute** on DrvFs. **And it could only be bounded, not measured** —
+see §8.3: the fingerprint records no start time.
+
+**`S27-1` and wave 27's three mutants — WITHDRAWN**, formally, after four waves on the cut list, per design §16
+and wave 29 §13. **And note that [F107](#f107) shows `RULE W30-D` falsely reported this row already paid** — it
+matched wave 27's `S27-4` arm. The withdrawal is on the merits, not on that match.
+
+**`docs/synthetic-af-bank-results-table.md`'s `K` column — WITHDRAWN**, per design §13's own rule for this item.
+Owed by waves 28, 29 and 30; unpaid by all three. `kcol_w30.py` remains on disk with a `21 of 21` self-test and
+can be run in ~2 m by any later ship.
+
+---
+
 ### F96 — The harness's `stepBehavioral` "truth" is a fixed point of the recommender it scores, so every goal-2 conclusion is denominated in a bar the code under test produces
 
 **Status:** Open (diagnosed to a line; no fix priced) · found 2026-08-13, wave 29, `RULE W29-S` clause `S-a`
@@ -522,6 +869,28 @@ the two **fastest** cells in a five-cell arm, because nothing survived the gate 
 
 **Status:** Open — the hypothesis wave 30 should pre-register · found 2026-08-13, wave 29 ·
 `/mnt/d/hf_w29/l/out/L{0,1}/attempt01/golden_eval.txt`
+
+> #### AMENDED, wave 30 — the mechanism HOLDS, the joint-recovery claim is REFUTED at a pre-registered bar
+>
+> `RULE W30-G` = **`G-NOT-RECOVERABLE`**, on a 2x2 factorial with `MaxDistortion` opened in the **correct**
+> direction (lowered; wave 29 raised it and killed two cells before they ran, F98).
+>
+> **What holds:** the two gates release real mass — 36 660 high-tier candidates across the cells — and the
+> conservation identity balances **integer-exact on 5 of 5** real cells (F105), so the flow account this entry
+> rests on is sound.
+>
+> **What is refuted:** the *joint recovery* claim. `dTP(joint) = +1572` against a summed-singles `+1480` and a
+> pre-registered synergy bar of `2 x singles = 2960`. The joint clears the **material** bar (502.5, computed as
+> `0.01 x FN_total`) and is **essentially ADDITIVE, not synergistic**, while `G-2` shows **re-capture dominates
+> at 92 %** — what one gate releases, the gates downstream take.
+>
+> **The outcome was called either way.** Wave 30 registered TWO differing predictions before the data — this
+> entry's (`G-JOINTLY-BOUND`) and the pre-registration's own (`G-NOT-RECOVERABLE`) — so neither result let the
+> wave claim a hit it had not called. That is the strongest form of evidence this series has produced.
+>
+> **[F22](#f22) fences the reading:** on this rig HFR over-reads badly below ~1.1 px and autofocus already
+> lands, so **none of this may be quoted as a focus improvement**. The deliverable is which gate binds, a
+> goal-3 question.
 
 `RULE W29-L`'s pre-registered statistic is the difference in `FN_total`. On `D01`, lowering
 `MinStarBoundingBoxSize` 6 → 3 gives `FN_total` 50 249 → 50 246, i.e. **−3**, which reads as "this gate does

--- a/docs/followups.md
+++ b/docs/followups.md
@@ -791,8 +791,32 @@ attributable to the one edited field.
 
 ### F94 — Verdict trees keep shipping with uncovered regions, and the standing rule against it did not stop the second one
 
-**Status:** **Open — a class, now on its second consecutive wave** (2026-08-13, wave 28) · generalises wave 27
-§8.1 · belongs beside [F68](#f68) part 5
+**Status:** **Open — a class, now on its THIRD consecutive wave, and wave 29 found the reason the fix does not
+work** (2026-08-13, waves 27–29) · generalises wave 27 §8.1 · belongs beside [F68](#f68) part 5
+
+> #### APPEND, wave 29 — the coverage PROOF is the thing that is wrong, not just the tree
+>
+> Wave 29 answered F94 by **enumerating every tree and printing `uncovered: 0`** on all five instruments. It
+> was not enough, and the failure is instructive.
+>
+> `RULE W29-L` printed `regions enumerated: 8   uncovered: 0` and then ran to the clause state
+> **`(L-0=True, L-1=None, L-2=None)`** — a triple its own enumeration **never visits**, because the
+> enumeration ranges over `{True, False}` and the clauses are three-valued: `L-1` and `L-2` are `None` when
+> `joint` is not positive, which is a could-not-look and not a `False`.
+>
+> **A tree proved total over `{True, False}` is not total over `{True, False, None}`**, and every rule in this
+> series that has a could-not-look state has three-valued clauses. So the remedy waves 28 and 29 adopted —
+> enumerate and assert `uncovered: 0` — **proves the wrong totality** and will keep printing a clean coverage
+> line beside an uncovered state.
+>
+> **The corrected remedy: enumerate over the clause's ACTUAL value domain, `None` included, and assert that
+> the verdict function is total over THAT product.** A cheap check that would have caught it: assert the run's
+> own observed clause tuple is a member of the enumerated set, which costs one line and cannot be satisfied by
+> a proof of the wrong thing.
+>
+> Wave 29's `w29l_score.txt` also shipped a **false explanatory sentence** on the same run — *"the control did
+> not hold"* when `L-0` **held** (8 fields, 0 disagreeing). The verdict `L-UNEVALUATED` is correct on the
+> numbers; only the prose was wrong. It is annotated in place on the artifact rather than edited out.
 
 Wave 27's `RULE T27` tree left `3 ≤ union ≤ 9` with neither set at 5 uncovered, and the scorer printed
 `T-TREE-GAP` rather than papering over it. Wave 28's design §12 turned that into a standing rule — *"every

--- a/docs/followups.md
+++ b/docs/followups.md
@@ -434,6 +434,35 @@ shape for this space.
 **Status:** **OPEN — a decision, not a defect** (2026-08-13, answering the owner's question after wave 26) ·
 depends on [F83](#f83), reframed by [F31](#f31) and [F23](#f23)
 
+> #### CORRECTION, wave 27, 2026-08-13 — this entry's `91.3 %` describes a PRE-REPAIR quantity
+>
+> **Every passage below that says "91.3 % reference omission", and item (2), was written as though
+> [F31](#f31)'s repair did not exist. It shipped 2026-08-03** (`aaf26e8`, refined `5c382a1`) as
+> `TestApp/SynthBank/TruthProtection.cs`, wired into **both** `GoldenEvalRunner.cs:301-307` and
+> `BankVerifyRunner.cs:464-466` — **and F31 is recorded `Done` in this same file, ~1 600 lines above.**
+>
+> Wave 26's re-score (`/mnt/d/hf_w26/pd08/F31_truth_rescore.txt`) re-derived false positives from the golden's
+> `stars` list **alone**, consulting neither the golden's own `unresolved` boxes nor `TruthProtection`. Its 150
+> decompose as **50 excluded by `unresolved` + 89 truth-protected + 11 surviving**; its `137` is a *third*
+> quantity ("within 12 px of ANY truth star"). **`golden eval`'s FP field on those same detections is 11**, and
+> the owner's table's `0.966` is `308/(308+11)` — truth-corrected as printed. Two different fields, both called
+> "false positive" ([F68](#f68) part 1).
+>
+> In place, below:
+> * **Item (2) — "Re-measure precision against `truth.json`" — is DISCHARGED, not owed.** It shipped in wave 2.
+> * *"without it, F23 and F83 are both undecidable"* is **false**. F23 was re-measured at `afbank-verify/5`, and
+>   that re-measurement is what voided it.
+> * Point 4's *"`D08`'s apparent cost is 91.3 % reference omission"* should read: **`D08`'s scored cost is 11
+>   genuine junk detections**, all on the two extreme wing frames, zero on the seven interior frames. The
+>   correction **strengthens** this entry's conclusion — see [F83](#f83) caveat 3.
+> * Item (4)'s **"13 junk detections" is 11**: two of the 13 sit inside a golden `unresolved` box.
+>
+> **What was actually open:** `golden eval` emits **none** of `bank-verify`'s four truth disclosures
+> (`scoringMode`/`protectedStars`, `precisionNull`, `truthViolations`, `scoredFraction`), so no reader of a
+> published `golden_eval.txt` can tell whether protection was applied. That silence is the mechanism that
+> produced this misreading, and wave 27 ships the fix. See
+> `docs/synthetic-af-bank-followups-wave27-design.md` and `docs/wave27-register-correction-survey.md`.
+
 **The eight at-floor landings** (`BrightnessSensitivity = 0.0`), resolved from source predicates by wave 26's
 prep, with their combined effective gates:
 
@@ -658,7 +687,16 @@ lowers `recall@all` on all four, and raises `REJECTED:LowSensitivity`. **All fou
    mechanism on **this dataset by name**: *"`D08` holds 81 golden stars at focus and 9 at the extreme frame,
    against 123–126 truth stars per frame throughout."* The base cell accepts 10 and 15 on frames whose golden
    holds 9. **So the +0.034 may be real faint stars the golden omits rather than junk**, and separating the two
-   needs a re-score against each frame's own `*.truth.json` — F31's own method, **not run**.
+   needs a re-score against each frame's own `*.truth.json` — F31's own method, ~~**not run**~~.
+
+   > **CAVEAT 3 IS DISCHARGED, wave 27, 2026-08-13 — and it resolves IN THIS ENTRY'S FAVOUR.** The separating
+   > measurement had already been run, twice over. (i) The scoring is truth-protected at source since
+   > 2026-08-03 ([F31](#f31)), so these 11 survived `ExcludeProtected` — by construction **none of them has an
+   > `omitted`/`merged-into` truth star within the 12 px radius**. (ii) Wave 26's own per-frame table
+   > (`/mnt/d/hf_w26/pd08/F31_truth_rescore.txt`) reports **0 real** of the wing-frame false positives on both
+   > `13672` and `14328`, against "ALL REAL" on the seven interior frames. **So the 11 are genuine junk and the
+   > `+0.034` is real, not a reference artifact.** Caveat 2 (saturation) is untouched by this and is precisely
+   > what `RULE T27` measures.
 
 **What survives all three**, because it does not read the golden at all: the FN attribution. `REJECTED:LowSensitivity`
 is the *detector's* count of what the sensitivity gate rejected, and it goes None → 55 / 28 / 16 / 37.
@@ -2848,7 +2886,7 @@ would alias one instance.
 The underlying overwrite ([F15](#f15--optimize---per-run-overwrites-each-runs-stored-settings)) is unchanged — a
 bank folder still accumulates whichever prepass went last. What changes is that the survivor now says so.
 
-### F31 — Synthetic-bank precision is NOT exact: the golden omits real stars, and they score as false positives
+### F31 — ~~Synthetic-bank precision is NOT exact: the golden omits real stars, and they score as false positives~~ — FIXED 2026-08-03; the title is the DEFECT, not the current state
 **Status:** **Done** (2026-08-03, wave 2 — repaired, validated against a null control, and everything re-baselined at `afbank-verify/5`) · found 2026-08-03 verifying the F23 wave-1 result · **INVALIDATED F23's evidence base**
 
 `docs/synthetic-af-bank-baseline-results.md` headlines the synthetic bank with "Golden precision (D06,

--- a/docs/followups.md
+++ b/docs/followups.md
@@ -429,6 +429,167 @@ shape for this space.
 > three where the search **also** drove `StarClippingMultiplier` down, twice to the axis's own 0.25 floor.
 > Reproduce: `/mnt/d/hf_w26/q26_score.txt`; `docs/synthetic-af-bank-followups-wave26-results.md` §4.3, §7.
 
+### F92 — The post-wavelet blur is WELDED to `StructureLayers`, so one knob sets two opposing scale cutoffs
+
+**Status:** **Open — source-derived, zero compute, and it re-opens [F43](#f43)** (2026-08-13, wave 28,
+`RULE W28-S` = `S-WELDED`, 3 of 3)
+
+`StarDetector.cs:631-632` blurs the structure map immediately after the à trous residual is subtracted:
+
+```csharp
+// Step 5: Excluding large structures can cut off the outsides of large stars, or leave holes when far out
+//         of focus. Blurring smooths this out well for structure detection
+CvImageUtility.ConvolveGaussian(structureMap, structureMap, p.StructureLayers * 2 + 1);
+```
+
+with `sigma = 0.159758 * kernelSize` when unset (`CvImageUtility.cs:80-82`). At the shipped
+`StructureLayers = 4` the kernel is 9×9 and **σ ≈ 1.44 px**, so a 1-px source loses roughly `1/(2πσ²) ≈ ×0.077`
+of its peak amplitude **before** it is compared against
+`binarizeThreshold = median + NoiseClippingMultiplier · sigma` (`:653`).
+
+**The blur's stated purpose is to help LARGE and defocused stars, and its entire cost falls on small ones.**
+Its width is keyed to `StructureLayers`, which is the knob for the *upper* scale cutoff — the shipped tooltip
+says so: *"At the default of 4 (2⁴=16), structures larger than 16 pixels in size are excluded"*
+(`OptionsDataTemplates.xaml:444`). **Lowering `StructureLayers` therefore narrows the blur (helps a 1-px star)
+and makes the residual less smoothed (hurts it), in one move.**
+
+**Measured as a rule, both hashes recorded** (`/mnt/d/hf_w28/w28s_score.txt`, `StarDetector.cs`
+`1e202777…`, `IStarDetector.cs` `5304ed5f…`): the width argument is literally `p.StructureLayers * 2 + 1`
+(raw, **not** `EffectiveStructureLayers`); **no** member of `StarDetectorParams` — 55 properties — controls the
+blur width independently; and `EffectiveStructureLayers(p)` reaches the residual at `:619`/`:622` and appears
+**0 times** in the blur's argument list. The defocus/donut boost (`:1567-1578`) already decouples them in one
+direction, so **there is precedent for decoupling the other.**
+
+**Consequence for the register:** [F43](#f43)'s *"`StructureLayers` 4 → 2 makes it strictly worse"* moved both
+cutoffs at once and is **confounded in source**. The experiment that separates them has never been run.
+
+**Price to run it:** ~45 m code (a dedicated blur-width field defaulting to today's expression, so the default
+is bit-identical) + ~10 m arm; **plus a fresh 42 m `optimize` baseline and a re-derivation if it is ever to
+ship**, because the change reaches the detector. Design §11 defers it; `RULE W28-N` (see [F93](#f93-ready-to-paste))
+is the evidence that the amplitude account it rests on is correct.
+
+### F93 — `NoiseClippingMultiplier` is the binding gate below the calibrated band on the bank too — with one dataset where it is not enough
+
+**Status:** **Open — measured, and explicitly NOT a licence to change a default** (2026-08-13, wave 28,
+`RULE W28-N` = `N-RECOVERS`, 3 of 3) · corroborates [F43](#f43) on synthetic frames · bounded by [F22](#f22)
+
+[F43](#f43) found that on a reporter's **real** 61 MP 19.4″/px rig the binding gate was `NoiseClippingMultiplier`,
+not `Sensitivity`. Wave 28 ran it on the bank: 3 floored datasets × `NC ∈ {landed, 2.0, 1.0}`, no build, one
+edited field per cell, 432 s.
+
+| dataset | `NC` landed | high-tier `NO CANDIDATE` landed → `NC 1.0` | `recall@high` landed → `NC 1.0` | `recall@all` | precision at 1.0 |
+|---|---|---|---|---|---|
+| `D01_ultrawide_40mm` | 3.8125 | 42 991 → **8 931** (−79.2 %) | 0.183 → **0.195** | 0.123 → 0.183 | 1.000 |
+| `D02_rich_135mm` | 3.9375 | 3 732 → **1 071** (−71.3 %) | 0.446 → **0.687** | 0.377 → 0.598 | 1.000 |
+| `D03_redcat_250mm` | 3.625 | 197 → **7** (−96.4 %) | 0.365 → **0.549** | 0.238 → 0.364 | 1.000 |
+
+**The mechanism is confirmed and the payoff is not uniform.** `D02` and `D03` recover a quarter and a fifth of
+`recall@high`. **`D01` does not:** 34 060 high-tier candidates now form, **97.8 % of them are re-rejected by a
+later gate** (`TooDistorted` +13 866, `LowSensitivity` +12 826, `TooSmall` +6 515), and `recall@high` moves
++0.012. Its attribution profile inverts — `NO CANDIDATE` 84.3 % → 17.8 %, gates 12.1 % → 79.3 % — so **at
+`NC = 1.0` `D01` looks like `D02`/`D03` did at their landed settings.** The gates fire in sequence
+(`TooSmall` → `OnBorder` → `TooDistorted` → `Degenerate` → `LowSensitivity`), so those counts are
+first-rejection-wins and **which gate binds on `D01` is NOT established.**
+
+**Three things this entry does not say.** (1) It is **not a ship**: no wave-28 rule pre-registered a change on
+this axis, and the optimizer *chose* the landed values under an objective that charges nothing for a missed
+detection ([F83](#f83)). A default or search-bound change owes its own wave with a fresh baseline. (2) The
+`precision = 1.000` is **1.000 at baseline too**, so `N-3` shows no detected cost rather than a measured cost of
+zero. (3) [F22](#f22) still binds: below ~1.1 px measured HFR over-reads by up to +234 %, so **stars recovered
+below the band carry an HFR that cannot resolve the vertex** — and `D01` already reaches `BestJ` 0.994825.
+
+**Artifacts:** `/mnt/d/hf_w28/nc/<dataset>_nc<v>/attempt01/golden_eval.txt`, `w28n_score.txt`,
+`w28n_manifest.tsv`. The three landed cells reproduce the published `table18` rows exactly, so every delta is
+attributable to the one edited field.
+
+### F94 — Verdict trees keep shipping with uncovered regions, and the standing rule against it did not stop the second one
+
+**Status:** **Open — a class, now on its second consecutive wave** (2026-08-13, wave 28) · generalises wave 27
+§8.1 · belongs beside [F68](#f68) part 5
+
+Wave 27's `RULE T27` tree left `3 ≤ union ≤ 9` with neither set at 5 uncovered, and the scorer printed
+`T-TREE-GAP` rather than papering over it. Wave 28's design §12 turned that into a standing rule — *"every
+verdict tree in this wave is checked for total coverage of its outcome space at pre-registration"* — and then
+**`RULE W28-N`'s tree shipped with 4 of 135 regions uncovered, every one of them a region where `N-1` is
+false.** `N-1` is the clause that checks the edit took effect; a run where it silently did not would have scored
+`N-RECOVERS` on the tree as written.
+
+**The pattern is specific and predictable: the uncovered region is always the VALIDITY clause.** `N-2` and `N-3`
+are substantive and appear in every branch; `N-1` is the gate that says the measurement happened at all, it is
+expected to hold, and it fell out of the tree. `W28-S` (27 regions) and `W28-B` (432 regions) both enumerate
+clean — and neither has a validity clause outside its own conjunction.
+
+**Remedy, and it is mechanical rather than a reminder:** a design must **enumerate its own outcome space at
+pre-registration** — the scorers already do this in code, and printing `regions enumerated: N   uncovered: 0`
+costs nothing — and **every clause, including the ones expected to hold, must appear in the tree.** A scorer
+that finds a gap prints `<RULE>-TREE-GAP`, enumerates the uncovered regions, prints what the design's literal
+tree would have said, and **does not repair and re-score** (`/mnt/d/hf_w28/w28n_score.txt`, self-test [5]).
+
+### F95 — A blocking pre-flight that runs before the instruments exist certifies an empty population
+
+**Status:** **Open — remedy known, not applied this wave** (2026-08-13, wave 28) · [F80](#f80)/[F87](#f87)'s
+family, third distinct shape
+
+`verify_derivation_w28.py` ran at `11:06:36` over `/mnt/d/hf_w28/`, which then contained exactly one file —
+itself. `vdrift_w28.txt` reads `files checked: 1` and `>>> V-UNEVALUATED: no sibling target was referenced by
+any driver in this root`. The wave's six instruments (`fp_w28.sh`, `score_w28s.py`, `score_w28b.py`,
+`score_w28n.py`, `w28b_manifest.sh`, `w28n_arm_w28.sh`) were all written afterwards and **were never checked**.
+The plan's gate required `V-CLEAN`; the design says `UNEVALUATED` is never a pass; the wave proceeded.
+
+**The self-test and both pinned FAIL fixtures are healthy** — `SELF-TEST PASS`, 262 `V28-B` findings on
+`/mnt/d/hf_w27`, 2 `V28-C` findings on `/mnt/d/hf_w24`, and `/mnt/d/hf_w26` demonstrating expiry with 0. **The
+instrument works; it was pointed at nothing.**
+
+**The class, stated so it survives this wave:** F80's first three gaps were a *pattern* too narrow; F87's was a
+*population containing the instrument*; this is a *population that was empty at the only moment the check was
+taken*. **A blocking pre-flight must be re-run at the wave's close over the finished root, and the closing run
+is the one whose verdict is quoted.** The pre-flight run proves the checker works; the closing run proves the
+wave is clean. They are two runs and this series has been conflating them. Price: **~2 m per wave.**
+
+### 9.5 Amendments owed to existing entries
+
+* **[F43](#f43) — AMEND IN PLACE, and it is the amendment this wave owes most.** The entry's *"`StructureLayers`
+  4 → 2 makes it strictly worse (0 at both central positions)"* is **confounded in source**, proved by
+  `RULE W28-S` = `S-WELDED` at zero compute. Lowering `StructureLayers` moves **two** cutoffs in opposite
+  directions: it narrows the post-wavelet Gaussian at `StarDetector.cs:632` (whose width is literally
+  `p.StructureLayers * 2 + 1`, so 4 → 2 takes the kernel 9×9 → 5×5 and σ 1.44 → 0.80 px, which **helps** a 1-px
+  star clear the binarization threshold) **and** shrinks the à trous residual's low-pass from ≈2⁴ to ≈2² px, so
+  `src − residual` retains less of the star (which **hurts** it, and by more). The measurement stands; the
+  **inference that the axis is useless does not**, because the two effects were never separated and no member of
+  `StarDetectorParams` can separate them. **F43's "`MinHFR` is the ONLY axis that rescues it" must now be read as
+  "the only axis that rescues it among those tested, on an axis set that contained a confounded knob."** See
+  [F92](#f92-ready-to-paste); and note [F93](#f93-ready-to-paste) finds a **second** axis that rescues `D01`'s
+  candidate formation (`NoiseClippingMultiplier` 3.8125 → 1.0 cuts its structure gap 79.2 %) — though not its
+  `recall@high`.
+* **[F62](#f62)** — append that wave 28 tested the "one band-pass phenomenon" claim out of sample and **it did
+  not survive below the band**. `RULE D27`'s upper-edge result is untouched and the prediction holds on **9 of 10**
+  blind datasets above the band; the lower-edge prediction fails on **0 of 4** LOW datasets, with `Δacc > 0` on
+  all 17. `RULE D27` and item 8 may still be two views of one mechanism, but the *evidence* for the unification is
+  one-sided and must be quoted that way.
+* **[F31](#f31)** — append a second, independent demonstration of the reference's wing evaporation: on wave 28's
+  blind population the golden-denominated and detector-only routes disagree on **5 of 17** datasets and **all
+  five disagree in the same direction** (`Δrecall < 0 < Δacc`). A per-frame recall statistic is biased against
+  the focus frame wherever the golden's denominator peaks there.
+* **[F21](#f21)** — extend the measured `golden eval` rate. Wave 27 recorded 6–46 s per 9-frame cell (full
+  20-dataset arm 349 s). **Wave 28's `D01` at `NC = 1.0` took 179 s** — 3.9× the previous maximum — because
+  lowering the threshold multiplies the candidate count. **Price a cell from the RANGE and from the knob
+  setting, not from the dataset alone.** Wave 28's 10 cells totalled 381 s of `TestApp` time inside a 432 s wall.
+* **[F35](#f35)** — its finding that *"the W class's recall is lost in candidate FORMATION — the structure map
+  never proposes 49 % of them"* now has a lever: `NoiseClippingMultiplier` converts most of that loss into
+  formed candidates ([F93](#f93-ready-to-paste)). On `D02`/`D03` they become detections; on `D01` 97.8 % of them
+  are re-rejected downstream, which is also where F35's *"`MinimumStarBoundingBoxSize` rejects another 17 % as
+  `TooSmall`"* now points.
+* **[F84](#f84)** — unchanged and re-affirmed: **wave 28 proposed and measured nothing on the `Sensitivity`
+  axis.** `D01`'s `LowSensitivity` count rising from 786 to 13 612 at `NC = 1.0` is a **downstream consequence**
+  of more candidates existing, not evidence for or against a sensitivity floor.
+* **`docs/synthetic-af-bank-results-table.md`** — add the **in-focus kernel HFR `K` (px)** column from
+  `truthModel` (`max(hfrMin, hfrMinEffective)`), and the note that `D01`/`D02`/`D03` are the **only three floored
+  by the generator** (`hfrMin < hfrMinEffective`), all at `K = 0.700` despite 19.4 / 5.7 / 3.1 ″/px. It reorders
+  the recall column into a monotone story and costs nothing. **Do not annotate it with a 2–4 px band claim
+  below the band** — `W28-B` is `B-SPLIT` and the lower edge is not established.
+
+---
+
 ### F85 — A closed, shipped correction was re-measured as an open defect, because two fields share a name
 
 **Status:** **Done** (2026-08-13, wave 27) — the disclosure gap is fixed; the register contradiction is
@@ -3918,7 +4079,9 @@ agrees-with-the-presets case.
 ### F43 — The optimizer wizard refuses to start unless the DEFAULT settings already produce a usable curve
 **Status:** **Done (wave 5)** for the Live path; **replay DECIDED (wave 6) — extend, but not before the
 `BaselineJ = 0` presentation question is answered**, so the implementation is still open · found 2026-08-05 from a
-user report on a 40 mm rig
+user report on a 40 mm rig · **AMENDED wave 28: this entry's "`StructureLayers` 4 → 2 makes it strictly worse"
+is CONFOUNDED IN SOURCE — one knob moves two opposing cutoffs (`RULE W28-S` = `S-WELDED`). See the amendment
+below and F92**
 
 `SeedFitIsUsableAsync` (`StarDetectionOptimizerWizardVM.cs:2869`, called at `:2541`) evaluates the **default seed
 params** once and refuses to optimize unless some run yields a finite σ(focus) over ≥ 3 positions. On a Live
@@ -3960,6 +4123,35 @@ removes precisely the frames the vertex is fitted from.
 **And `MinHFR` is the ONLY axis that rescues it.** `MinimumStarBoundingBoxSize` 5 → 3 changes nothing (still 0 at
 focus); `StructureLayers` 4 → 2 makes it strictly worse (0 at *both* central positions). So the single knob that
 un-blocks this rig class is the one the guard's refusal prevents the search from ever touching.
+
+> #### AMENDMENT, wave 28, 2026-08-13 — the `StructureLayers` result above is CONFOUNDED IN SOURCE
+>
+> **The measurement stands. The inference that the axis is useless does not.** `RULE W28-S` = `S-WELDED`, 3 of 3
+> clauses, decided from source at zero compute (`/mnt/d/hf_w28/w28s_score.txt`; `StarDetector.cs` sha256
+> `1e202777…`, `IStarDetector.cs` `5304ed5f…`): **`StructureLayers` sets two opposing scale cutoffs at once.**
+>
+> * It sets the **upper** cutoff, via the à trous residual's ≈`2^StructureLayers` px low-pass, which is
+>   *subtracted* — the knob's documented purpose.
+> * It **also** sets the width of the post-wavelet Gaussian blur, which is the **lower** cutoff:
+>   `CvImageUtility.ConvolveGaussian(structureMap, structureMap, p.StructureLayers * 2 + 1)`
+>   (`StarDetector.cs:631-632`), with `sigma = 0.159758 * kernelSize` (`CvImageUtility.cs:80-82`). The width
+>   argument is **raw** `p.StructureLayers`, not `EffectiveStructureLayers(p)`; **no** member of
+>   `StarDetectorParams` (55 properties) controls it independently; and `EffectiveStructureLayers(p)` reaches the
+>   residual at `:619`/`:622` and appears **0 times** inside the blur call's argument list.
+>
+> So **4 → 2 takes the kernel 9×9 → 5×5 and σ 1.44 → 0.80 px, which HELPS a ~1 px star clear the binarization
+> threshold at `:653`, while simultaneously shrinking the residual's low-pass from ≈2⁴ to ≈2² px, so
+> `src − residual` retains less of the star — which HURTS it, and by more.** The two effects were never
+> separated, and with the shipped parameter set they **cannot** be: there is no knob for the blur width alone.
+> The experiment this entry's sentence assumes was run has never been run.
+>
+> **Read the claim as: "`MinHFR` is the only axis that rescued it among those tested, on an axis set that
+> contained a confounded knob."** See **F92** for the decoupling build (~45 m + ~10 m arm, +42 m `optimize`
+> baseline if it is ever to ship). And note **F93**: `NoiseClippingMultiplier` 3.8125 → 1.0 on this same `D01`
+> cuts its high-tier `NO CANDIDATE (structure gap)` count **42 991 → 8 931 (−79.2 %)** at precision 1.000 — a
+> **second** axis that rescues candidate *formation* on this rig class, though on `D01` 97.8 % of the recovered
+> candidates are then re-rejected by a later gate and `recall@high` moves only +0.012. Full working:
+> `docs/synthetic-af-bank-followups-wave28-results.md` §1, §2, §9.
 
 **Why [F35](#f35--minhfr-should-be-seeded-from-the-sweep-wings-and-neither-available-hfr-statistic-can-size-it)
 does not already cover this.** F35's `MinHfrSeed` is applied inside `OptimizeAsync` (`:3076`) — **after** this

--- a/docs/followups.md
+++ b/docs/followups.md
@@ -429,6 +429,293 @@ shape for this space.
 > three where the search **also** drove `StarClippingMultiplier` down, twice to the axis's own 0.25 floor.
 > Reproduce: `/mnt/d/hf_w26/q26_score.txt`; `docs/synthetic-af-bank-followups-wave26-results.md` §4.3, §7.
 
+### F96 — The harness's `stepBehavioral` "truth" is a fixed point of the recommender it scores, so every goal-2 conclusion is denominated in a bar the code under test produces
+
+**Status:** Open (diagnosed to a line; no fix priced) · found 2026-08-13, wave 29, `RULE W29-S` clause `S-a`
+= HOLDS · `/mnt/d/hf_w29/w29s_score.txt`
+
+`SynthValidateRunner.ComputeStepBehavioral` (`:1213–1270`) builds an analytic curve, fits it, calls
+`StepSizeRecommender.Recommend` at **`:1262`**, and loops until `rec.StepSize == step`. `RULE W29-S` asserts
+from source, at `HEAD`, by sha256, that the method is **declared once**, contains **exactly one** `Recommend(`
+call site inside its body (whole-file count 2, at `:792` and `:1262`, printed so the scoping is visibly doing
+work), and is the **only writer** over 70 harness files of the value serialized as `terminal.stepBehavioral`.
+
+**Consequence.** A change to `Recommend` moves the bar **and** the measurement together. This is the mechanism
+behind [F82](#f82)'s observation that `stepBehavioral` moved 8.0 → 9.0 across wave 25's two arms while it was
+identical on the other 17 cells: wave 25 changed `Recommend`. **Assertion `A3`, and every goal-2 statement in
+waves 20–29 that quotes `stepBehavioral` as truth, is a self-consistency check and not an accuracy measurement.**
+
+**What it does NOT say.** It does not say the recommender is wrong; a fixed point can be correct. It says the
+harness cannot tell. **The remedy is a spec-derived truth model** — backlog item 4's `A4` gap, priced at 20 m
+of code **+ 42 m of gate** because it rebuilds `TestApp`.
+
+**Note on scope.** Design §14 pre-registered F96 as a two-part entry — the truth-model coupling **and** "F82's
+fix has no product carrier" — to be **withdrawn in place** on `S-CARRIER-EXISTS`. The verdict was
+`S-CARRIER-EXISTS`, so **the carrier half is withdrawn and is not registered.** The coupling half is `S-a`,
+which held, and stands.
+
+---
+
+### F97 — F82's shrink-while-widening transition occurs on exactly ONE cell in the bank, and on ZERO of the fifteen that were blind
+
+**Status:** Open (measured; F82's fix choice unchanged) · found 2026-08-13, wave 29, `RULE W29-R` =
+**`R-STANDS`** · `/mnt/d/hf_w29/w29r_score.txt`
+
+Wave 26 pre-registered a reversal condition on its choice between F82's two fixes — *"if a later wave measures
+that `SearchSpan` … shrinks on more than a single cell while the requested sweep widens, then … (2) becomes
+correct."* **Three waves quoted it; none ran it.** Wave 29 ran it at zero compute over the 18 addressable
+paired S1 cells under `/mnt/d/hf_w25/after`, via the exact inversion
+`impliedSearchSpan = stepRecommendation.halfWidth / (1.5 × 0.5)`, with the multiple asserted `= 1.5` at **both**
+the B15 tree `29665a62e4f8` and `HEAD`, and with all 37 rounds confirmed capped-or-floored and none
+detect-bounded before any statistic was taken.
+
+```
+k = 18   c = 1   c_blind = 0   qualifying cells: ['D01_ultrawide_40mm']
+```
+
+**`c = 1`, and the one cell is `D01`, which was already burned.** `D05_tec140_1000mm` and
+`D19_cygnus_deep_shed` produced no report and **left the denominator** as named `CNL-NOREPORT`, never as zeros.
+
+**What this changes.** F82 is real and (per [F98's sibling finding in `RULE W29-S`](#f96)) reaches a real
+product path — but it is **rare, not general**: one cell in eighteen, zero in fifteen blind. On all 17 other
+cells the implied and requested spans move together on every transition. **Anyone pricing a fix should price it
+against 1 of 18, not against the 37-of-37 capped-or-floored population.** Wave 26's choice of fix (1) stands on
+wave 26's own grounds; the reversal condition is now **evaluated** rather than merely unexamined.
+
+**Blindness spent.** Producing this verdict required publishing the per-cell table for all 18 cells, so the 15
+formerly-blind cells' `halfWidth`/`bootstrap`/implied-span values are now read. See F100.
+
+---
+
+### F98 — `MaxDistortion` is a MINIMUM fill-ratio despite its name, and 0.9 is above the ~0.79 ceiling of a perfect disk, so a whole arm cell was dead before it ran
+
+**Status:** Open — **candidate goal-3 product finding** · found 2026-08-13, wave 29, `RULE W29-L` =
+**`L-UNEVALUATED`** · `/mnt/d/hf_w29/w29l_score.txt`, `/mnt/d/hf_w29/l/out/L{0,2,4}.log`
+
+`StarDetector.cs:1804` rejects a candidate as `TooDistorted` when `fillRatio < effectiveMaxDistortion`. The
+parameter is a **lower bound on bounding-box fill ratio**; **raising it tightens the gate.** The file's own
+comment at `:1786` states the ceiling: *"a perfect disk fills ~PI/4 ≈ 0.79."* With `DefocusAwareGates: false`
+in `D01`'s landed tree, `ComputeEffectiveMaxDistortion` returns `p.MaxDistortion` verbatim.
+
+Wave 29's design §6 pre-registered `MaxDistortion` **0.5 → 0.9** under the heading *"one knob relaxed per
+cell"*. Measured result on `D01`, 9 frames: **`TP=0 FP=0 FN=110384`, `recall@high = 0.000 (0/62 411)`** on
+both `L2` and `L4` — total detection collapse. Corroborated by wall clock: `L2` (152 s) and `L4` (145 s) were
+the two **fastest** cells in a five-cell arm, because nothing survived the gate to do downstream work.
+
+**Two findings, and they are separable.**
+
+1. **The instrument finding.** A pre-registration can specify a knob edit whose *direction* no clause reads.
+   The arm's self-test proved the edit was **surgical** (`33 of 33`, *"exactly 1 file changed"*, *"an unnamed
+   field is UNCHANGED"*) — surgical is not correctly signed. `RULE W29-L`'s verdict is
+   **`L-UNEVALUATED`** and it stands; the cell was not re-run at a corrected value and scored.
+2. **The product finding.** `OptimizerVariable.cs:176` declares the searchable axis
+   `Continuous(nameof(StarDetectorParams.MaxDistortion), 0.1, 1.0, 0.1)`. **The upper ~21 % of that axis
+   (> π/4 ≈ 0.785) is provably detection-killing for round stars** — any value above the perfect-disk fill
+   ratio rejects every candidate. A searchable range whose top fifth returns zero detections is a parameter
+   space that wastes optimizer evaluations, and the name `MaxDistortion` reads as the opposite of what it
+   gates. **Worth ~20 m to bound the axis at π/4 and rename or document the field; owes the 42 m gate because
+   it touches plugin code.**
+
+---
+
+### F99 — Relaxing the bounding-box floor on `D01` releases 9 537 candidates and three survive: the binding gates are downstream, and the pre-registered statistic could not see it
+
+**Status:** Open — the hypothesis wave 30 should pre-register · found 2026-08-13, wave 29 ·
+`/mnt/d/hf_w29/l/out/L{0,1}/attempt01/golden_eval.txt`
+
+`RULE W29-L`'s pre-registered statistic is the difference in `FN_total`. On `D01`, lowering
+`MinStarBoundingBoxSize` 6 → 3 gives `FN_total` 50 249 → 50 246, i.e. **−3**, which reads as "this gate does
+almost nothing". The per-gate blocks in the same artifact say otherwise:
+
+| gate | `L0` | `L1` (MinBox 6→3) | Δ |
+|---|---|---|---|
+| `REJECTED:TooSmall` | 11 372 | 1 835 | **−9 537** |
+| `REJECTED:TooDistorted` | 14 876 | 20 573 | **+5 697** |
+| `REJECTED:LowSensitivity` | 13 612 | 17 426 | **+3 814** |
+| others | | | +23 |
+
+**9 537 high-tier candidates were released from the bounding-box floor and 99.97 % of them were immediately
+re-caught by `TooDistorted` and `LowSensitivity`. Three reached acceptance.** The gate is not inert; its entire
+yield is absorbed one and two gates downstream.
+
+**The lesson is about the statistic, not the detector.** A first-rejection-wins attribution differenced only at
+the *total* cannot distinguish a gate that never fires from a gate whose output is fully captured downstream.
+**Wave 30's rule over sequential gates must read the per-gate flow, not the net.** And the substantive
+hypothesis this generates, stated so it can be wrong: **`D01`'s binding constraint is `TooDistorted`, jointly
+with `LowSensitivity`, and no single-knob change recovers it** — which is `L-JOINTLY-BOUND`'s claim arrived at
+by a different route than the rule that could not evaluate it.
+
+---
+
+### F100 — A blindness ledger that promises a quantity will stay unread, beside an instrument that must read it, burns the population at pre-registration time
+
+**Status:** Recorded (the burn is spent; the structural fix is cheap) · found 2026-08-13, wave 29 ·
+design §7 vs `/mnt/d/hf_w29/w29r_score.txt`
+
+Wave 29's design §7 wrote: *"the requested-vs-implied comparison has **never** been computed on any other
+cell"*, and named the 15 non-burned cells as **BLIND, and carrying `W29-R`'s verdict**. The same document's
+§5.3 pre-registered a scorer that computes exactly that comparison over all 18 addressable cells and prints
+`c` and `c_blind`. **`w29r_score.txt` publishes the full 18-row table.** The ledger's claim is now false, and
+the instrument that falsified it was commissioned by the document that made the claim.
+
+**The rule was not tuned** — `W29-R` is implemented exactly as §5.3 writes it, and its verdict was taken on the
+first computation of the statistic, which is what blindness protects. **But it is the last verdict on this
+population that can claim blindness.** Any future rule over `SearchSpan` persistence on `/mnt/d/hf_w25/after`
+has no blind cells left.
+
+**Fix, ~5 m per wave:** the design's blindness ledger must be checked against the design's own instrument
+specifications before the pre-registration commit — every quantity the ledger promises stays unread must not
+appear in any clause's per-member output. Nothing does this today.
+
+---
+
+### F101 — The derivation checker's `historical_ranges` has now failed THREE generations, each time with a passing self-test
+
+**Status:** Repaired in wave 29's checker; the pattern is the entry · found 2026-08-13, wave 29 ·
+`/mnt/d/hf_w28/verify_derivation_w28.py:579`, `/mnt/d/hf_w29/verify_derivation_w29.py:224–238`
+
+[F87](followups.md) recorded this function eating its own file; wave 27 repaired it; wave 28's design required
+the repair be carried forward and demonstrated, and wave 28's self-test clause `[6]` did demonstrate both ends
+it knew about. **It was still broken.** Wave 28 counted brackets on the **raw** line, so an unbalanced `[` or
+`{` inside a **string literal** opened a phantom block that ran to EOF. Measured on wave 28's own 599-line
+file:
+
+```
+ranges computed by WAVE 28's own function: [(93, 120), (557, 565), (579, 598)]
+  range 579 -> 598   opener: defonly = ['HISTORICAL_BLOCKS = ("PRIOR_BUILD_IDS", "ALLOW = [")',  ...
+   *** RUNS TO EOF ***
+```
+
+**29 of 599 lines of wave 28's own checker, including its tail, were exempt from `V28-B` and `V28-C` for the
+whole of wave 28.** It concealed nothing — every token in the exempt span is wave 28's own wave id — and that
+is luck, not design. Wave 29 blanks string literals length-preservingly before counting and asserts all four
+ends in clause `[6]`, including *"a token INSIDE the declared historical literal is NOT reported"*.
+
+**The durable finding is the pattern:** three generations, three passing self-tests, because each generation's
+self-test tested the ends the previous generation broke. **A self-test that only covers the last bug found is a
+regression test, not a specification.**
+
+---
+
+### F102 — `V28-C` returned zero because its population was almost empty: 124 of 126 printing lines in wave 28's scorers were never scanned
+
+**Status:** Repaired in wave 29's checker; the vacuity class is the entry · found 2026-08-13, wave 29 ·
+`/mnt/d/hf_w28/verify_derivation_w28.py:170`, `/mnt/d/hf_w29/verify_derivation_w29.py:160`
+
+`V*-C` forbids typed ordinals and counts in an instrument's printed output. Wave 28's line-selector was
+`\b(print|log|echo|printf|Prog|tee)\b`; wave 28's three scorers emit through `out.write(`, which matches none
+of it. Measured over `score_w28b.py` (36), `score_w28n.py` (52), `score_w28s.py` (38):
+
+```
+out.write( lines total : 126
+matched by w28 PRINTS  : 2      (incidentally -- the string being WRITTEN contained a keyword)
+matched by w29 PRINTS  : 126
+```
+
+**Wave 28's `V28-C: 0` was vacuous.** Wave 29 widened the selector to
+`\b(?:\w*[._])?(?:printf|print|echo|log|write|emit|say|tee|Prog)\b` and **demonstrated** the widening rather
+than asserting it — self-test `[3]` carries *"V29-C via `out.write` fired on its own mutant"* and *"V29-C via
+an underscored helper fired on its own mutant"*.
+
+**The class, which is the same as F101's and should be read with it:** a clause can pass for three waves
+because it has no candidates, and **no verdict tree in this series distinguishes "zero findings" from "zero
+candidates".** [F94](followups.md) made trees total over their *outcomes*; nothing makes a clause report its
+*population*. **~10 m to make every clause print `candidates: N   findings: M` and refuse on `N = 0` where a
+population is expected.**
+
+---
+
+### F103 — A pinned per-clause fixture goes silent exactly one wave later, as predicted in an instrument's own header and confirmed by measurement
+
+**Status:** Closed as a mechanism; standing obligation to re-measure each wave · found 2026-08-13, wave 29 ·
+`/mnt/d/hf_w29/vdrift_selftest_w29.txt` `[5b]`, `vdrift_probe_hf_w2{4,6,7,8}.txt`
+
+Wave 28 pinned `/mnt/d/hf_w27` as its live `V28-B` fixture and wrote into its own instrument's header that such
+a pin expires one wave later, because `PREV` advances and last wave's tokens stop being "previous-wave". Wave
+29 measured all four candidate roots before pinning anything:
+
+| root | `-A` resolving | `-B` findings | `-C` findings | role |
+|---|---|---|---|---|
+| `hf_w24` | 1 of 1 | 0 | **2** | durable `-C` fixture, third wave running |
+| `hf_w26` | 2 of 6 | **0** | 1 | expired at wave 28; kept and **asserted silent** |
+| `hf_w27` | 1 of 5 | **0** | 1 | **EXPIRED as predicted** — wave 28's live `-B` |
+| `hf_w28` | 0 of 5 | **100** | 1 | the new live `-B` |
+
+**This is the strongest evidence class this series has produced**, and the reason is structural: it is a
+**falsifiable forward claim about the instruments, written before the measurement, with a stated mechanism, and
+checked one wave later.** Everything else in the series is a rule scored against artifacts that already
+existed. **`hf_w28` is next to expire; wave 30 must re-measure and must treat a clause with no live fixture as
+a FAIL, not a pass.**
+
+---
+
+### AMENDMENTS TO EXISTING ENTRIES
+
+**[F82](followups.md) — AMEND IN PLACE. Its fix choice stands; its scope, its generality and its truth
+model are now measured.** Append:
+
+> **Amended 2026-08-13, wave 29.** Three things about this entry were unmeasured when it was written.
+>
+> 1. **The "truth of 9" is a PRODUCT-DERIVED FIXED POINT, not a spec-derived truth.** `terminal.stepBehavioral`
+>    is `StepSizeRecommender.Recommend` iterated to a fixed point by
+>    `SynthValidateRunner.ComputeStepBehavioral:1262` — see **F96**. `D01`'s stall is measured against a bar the
+>    recommender itself produces, and wave 25 moved both together.
+> 2. **"Confined to the recommender's caller state" names a caller, and it is
+>    `StarDetectionOptimizerWizardVM.CaptureNewSweepAsync` (`:5012`).** `RULE W29-S` clause `S-b` returned
+>    **FALSE**: of `BuildSummaryAsync`'s five callers, `CaptureNewSweepAsync` takes a **fresh sweep**
+>    (`RunLiveAttemptAsync`, `:5071`), calls `BuildSummaryAsync` at `:5098`, and carries the previous round's
+>    recommended geometry forward through the instance field `recaptureStepSize` (`:2608`, assigned `:5037`,
+>    consumed `:3236`). **F82 is a real product defect on a real product path**, and the wave-29
+>    pre-registration's claim that it "reaches no user" and "scores goal 2 zero" is **withdrawn**.
+> 3. **Its generality is one cell in eighteen.** `RULE W29-R` = `R-STANDS`: `k = 18`, `c = 1`, `c_blind = 0`.
+>    The only qualifying cell is `D01` itself. See **F97**. Wave 26's choice of fix (1) stands, on wave 26's
+>    own grounds, with the escape clause now **evaluated** rather than unexamined.
+> 4. **A third candidate fix is registered and deliberately NOT chosen** (wave 29 design §4.4): bound
+>    `maxHalfWidth` below by the span the sweep actually **requested**, guarded by
+>    `BandDemonstrablyUnsampled(sampledHfrRange)`. `RULE W29-S` clause `S-c` **HOLDS** — the requested positions
+>    are in `SweepDetectability.FrameFocuserPositions`, reachable inside `Recommend` via
+>    `MeasureMaxUsefulHalfSpan`. It needs **no cross-round state and no `A3` re-derivation**, which makes it the
+>    cheapest of the three (~45 m + a 3-cell re-run + the 42 m gate) and is precisely why the wave that thought
+>    of it did not select it. **The next wave pre-registers the choice among three.**
+
+**[F81](followups.md)** — append: the floor F81 shipped **is** reached in the product on a re-swept round, not
+only at round 0 of a session. `CaptureNewSweepAsync` (`:5012`) re-captures and carries `recaptureStepSize`
+forward, so the wizard's `Capture new sweep` path has genuine cross-round sweep state. The `Continue` and
+`Re-optimize` paths do not — they call `LoadRunStampedAsync` and re-optimize already-captured frames — so on
+those two the floor is inert after round 0, and that half of the original claim stands.
+
+**[F94](followups.md)** — append: wave 29's design §10 is the first in the series to publish its own outcome
+space as a table, and **every scorer re-derived it in code and agreed with the published counts**: `W29-S`
+**8 / 0 uncovered**, `W29-R` **4 / 0**, `W29-L` **8 / 0** — matching design §10's three tables exactly — and
+`V29`, which §10 declared as inheriting wave 28's tree without a count, re-derived **12 / 0** including the
+`A=None` empty-population region. The two logically-unreachable regions (`R-INCOHERENT`, `L-INCOHERENT`) are
+present, asserted empty, and checked against the measured numbers (`c = 1 ≤ k = 18 is True`; `L-1 ∧ L-2 =
+False`). **The remedy works for outcome coverage.** It does **not** cover two adjacent failures found this wave: a clause whose *population* is
+empty (**F102**) and a clause whose realized value is **neither `True` nor `False`** — `W29-L` ended at
+`L-0 = True, L-1 = None, L-2 = None`, a state outside the enumerated boolean cube, yet the scorer still printed
+`uncovered: 0` and appended a canned `READING:` line saying *"the control did not hold"* **when `L-0` in fact
+HELD**. The tree was total over booleans and the run was not a boolean. **Trees must enumerate `None` as a
+clause value, and a verdict's explanatory text must be derived from the clause values rather than templated per
+verdict name.**
+
+**[F95](followups.md)** — append: **the remedy's first half works and was proved this wave.** Wave 29's plan
+ordered instruments (Step 1) before the blocking pre-flight (Step 2); the last instrument was written at
+`17:01:28Z`, the pre-flight ran at `17:35:55Z` over a **populated root of 7 files**, and returned `V-CLEAN`
+with `SELFTEST V29 27 of 27`. Wave 28's equivalent certified **one file**. **The second half did not run** —
+the closing `V29` (`vdrift_w29_FINAL.txt`) has no artifact, against design §11's *"NOT cut, at any budget."*
+Both halves are needed and the series has now demonstrated one of them.
+
+**[F21](followups.md)** — append wave 29's per-step estimate vs actual (§10). Steps 1, 2, 4, 5 and 6 all landed
+**under**; the only two that overran were the two priced from instinct rather than from a measured rate
+(fingerprint sweeps, §10). Measured constant for future waves: **the six declared read-only roots are ~41.8 GB
+/ 2 452 files and hash at ~61 MB/s, i.e. ~12 m per sweep, ~24 m for a two-sided fingerprint.**
+
+**`docs/synthetic-af-bank-results-table.md`** — still owed from wave 28: the `K` column from `truthModel`
+(`max(hfrMin, hfrMinEffective)`), the note that `D01`/`D02`/`D03` are the only three floored by the generator,
+and **no 2–4 px band claim below the band** (`W28-B` = `B-SPLIT`). **Not paid this wave.** ~10 m.
+
+---
+
 ### F92 — The post-wavelet blur is WELDED to `StructureLayers`, so one knob sets two opposing scale cutoffs
 
 **Status:** **Open — source-derived, zero compute, and it re-opens [F43](#f43)** (2026-08-13, wave 28,
@@ -1479,7 +1766,38 @@ Reproduce: `StepSizeRecommender.cs` (the `BandDemonstrablyUnsampled` guard, the 
 
 ### F82 — The half-width floor is not sticky across rounds, and the cap recomputed from a shrunken fit pulls it back down
 **Status:** Open (diagnosed to a line, two candidate fixes, priced) · found 2026-08-13, wave 25, on the one
-labelled control that missed its pre-registered bar
+labelled control that missed its pre-registered bar · **SCOPE AND GENERALITY MEASURED, wave 29 — see below**
+
+> #### AMENDMENT, wave 29, 2026-08-13 — the fix choice stands; the scope and the generality are now measured
+>
+> **1. It IS a product defect, on a real product path.** Wave 29's own pre-registration argued the opposite —
+> that no caller had anywhere to put a cross-round half-width, so the fix would reach no user — and **its own
+> rule refuted it**: `RULE W29-S` = **`S-CARRIER-EXISTS`**. The design's caller table named two of
+> `BuildSummaryAsync`'s **five** callers; **`CaptureNewSweepAsync`** (`StarDetectionOptimizerWizardVM.cs:5012`)
+> takes a **fresh sweep** via `RunLiveAttemptAsync`, calls `BuildSummaryAsync` at `:5098`, and carries the
+> previous round's recommended geometry forward in `recaptureStepSize`. So `SearchSpan` **can** change between
+> wizard rounds and the defect **can** occur there.
+>
+> **2. But it is far rarer than this entry implies.** `RULE W29-R` ran wave 26's own reversal condition, which
+> three waves had quoted and none had executed: over **18 addressable paired S1 cells**, the
+> shrink-while-widening transition occurs on **`c = 1`** — and that one cell is `D01`, which is burned.
+> **`c_blind = 0` over the fifteen cells that were blind.** See [F97](#f97).
+>
+> **3. The reversal condition is NOT met, so fix (1) stands — now on evidence rather than on caution.**
+> Wave 29 deliberately did **not** flip the choice, and did not choose the third candidate it registered:
+> choosing a fix in the same wave that discovers a new reason to prefer it is the [F14](#f14) / `RULE D20`
+> fence in a new costume.
+>
+> **4. The bar this entry is scored against is produced by the code under test** — `SynthValidateRunner
+> .ComputeStepBehavioral:1262` iterates `StepSizeRecommender.Recommend` to a fixed point. That is
+> [F96](#f96), and it is why `stepBehavioral` moved 8.0 → 9.0 across wave 25's two arms while staying
+> identical on the other seventeen cells: wave 25 changed `Recommend`, so it moved the bar as well as the
+> measurement. **Any future scoring of this entry must say which side of that loop it is standing on.**
+>
+> **5. The price in the handoff (~45 m) is for the HARNESS change.** The product carrier needs new persisted
+> session state surviving between wizard sessions, with the `Continue`/`Re-optimize` paths excluded where it is
+> inert, plus migration and the question of whether it is an option (and therefore owes a control in
+> `Resources/OptionsDataTemplates.xaml`). That is a ~2–4 h band and nobody has priced it.
 
 [F81](#f81--maxhalfwidthsampledhalfspanmultiple-has-been-a-ceiling-with-no-floor-and-the-half-width-unresolved-exit-returned-before-the-ceiling-was-consulted-at-all)'s
 floor engaged on **all three** published stall cells at round 0 and handed off to the cap at round 1 exactly as

--- a/docs/followups.md
+++ b/docs/followups.md
@@ -527,6 +527,19 @@ tree would have said, and **does not repair and re-score** (`/mnt/d/hf_w28/w28n_
 
 ### F95 — A blocking pre-flight that runs before the instruments exist certifies an empty population
 
+> **NARROWED the same day, and the narrowing is the useful part.** The pre-flight was **re-run over the
+> populated root** and returns **`V-CLEAN`: 7 files checked, `V28-A` 8 of 8 siblings resolving, `V28-B` 0,
+> `V28-C` 0** (`/mnt/d/hf_w28/vdrift_w28_FINAL.txt`). **The instruments were clean all along**, so this entry
+> is not "a wave shipped unchecked instruments" — it is a **SEQUENCING** defect, and that is the durable
+> lesson:
+>
+> **A blocking pre-flight must run BEFORE the measurement and AFTER the instruments exist.** Every plan in this
+> series has said "before anything", which is a strictly larger window and admits an empty population. The
+> checker behaved correctly throughout — it refused to call an empty population 1.0000 and said so in those
+> words — so what failed was the *plan's* ordering, not the instrument. Both artifacts are kept: `vdrift_w28.txt`
+> (the empty-population run) and `vdrift_w28_FINAL.txt` (the real one).
+
+
 **Status:** **Open — remedy known, not applied this wave** (2026-08-13, wave 28) · [F80](#f80)/[F87](#f87)'s
 family, third distinct shape
 

--- a/docs/followups.md
+++ b/docs/followups.md
@@ -429,6 +429,179 @@ shape for this space.
 > three where the search **also** drove `StarClippingMultiplier` down, twice to the axis's own 0.25 floor.
 > Reproduce: `/mnt/d/hf_w26/q26_score.txt`; `docs/synthetic-af-bank-followups-wave26-results.md` §4.3, §7.
 
+### F85 — A closed, shipped correction was re-measured as an open defect, because two fields share a name
+
+**Status:** **Done** (2026-08-13, wave 27) — the disclosure gap is fixed; the register contradiction is
+corrected in place · relates to [F31](#f31), [F68](#f68) part 1, [F79](#f79), [F84](#f84)
+
+`golden eval`'s `FP` and a Python re-derivation from the golden's `stars` list alone are **both** "false
+positives": **11** and **150** on the same detections. Wave 26 read the second and compared it against the
+first, concluding the owner's precision column was a lower bound when it was already truth-corrected. The 150
+decomposes as **50** excluded by the golden's own `unresolved` boxes + **89** excluded by `TruthProtection` +
+**11** surviving genuine wing-frame junk; its `137` ("within 12 px of ANY truth star") is a **third** quantity,
+neither of the other two. **The junk count is 11, not 13** — two of the "13" sit inside an `unresolved` box.
+
+**Proximate cause:** `GoldenEvalRunner` applied `TruthProtection` and never reported that it did, while
+`BankVerifyRunner` reported it in three places. A grep of the 20 published logs, `golden_eval.txt` and
+`golden_eval_frames.csv` for `scoringMode` / `protected` / `precisionNull` returned **zero hits**.
+
+**Independent confirmation of the 89:** `score_t27_w27.py --protection off` gives `D08` FP `11 → 100`
+(`/mnt/d/hf_w27/t27_v0_failend.txt`), and **350** across the population.
+
+**Remedy, shipped:** `TestApp/SynthBank/TruthDisclosure.cs` ports all four of `bank-verify`'s disclosures into
+`golden eval` — `scoringMode` + `protectedStars`, `precisionNull`, `truthViolations`, `scoredFraction` — plus a
+fifth, `protectedDetections` (protection *exercised*). Wording is shared between the two harnesses so they
+cannot drift apart. **`RULE S27-4` proves the change is report-only at byte level: 360 of 360 detection
+artifacts byte-identical, `TP`/`FP`/`FN` unchanged on 20 of 20, and 20 of 20 report sinks changed** (so the port
+is not inert). **Open sub-item:** `S27-1`'s route agreement was not adjudicated, and `protectedDetections` is
+single-routed — see wave 27 results §7.3 and §8.6.
+
+### F86 — The golden sidecars on disk carry the PRE-REPAIR policy in their own words
+
+**Status:** **Open — a named caveat, deliberately not fixed** (2026-08-13, wave 27) · relates to [F31](#f31),
+[F85](#f85)
+
+`GoldenFromTruth.cs:744-748` writes *"a detection here should count as a false positive"* into the `Reason`
+field of every `omitted` component, and that string is sitting in **all 180 `*.golden.json` in the bank**. The
+behaviour it describes was repaired on **2026-08-03** and the string was not, because it is a diagnostic field
+nothing reads programmatically. **It is the single most likely thing that actually misled wave 26.**
+
+Wave 27 fixes the two contradicting XML doc comments (`GoldenFromTruth.cs:34-36` *"a detector reporting
+something at its location should be scored as a false positive"* vs `:76-84` *"scoring a detection there as a
+false positive would be punishing a detector for something the reference itself cannot certify either way"*) and
+**deliberately does NOT regenerate the sidecars**, for three reasons in this order:
+
+1. regenerating 180 goldens collides with **fingerprint class 2 preservation** and would invalidate every
+   precision/recall number this series has published;
+2. changing only the generator string would make future sidecars disagree with the 180 on disk — a silent
+   divergence, the same class of defect being fixed;
+3. nothing reads `Reason` programmatically.
+
+**Anyone reading a `Reason` field in a `*.golden.json` must read this entry first.** The correct policy is:
+`omitted` and `unresolved` are both *visibility* judgements, visibility bears on **recall**, and a rendered star
+is not a false positive at any SNR.
+
+### F87 — A rule that describes itself must exclude itself from its own population, or it launders its own subject
+
+**Status:** **Done** (2026-08-13, wave 27) — closed with a both-ends self-test · a **fourth** gap in
+[F80](#f80)'s checker, and a **new class**, not the `_`-word-boundary family
+
+`verify_derivation_w27.py`'s `in_historical_block()` scanned backwards for any line *containing* a
+`HISTORICAL_BLOCKS` token and treated it as opening a historical literal — **but the line that DEFINES
+`HISTORICAL_BLOCKS` contains every one of those tokens**, so from that line to EOF the `V27-B` clause was
+switched **off**.
+
+**Evidence, both ends:** before the repair the checker reported **`V-CLEAN`, 0 unlicensed tokens** on its own
+file **while printing `=== RULE V26 ===` as its banner on a wave-27 root** (`/mnt/d/hf_w27/vdrift_w27_run1.txt`);
+after the repair it reported **32 findings on itself** (`vdrift_w27_run2.txt`, the pre-repair copy is preserved
+as `verify_derivation_w27.py.bak` and contains **69** literal `V26` occurrences), and **255** on the pinned
+`/mnt/d/hf_w26` fixture (`vdrift_selftest_FINAL.txt` `[5b]`). *(A "53 tokens" figure quoted during the wave was
+a `grep -c` of lines, a third quantity, and is withdrawn; a pre-repair "204" on the `hf_w26` fixture was read but
+its artifact was not kept, so it is testimony. **Neither is load-bearing** — the run1-versus-run2 pair proves the
+defect without any count.)*
+
+**The lesson, and it generalises past this checker:** the first three F80 gaps were a *pattern* being too narrow.
+This one is a *population* silently containing the instrument, so the instrument's own definition of what to look
+for became a licence to stop looking. **Any self-describing rule must state whether its own source is in its
+population, and prove the answer with a fixture.** Closed with self-test clause `[6]`, which demonstrates that a
+real historical block is exempt, that the file after it is not, and that the definition line opens nothing. Two
+FAIL fixtures are now pinned: `hf_w24` (kept) and `hf_w26` (added, not swapped).
+
+### F88 — `git diff --name-only <tree>` omits UNTRACKED files, so a two-binary provenance diff can miss a whole new source file
+
+**Status:** **Open — remedy known and applied once** (2026-08-13, wave 27) · belongs beside [F66](#f66)
+
+Wave 27's B16 adds `TestApp/SynthBank/TruthDisclosure.cs` — the entire substance of the change — and it was
+**untracked at build time**, so `binary_provenance_w27.txt`'s tracked diff lists 3 files and omits it.
+`Q27-V1`, which intersects the change set against the `optimize` gate's reachable set to decide whether a
+42-minute gate is owed, would have computed that intersection over an incomplete population.
+
+**Remedy, applied:** take the **union** of `git diff --name-only <tree> -- '*.cs'` and `git ls-files --others
+--exclude-standard -- '*.cs'`. `q27_v1.txt` does this and reports 5 files.
+
+**Same shape as [F66](#f66):** a provenance instrument reporting confidently on a population that silently
+excludes the thing under examination. Every future two-binary provenance step must take the union.
+
+### F89 — A mutation harness that restores with `cp -p` restores the pre-mutation MTIME, and MSBuild then skips the recompile
+
+**Status:** **Open — remedy known** (2026-08-13, wave 27, controller process finding; **no artifact**)
+
+`cp -p` preserves mtime. After a mutant is restored with it, MSBuild sees a source no newer than its object and
+**skips the rebuild**, so the next run silently re-measures the mutant. In wave 27 it made a correctly-restored
+tree look broken.
+
+**Remedy:** `touch` the file after every restore; keep the sha256 check, which guards content but says nothing
+about mtime. **Recorded honestly: this finding's evidence is the controller's account, not a file.** One mutant
+(`M-S3`) was subsequently re-verified with its run record kept (`s27_2_mutant_MS3.log`, 3 red of 19); `M-S1`,
+`M-S2a` and `M-S2b` remain testimony, and this defect is the likeliest reason their records were lost.
+
+### F90 — Reuse the computation, never the banner, or the artifact lies about which rule it evaluated
+
+**Status:** **Open — remedy known, one instance annotated** (2026-08-13, wave 27) · belongs with
+[F74](#f74)'s family, not [F80](#f80)'s
+
+`score_repro_w27.py` — the `RULE R27` comparator — was reused to perform wave 27's `S27-4` byte comparison. It
+emits its own rule name **unconditionally**, so `/mnt/d/hf_w27/s27_score.txt` ends
+`>>> RULE R27 = R-DIFFERS (40 files)` while `/mnt/d/hf_w27/repro_all_score.txt` ends
+`>>> RULE R27 = R-IDENTICAL`. **For a period the record carried two contradictory verdicts for the same rule
+name**, on two different populations, and a reader grepping `RULE R27 =` would have found the contradiction with
+no way to tell which was which.
+
+**This is sharper than F80's prose drift.** F80 is about *commentary* that stops describing the instrument.
+Here the **verdict line itself** — the one line a future reader greps — was correct for the code and wrong for
+the run.
+
+**Remedy:** a reusable scorer must take its rule label as an **argument** and assert it against the manifest it
+was handed, exactly as this series already computes every ordinal rather than typing it. **Fixed for wave 27 by
+annotation, not deletion**: `s27_score.txt` now opens with a banner saying its own verdict line must not be
+quoted and naming `s27_4_score.txt` as the scored clause, with the wrong line left in place at the foot so the
+record shows what happened.
+
+### F91 — A BEFORE/AFTER control whose two sweeps are built by different expressions reports a FALSE violation
+
+**Status:** **Done** (2026-08-13, wave 27) — caught by the population assertion, corrected, both readings kept ·
+[F74](#f74)'s shape in the BEFORE/AFTER direction
+
+Wave 27's first `T27-V4` AFTER sweep returned **`T27-V4 = VIOLATED`**. **Nothing on disk had changed.** The
+AFTER expression omitted the **20 `.log` files** that the BEFORE expression had captured, so it compared 780
+paths against a BEFORE list of 800 and reported the 20 absentees as moved. A fingerprint gate is the control
+that decides whether a wave's denominators moved under it; a false `VIOLATED` there forces `T-UNEVALUATED` on a
+wave whose population was in fact untouched.
+
+**The only reason it surfaced** is the standing rule that the **population size is asserted inside the file** —
+`BEFORE 800 / AFTER 780` is arithmetic, not a judgement call. The corrected sweep reads **`BEFORE 800 AFTER 800
+compared 800 … DIFFERING: 0 → T27-V4 = PRESERVED`**.
+
+**The rule, general:** *a BEFORE/AFTER control must build both populations from the SAME expression.* Two
+expressions intended to describe one population are two populations, and every difference the control reports is
+then unattributable — in either direction. Prefer one function, called twice, with the population size asserted
+equal before any hash is compared.
+
+### Amendments owed to existing entries
+
+* **[F31](#f31)** — append `RULE T27`'s verdict: **the repair it made is SOUND on 18 of the 19 blind datasets,
+  saturated on `D18_m24_deep_shed` alone (`precisionNull` 0.2820, `A_all` 0.2372, `A_protOnly` 0.1938), with
+  `D01_ultrawide_40mm` a named near-miss at 0.2182.** F31 is **not** reopened — the verdict is neither
+  `T-SATURATED` nor `T-CHANCE-DOMINATED`, so the density guard is not triggered. Also record that F31's null was
+  demonstrated on one dataset (`D09`) and is now generalised to 20, at four offsets, and that the shipped
+  single-offset control is **under-powered on 7 of them**.
+* **[F83](#f83)** — the decision proceeds on real numbers. **Caveat 3's `+0.034` must carry a factor label**: it
+  is `+0.034` at detection binning 1 and `+0.003` at binning 2, where `D08` reads `P=0.997 FP=1` (§4.3).
+* **[F62](#f62)** — append `RULE D27` = `D-MOVED`, 6 of 6: scoring at the optimizer's own detection-binning
+  factor moves `recall@all` by up to **+0.296** (`D14`) and by **−0.012** on `D15`. The no-`BestJ`-across-factors
+  landmine now has a measured magnitude on the recall side.
+* **[F21](#f21)** — add the measured `golden eval` rate (§10) so no future wave prices a golden-eval arm off the
+  `optimize` rate.
+* **[F80](#f80)** — cross-reference [F87](#f87) as the fourth gap and the first of a new class; and add the
+  reuse-direction case from wave 27 results §7.8, where a scorer re-aimed at a new population kept the original
+  rule's verdict banner, so `s27_score.txt` claims `RULE R27 = R-DIFFERS` while `repro_all_score.txt` claims
+  `RULE R27 = R-IDENTICAL`.
+* **`docs/synthetic-af-bank-results-table.md`** — annotate `D18`'s precision cell in place as **uninformative**
+  with its three statistics; annotate `D01` with the near-miss; add the `scoredFraction` column or at minimum
+  the six low rows of §3; re-state the seven `RULE D27` rows at both factors with each labelled.
+
+---
+
 ### F84 — The at-floor sensitivity datasets: what is actually owed, and what the evidence has already killed
 
 **Status:** **OPEN — a decision, not a defect** (2026-08-13, answering the owner's question after wave 26) ·

--- a/docs/followups.md
+++ b/docs/followups.md
@@ -429,6 +429,30 @@ shape for this space.
 > three where the search **also** drove `StarClippingMultiplier` down, twice to the axis's own 0.25 floor.
 > Reproduce: `/mnt/d/hf_w26/q26_score.txt`; `docs/synthetic-af-bank-followups-wave26-results.md` §4.3, §7.
 
+### F110 — F82's entire evidence was taken with the detectability bound OFF, while the product supplies it unconditionally
+
+**Status:** **Open — source-derived, zero compute, and it can VOID F82's fix decision** (2026-08-13, found while
+deciding F82's fix) · bounds [F82](#f82) · a validity precondition, not a defect in the fix
+
+`--step-detect-bound` is **opt-in** in the harness (`TestApp/SynthValidateRunner.cs:783-793`), and `D01`'s
+published rounds carry **`maxUsefulHalfSpan: NaN`** — the bound was never applied to any cell of the evidence
+this entry rests on. **The product supplies detectability unconditionally**
+(`StarDetectionOptimizerWizardVM.cs:4073-4079`) and applies it **after** the floor.
+
+So every number in F82 — the `12.0 → 9.0` half-width, the stall at step 3, the whole diagnosis — was measured in
+a configuration the product does not run. **[F97](#f97)'s `S-CARRIER-EXISTS` established that a carrier exists;
+it did not check that the carrier's CONFIGURATION reproduces the numbers**, and those are different claims.
+
+**Consequence, and it is a live risk rather than a theoretical one:** if the detect bound already clamps
+`maxHalfWidth` below the requested-span floor on `D01` in the product's configuration, then candidate (3′) is
+inert there and the fix decision is void. That is why the decision document makes it verification clause
+**`V-0`**, a **validity gate run before any code is written**, rather than an assumption.
+
+**The general lesson, which is [F68](#f68)'s fifth part wearing new clothes:** *establishing that a product path
+exists is not establishing that the product path was measured.* A harness flag that defaults off, against a
+product that supplies the value unconditionally, is a silent divergence between the thing measured and the thing
+shipped — and nothing in this series' controls looks for one.
+
 ### F104 — `D01`'s two candidate gates release 36 660 high-tier candidates and re-capture takes 92 %: the joint is material and ADDITIVE, so F99's joint-recovery claim is refuted at a pre-registered bar
 
 **Status:** Closed — the product question is answered, and answered negatively · found 2026-08-13, wave 30,
@@ -2160,6 +2184,32 @@ Reproduce: `StepSizeRecommender.cs` (the `BandDemonstrablyUnsampled` guard, the 
 ### F82 — The half-width floor is not sticky across rounds, and the cap recomputed from a shrunken fit pulls it back down
 **Status:** Open (diagnosed to a line, two candidate fixes, priced) · found 2026-08-13, wave 25, on the one
 labelled control that missed its pre-registered bar · **SCOPE AND GENERALITY MEASURED, wave 29 — see below**
+
+> #### THE FIX CHOICE IS DECIDED, 2026-08-13 — and wave 26's pre-registered fix (1) is **REFUTED**
+>
+> Full argument: `docs/f82-fix-choice-decision.md`. **DECISION: candidate (3′), the requested-span lower bound
+> in explicit-parameter form.**
+>
+> **Fix (1) — the monotone floor — does not fix anything, and three waves quoted it as settled.**
+> `step = round(halfWidth / PointsPerSide)` with `PointsPerSide = 3.5` (`StepSizeRecommender.cs:201, :382`).
+> Fix (1) sets `D01` r1's `maxHalfWidth` to r0's floored `12.0`, and **both** the cap (`:347-350`) and the floor
+> (`:363-366`) clamp *to* `maxHalfWidth` — so `halfWidth = 12.0` either way, and `12.0 / 3.5 = 3.43 → step 3`,
+> **the same step that stalled.** It changes **zero recommended steps anywhere in the bank**. F82's own claim
+> that (1) *"fixes `D01` directly"* is false on F82's own table. Candidate (3) gives
+> `1.5 × 0.5 × 24 = 18.0 → 18.0 / 3.5 = 5.14 → step 5`, i.e. **3 → 5**.
+>
+> **Two further corrections to this entry's supporting record:**
+> * **Wave 29 §1's blast-radius inference is false on its own artifacts.** *"37 of 37 rounds capped-or-floored,
+>   so (2) moves every round of every cell"* does not follow: the fitted span **equals** the requested span on
+>   **36 of 37** rounds, so (2) and (3) are bit-inert on 36 of 37 and are indistinguishable on this bank. What
+>   separates them is a contract argument, not a measured one.
+> * **The price band for a product carrier was against the wrong carrier.** Wave 29 assumed cross-session
+>   persistence (~2–4 h, migration, an option, an XAML control). `S-CARRIER-EXISTS` found a **within-session**
+>   carrier where the state is an ordinary instance field like `recaptureStepSize` — **~1 h, no migration, no
+>   option, no XAML.**
+>
+> **What is retired:** fix (1) as this entry's remedy. **What is owed before code:** verification clause `V-0`
+> below.
 
 > #### AMENDMENT, wave 29, 2026-08-13 — the fix choice stands; the scope and the generality are now measured
 >

--- a/docs/post-merge-cleanup-prompt.md
+++ b/docs/post-merge-cleanup-prompt.md
@@ -1,0 +1,181 @@
+# Clearing the last of the synthetic-AF-bank work — a SHIP run, not a wave
+
+**Run this after PR #196 merges.** Everything you need is on disk; nothing depends on a prior conversation.
+Read this file, then `docs/synthetic-af-bank-followups-wave30-results.md` §10 (the checkable ledger), then the
+register entries this file names. Those are the authority.
+
+---
+
+## 0. WHAT THIS IS, AND WHAT IT IS NOT
+
+**The wave series is STOPPED.** Waves 27–30 closed the last product question the synthetic bank can answer with
+another arm, and wave 30 §12 recommended stopping — a judgement, not the charter's trigger, and the reasoning is
+there.
+
+**So: no wave apparatus.** No `RULE X`, no verdict trees, no per-clause populations, no derivation pre-flight,
+no BEFORE/AFTER fingerprints, no blindness ledger. Those exist to take a **verdict** from a **measurement**, and
+**not one item below has a verdict to take.** Every item is a ship or a rescore. Building the apparatus around
+them would cost more than the items and would produce the fifth consecutive wave whose findings are mostly about
+its own instruments — which is exactly what stopping was meant to end.
+
+**What you DO keep**, because it is cheap and has repeatedly paid:
+
+- **Verify a claim before acting on it.** Every item below carries a **search command**; run it first. This run's
+  predecessor lost its first hour to a backlog item that had shipped ten days earlier ([F85](followups.md)), and
+  a later wave listed a debt paid seven hours before it opened ([F106](followups.md)).
+- **Read logs, not exit codes.** Confirm a `*_START` line **and** a live `TestApp` before believing an arm runs.
+  Piping to `tail` masks the exit code.
+- **Verify the suite by COUNT out of the log, never by the tick** ([F37](followups.md)).
+- **Never `git checkout --` to undo a mutation.** Byte backup, restore in a `finally`, **`touch` after every
+  restore** or MSBuild skips the recompile and the next run silently re-measures the mutant ([F89](followups.md)).
+
+---
+
+## 1. YOUR FIRST FOUR ACTIONS
+
+```bash
+date -u +%FT%H:%M:%SZ                      # T0. State the absolute stop in your first reply.
+gh pr view 196 --json state --jq .state    # must be MERGED. If not, STOP and say so.
+git checkout develop && git pull
+dotnet.exe test "$(wslpath -w Joko.NINA.Plugins/Joko.NINA.Plugins.sln)" -c Debug --nologo
+```
+
+**The stop is `T0 + <the duration the invoking message names>`; if it names none, use 6 hours.** Compute the
+absolute time and state it. **Never copy a literal stop time out of a prompt** — a run boundary written as a
+timestamp goes stale on the shelf.
+
+**Re-establish the suite baseline from that run, by COUNT.** It was **4039** on the wave-27 branch at merge time
+(`develop @ ec06bec` was 4015 + this run's 24). **Do not assume 4039 survives the merge** — other PRs land. The
+number you measure is the baseline; every count below is relative to it.
+
+**Branch: `ghilios/af-bank-cleanup`, ONE branch and ONE PR for everything below.** The owner asked for one PR and
+was right; a previous run split the work three ways and had to consolidate. Rebase onto `develop` and
+force-push (`--force-with-lease`) at each item boundary, and re-check whether `develop` moved rather than
+waiting to be asked.
+
+---
+
+## 2. THE WORK, IN THIS ORDER — the order is load-bearing twice
+
+### Item 1 — `V-0`, the validity gate that can void item 2 (~10 m, no code)
+
+**Run this before writing any F82 code.** [F110](followups.md): `--step-detect-bound` is **opt-in** in the
+harness (`TestApp/SynthValidateRunner.cs:783-793`) and `D01`'s published rounds carry `maxUsefulHalfSpan: NaN`,
+while the **product supplies detectability unconditionally**
+(`StarDetectionOptimizerWizardVM.cs:4073-4079`) and applies it **after** the floor. **So every number in F82 was
+measured in a configuration the product does not run.**
+
+- **Check:** `grep -c 'maxUsefulHalfSpan.*NaN' /mnt/d/hf_w25/after/D01_ultrawide_40mm__S1/synth_validate_report.json`
+- **Do:** re-run `D01`/S1 **with** `--step-detect-bound`, on `/mnt/d/hf_w25/exe` (B15 — no build).
+- **The question:** does the detect bound already clamp `maxHalfWidth` **below** the requested-span floor?
+- **If YES, item 2 is VOID.** Say so, record it, and skip to item 3. That is a real outcome, not a failure.
+- **If NO,** item 2 proceeds and you have its precondition in writing.
+
+### Item 2 — implement F82's decided fix, candidate (3′) (2 h 25 m – 3 h 10 m incl. the gate)
+
+`docs/f82-fix-choice-decision.md` is the decision and the argument. **Do not re-litigate the choice**; it was
+made with `W29-S`/`W29-R` in hand and it retired wave 26's fix (1) as **refuted** — at `D01`'s own numbers
+fix (1) gives `12.0 / 3.5 → step 3`, the step that stalled, changing **zero** recommended steps anywhere.
+
+- **Check it is still owed:** `grep -n 'PointsPerSide' Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/StepSizeRecommender.cs`
+- **The verification is pre-registered in §7 of the decision document. Use it; do not invent one.** In
+  particular: **a fix must not be scored on the cells that motivated it** — `D01`/`D02`/`D03` are burned. The
+  legitimate bar is `V-2`: the 15 non-burned cells' 36 rounds **36 of 36 bit-identical**, and `stepBehavioral`
+  **18 of 18** identical across arms.
+- **`V-1` has a predicted answer, computed before any code exists:** `halfWidth == 18.0`, step **3 → 5**. A
+  rule with a predicted answer is one that can be wrong, which is the only kind worth running.
+- **The 42 m gate is CERTAINLY owed** — `Q27-V1`'s FAIL end was *run* against a diff whose two files are
+  exactly this fix's (`/mnt/d/hf_w27/q27_v1.txt`). Predicted `G-PASS`, 8 of 8 bit-identical. Score with
+  `python3 /mnt/d/hf_w12/score_w12.py <root>/gate --rule G<N>`.
+
+### Item 3 — the `ACCEPTED-elsewhere` residual (~15 m, no code)
+
+**This gates the bottom half of item 4, so it comes first.** Wave 30 measured that **23–25 % of the distortion
+gate's acceptances were `ACCEPTED-elsewhere`** — accepted, but matched to a *different* golden star than the one
+they were released from. That is not a false positive (precision is **1.000, FP = 0** at `MaxDistortion` 0.5 /
+0.3 / 0.2 — see `/mnt/d/hf_w30/row7_precision_rescore.txt`), but it means the release→acceptance attribution is
+fuzzier than a clean mapping, and **nobody has resolved it.**
+
+- **Check:** `grep -n 'ACCEPTED-elsewhere' /mnt/d/hf_w30/g/out/M{1,3,4}/attempt01/golden_eval.txt`
+- **The question:** are those acceptances real stars matched to a neighbour (harmless, a matching artifact), or
+  the detector merging/mis-centring under a relaxed distortion gate (not harmless)?
+- The per-star detail is already on disk in `false_negatives_f<focuser>.csv` and `detected_f<focuser>.csv`.
+  **Zero TestApp minutes if you use them.**
+
+### Item 4 — bound and rename the `MaxDistortion` axis (~20 m + 42 m gate)
+
+[F98](followups.md): it is a **MINIMUM fill ratio despite its name** — `StarDetector.cs:1804` rejects when
+`fillRatio < effectiveMaxDistortion`, and a perfect disk's ceiling is ~π/4 ≈ 0.79. **So the top ~21 % of a
+searchable axis (`OptimizerVariable.cs`, range 0.1–1.0) returns zero detections for round stars**, and wave 29
+demonstrated the collapse by "relaxing" it to 0.9 and killing two arm cells before they ran.
+
+- **Check:** `grep -n 'fillRatio' Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/StarDetector.cs`
+- **Top bound: supported now.** Bound the axis at ~π/4 and rename it so the name states the direction.
+- **Bottom of the axis: only after item 3 resolves.** Do not touch it before.
+- **Renaming a persisted knob is a migration.** If it is user-visible it owes a control in
+  `Resources/OptionsDataTemplates.xaml` per `CLAUDE.md` — check, and say which applies.
+
+### Item 5 — the `A4` truth-model gap (20 m + 42 m gate) — only if items 1–4 leave room
+
+The harness computes the cap boundary from the **requested** sweep and the product from the **fitted** span;
+they disagree on `D01` r1 by 2×, and `A4` compares against `WasCapped` alone so it now flags floored rounds.
+**Fix the assertion, not the product**, and keep it out of any commit carrying a product change.
+[F96](followups.md) makes it more urgent, not less: `stepBehavioral` is `StepSizeRecommender.Recommend`
+iterated to a **fixed point**, so the harness scores the recommender against a fixed point of itself.
+
+---
+
+## 3. EXPLICITLY NOT IN SCOPE
+
+- **Rendering datasets at 1.4–19.4 ″/px** (≥ 1 h). It is the **only** route to a blind wide-field dataset and
+  has been open twelve waves — but it is new data, not cleanup, and it deserves its own decision from the owner.
+- **Anything on the `Sensitivity` axis.** [F84](followups.md) killed floors there — the search drives
+  `StarClippingMultiplier` down alongside it ([F6](followups.md)), and [F23](followups.md) measured a hard floor
+  as worse than doing nothing.
+- **A `NoiseClippingMultiplier` default change.** [F93](followups.md) says plainly that `N-RECOVERS` does not
+  license it: the optimizer *chose* the landed values under an objective that charges nothing for a missed
+  detection ([F83](followups.md)). It owes its own decision and a fresh baseline.
+- **The four withdrawn ledger rows** (wave 30 §10 rows 3–6). They were withdrawn **with reasons** after being
+  carried between two and four waves. **Do not re-list them.** One of them — wave 29's BEFORE fingerprint — is
+  unrecoverable by construction: a BEFORE taken now is an AFTER.
+
+---
+
+## 4. HARD CONSTRAINTS
+
+- **Never push `develop`.** Commit with the privacy email as **author and committer**:
+  `GIT_COMMITTER_NAME="George Hilios" GIT_COMMITTER_EMAIL="322725+ghilios@users.noreply.github.com"` and
+  `--author="George Hilios <322725+ghilios@users.noreply.github.com>"`.
+- **Every new test must be shown RED against a named mutant**, and you must *show* the red output, not assert
+  it. Byte backup, `finally` restore, **`touch` after restore**, sha256-verify, abort on damage.
+- **One `TestApp.exe` at a time; one `dotnet test` at a time.** Kill stragglers first.
+- **`dotnet test <sln>` does NOT build `TestApp`** — build it separately or a compile break never surfaces.
+- **Hash the dlls, never the apphost** — `TestApp.exe` is byte-identical across seven distinct binaries
+  ([F66](followups.md)). **`git diff --name-only <tree>` omits UNTRACKED files** — union it with
+  `git ls-files --others --exclude-standard` ([F88](followups.md)).
+- **Pass scorers WSL paths** (`/mnt/d/...`); a Windows path yields UNEVALUATED and looks like a failed arm.
+- **The gate is owed by anything touching plugin code.** Decide it the way `Q27-V1` does — intersect the C#
+  diff (unioned with untracked) against the reachable set, **reading the BEFORE binary's tree hash out of its
+  own provenance file**, never assuming the previous HEAD. Empty intersection ⇒ discharged, and **demonstrate
+  the FAIL end** on a diff known to reach it.
+
+---
+
+## 5. STOP CONDITIONS, AND THE HONEST ENDING
+
+**Stop at the computed time.** Do not start an item after it; finish what is in flight, push, summarise.
+
+**Stop EARLY and say so if** item 1 voids item 2 and items 3–5 are done, or if the gate fails and cannot be
+explained. **"Everything left is done, and the rest is out of scope" is the expected ending, not a failure.**
+
+**This run should END the synthetic-AF-bank thread.** When it closes, the honest position is: the bank is
+measured out, the remaining product questions need **new data**, and the next decision is the owner's — render
+the 1.4–19.4 ″/px datasets, or stop.
+
+---
+
+## 6. REPORTING
+
+Report what you **ran**, what it **returned**, and what you **changed** — with the suite verified by COUNT and
+the CI conclusion read out of the log. **Correct your own errors in the record, in place, where the owner can
+see them.** The previous run did this six times and the record is better for it.

--- a/docs/synthetic-af-bank-followups-w26-pd08-followon.md
+++ b/docs/synthetic-af-bank-followups-w26-pd08-followon.md
@@ -1,5 +1,23 @@
 # P-D08 from n = 1 to n = 3 — the prediction, fixed BEFORE the data
 
+> ## ANNOTATION, wave 27, 2026-08-13 — read this first; the document below is left as written
+>
+> **This document's `91.3 % reference omission` conclusion measures a PRE-REPAIR quantity.** Its re-score
+> derived false positives from each golden's `stars` list **alone**, consulting neither the golden's own
+> `unresolved` boxes nor `TruthProtection` — which had shipped on **2026-08-03** (`aaf26e8`) and was live in the
+> very binary being used. Of the 150 it counted, **139 had already been excluded** by the run that produced the
+> owner's table (**50** by `unresolved`, **89** truth-protected), and `golden eval` reported **`FP = 11`**.
+> Its `137` is a third quantity again — "within 12 px of ANY truth star". **Three different populations, all
+> called "false positives"** ([F68](followups.md) part 1).
+>
+> **The document's own per-frame table is correct and remains valuable** — it is what later showed the wing-frame
+> false positives to be **0 real**, discharging [F83](followups.md)'s caveat 3 in the entry's favour. What is
+> wrong is only the reading placed on the totals, and the conclusion drawn from it that a truth re-score was
+> still owed. It was not; it had shipped ten days earlier.
+>
+> Full account: `docs/wave27-register-correction-survey.md` and
+> `docs/synthetic-af-bank-followups-wave27-design.md` §0.
+
 **Written and committed before the two cells are scored.** This is a follow-on to wave 26, not a wave: no
 binary is built, no gate is run, and it costs two `golden eval` cells.
 

--- a/docs/synthetic-af-bank-followups-wave26-results.md
+++ b/docs/synthetic-af-bank-followups-wave26-results.md
@@ -482,6 +482,15 @@ it. Three specific reasons to hold it there:
    stars the golden omits, rather than junk.** Distinguishing the two requires re-scoring against each frame's
    own `*.truth.json` — F31's own method — **which this wave did not run**.
 
+   > **ANNOTATION, wave 27, 2026-08-13 — this caveat is DISCHARGED, in this wave's favour. The historical text
+   > above is left exactly as written.** The distinguishing measurement did not need running: **[F31](followups.md)'s
+   > repair had already shipped on 2026-08-03** (`aaf26e8`), and B15 — the binary this wave used — carries it.
+   > These 11 false positives are the ones that **survived `TruthProtection.ExcludeProtected`**, so by
+   > construction **none has an `omitted`/`merged-into` truth star within the 12 px radius**. Wave 26's own
+   > follow-on table then confirmed it directly: **0 real** on both wing frames against "ALL REAL" on the seven
+   > interior frames. **The 11 are genuine junk and the `+0.034` is real.** The caveat as written was correct
+   > about the mechanism and wrong that the measurement was outstanding.
+
 **What survives all three caveats, and is not subject to any of them:** the FN attribution. `REJECTED:LowSensitivity`
 is the *detector's own* count of candidates the sensitivity gate rejected, independent of the golden's
 completeness, and it goes None → **55 / 28 / 16 / 37**. The gate at 10 demonstrably rejects, at the landing it

--- a/docs/synthetic-af-bank-followups-wave27-design.md
+++ b/docs/synthetic-af-bank-followups-wave27-design.md
@@ -1,0 +1,911 @@
+# Wave 27 — pre-registration: is the truth correction SOUND, and why is it INVISIBLE?
+
+**Vessel decision.** PR #195 MERGED; wave 27 opens `ghilios/synthetic-af-bank-followups-wave27` fresh off
+`develop @ e19a779`.
+
+**Status:** pre-registration. Every rule, threshold, population, bar and validity gate below is fixed BEFORE any
+of the wave's own statistics are read. Written by the pre-registration agent; the controller executes.
+
+---
+
+## 0. THE HEADLINE, AND IT IS A CORRECTION TO THE BACKLOG
+
+**Backlog item 1 — *"Re-measure precision against `*.truth.json`, not `*.golden.json`, across the bank"* — is
+DONE. It shipped on 2026-08-03, ten days before it was written into the backlog as the top item.** Wave 27 does
+not do it. What wave 27 does instead is measure whether the shipped correction is **sound**, fix the fact that it
+is **invisible**, and correct three documents that describe it as open.
+
+The proof is short and every step is on disk:
+
+1. **`Joko.NINA.Plugins/TestApp/SynthBank/TruthProtection.cs`** exists at `develop @ e19a779`, added by `aaf26e8`
+   (2026-08-03 14:56 −0400), *"fix(bank-verify): stop charging false positives for real stars the golden dropped
+   (F31)"*, refined by `867d41c` and `5c382a1`.
+2. It is wired into **both** harnesses: `GoldenEvalRunner.cs:301-307` and `BankVerifyRunner.cs:465,483`.
+   `golden eval` is the instrument that produced the owner's results table.
+3. It was **active in the published run**. `/mnt/d/hf_w25/table18/D08_c11_2800mm.log` reads
+   `OVERALL: TP=308 FP=11 FN=7 precision=0.966 recall=0.978`. The owner's table's own `D08` row (`prec 0.966`,
+   `recall@all 0.978`) is arithmetically `308/(308+11) = 0.9655` and `308/315 = 0.9778`. Unprotected, the same
+   detections give `308/(308+150) = 0.673`. **The published 0.966 requires FP = 11, which requires protection.**
+4. **[F31](followups.md) is `Done`, closed 2026-08-03**, and its own entry already records the direct-truth
+   comparison the backlog asks for: *"Next-step (1) — score directly against truth — was measured and found to
+   agree with the repaired golden+protection scoring to within 0.006, so it was not worth a second scoring
+   path."*
+
+### 0.1 What the 91.3 % number actually measured
+
+`/mnt/d/hf_w26/pd08/F31_truth_rescore.txt` re-derived false positives **from the golden's `stars` list alone**,
+ignoring both `GoldenMatch.ExcludeUnresolved` and `TruthProtection`, and got **150**. `golden eval`'s actual `FP`
+field on the *same detections* is **11**. So wave 26 measured the **pre-repair** metric and compared it against
+the **post-repair** published number.
+
+**The full decomposition of the 150** — and it resolves into *three* quantities, not two:
+
+| | count | what it is |
+|---|---|---|
+| golden-`stars`-false | **150** | wave 26's number: the pre-repair `/3` metric |
+| − excluded by the golden's own `unresolved` boxes | **50** | `GoldenMatch.ExcludeUnresolved`, shipped long before F31 |
+| − excluded by `TruthProtection` (`omitted` / `merged-into`) | **89** | F31's repair |
+| **= `golden eval`'s published `FP`** | **11** | the genuine wing-frame junk |
+| *(separately)* within 12 px of **ANY** truth star | **137** | a **third** quantity, neither of the other two |
+
+**Correction, in place: the junk count is 11, not 13.** Two of the "13" sit inside a golden `unresolved` box, and
+`golden eval`'s `FP = 11` is the correct figure. Wherever this series has asserted 13 — including
+`docs/synthetic-af-bank-results-table.md`'s *"13 genuine junk detections"* — it is wrong by two.
+
+**And the correction STRENGTHENS [F83](followups.md)'s caveat 3 rather than weakening it:** none of the 11 has a
+truth star within 12 px, so they are genuine junk and `D08`'s `+0.034` precision cost is **real**.
+
+This is **[F68](followups.md) part 1 in its purest form — three different fields, all called "false positive"** —
+and it is **[F79](followups.md)'s shape again**: the same wrong reading reachable by more than one route, where
+only a scorer-versus-product comparison separates them. It is registered as such in §9.
+
+### 0.2 The owner's deliverable carries a false banner
+
+`docs/synthetic-af-bank-results-table.md` §"READ THE PRECISION COLUMN AS A LOWER BOUND" says D08's *"true
+precision is nearer 0.997 than the 0.966"* and that *"every 1.000 in the column is a floor rather than a
+ceiling."* **All of that is wrong.** The column is already truth-corrected; `0.966` is D08's honest precision;
+and its 11 surviving false positives are the genuine wing-frame junk the same document correctly identifies two
+paragraphs later. Correcting it is §8, and it is owed unconditionally.
+
+---
+
+## 1. THE QUESTION WAVE 27 ACTUALLY ASKS
+
+> **The correction is applied. Is it SOUND — or has it replaced a biased metric with a SATURATED one?**
+
+`TruthProtection` grants immunity from false-positive scoring to any detection landing within the match radius
+(12.0 px) of an `omitted` or `merged-into` truth star. Some of that immunity is **correspondence** and some of it
+is **chance**, and the denser the field the more of it is chance.
+
+This is not a hypothetical failure mode. **`TruthProtection.cs`'s own class doc records having already hit it
+once**: the first cut sized protection by the star's light footprint (`2·HFR`, ~40 px on a wing donut) and
+
+> *"saturated the metric: precision read 1.000 on all 17 datasets for all three F23 arms, because a 40 px box
+> around every faint truth star launders genuine noise blobs too. A metric that cannot separate configurations
+> is as useless as one that is biased, just in the other direction."*
+
+The match-radius box was chosen to fix that. **Nobody has ever checked whether it succeeded on the dense
+datasets** — and the dense datasets are extraordinarily dense (§4.2). Across `table18`, **FP = 0 on 19 of 20
+datasets**, the sole exception being `D08` at 11. A metric reading a perfect score almost everywhere is exactly
+the symptom the class doc warns about.
+
+### 1.1 Consequences, both directions, stated before the data
+
+| if protection is… | then |
+|---|---|
+| **SOUND** | the precision column is honest as published; `D08`'s `0.966` stands; the banner comes off with no replacement caveat; **[F83](followups.md)'s decision proceeds on real numbers** |
+| **SATURATED** | the precision column is an **UPPER** bound on the dense fields — *the opposite error from the one the banner claims* — every `1.000` there is uninformative rather than excellent; and **F83's "`J` has no precision term" becomes largely moot on this bank, because there would be no precision signal to put in `J`** |
+
+Both are results the owner needs. Neither is the answer the wave is hoping for.
+
+---
+
+## 2. WHERE THE CONTROLLER'S FRAMING IS WRONG
+
+The controller's first two messages framed the wave as a truth re-score with a peak-vs-integrated-SNR
+discriminator. The controller has since self-corrected most of this. What follows is the full accounting,
+including the parts still standing that this design rejects.
+
+### 2.1 The rival-causes framing (a)/(b)/(c) was the wrong shape, and the right shape was already in source
+
+The brief asked for a rule distinguishing **(a) OMISSION** (the reference is an incomplete list) from
+**(b) MIS-SPECIFICATION** (the reference's *statistic* is wrong for defocused sources) from **(c) COINCIDENCE**.
+
+**(a) and (b) are not rival causes. They are the same fact at two levels of description**, and the golden's own
+source says so. The golden is not a hand-made list; it is derived from truth by a declared policy, and the
+policy's `omitted` bucket at `GoldenFromTruth.cs:744-748` carries the literal reason *"a detection here should
+count as a false positive"*. The reference is incomplete **because** the policy's threshold dropped those stars.
+Asking which of the two caused the 91.3 % is asking whether water is wet or H₂O.
+
+**The genuinely diagnostic question is a fourth one the brief did not name, and it is decidable from source at
+zero compute:**
+
+> **(d) MIS-ASSIGNED SIDE.** `GoldenFromTruth.cs` contains two doc comments that contradict each other.
+> `SyntheticTier.Unresolved` is *"neither a required find nor a false positive"*; `SyntheticTier.Omitted` is *"a
+> detector reporting something at its location should be scored as a false positive"*. Both describe stars the
+> policy judged too faint to demand. **There is no principled reason a star at peak SNR 3.4 is a false positive
+> while one at 3.6 is neither.** `unresolvedSnr` is a *visibility* threshold, and visibility bears on **recall**,
+> not on falsity. A rendered star is not a false positive at any SNR. The defect was a **recall-side floor wired
+> into the precision side**.
+
+That is exactly what `TruthProtection` fixed, and the fix is one concept, not a new statistic. **So no new
+detectability boundary is needed for precision, and introducing one would re-import the very arbitrary threshold
+that caused the defect.**
+
+### 2.2 The integrated-SNR discriminator is rejected, and the project already measured why
+
+The proposed discriminator — detected-but-omitted stars separating from undetected-omitted stars on an
+integrated-SNR axis while overlapping on peak SNR — is **rejected on three independent grounds**:
+
+1. **It is algebraically degenerate within a frame.** For a source of total flux `F` and binned peak fraction
+   `p`, the golden's own statistic is `SNR_peak = F·p/σ` and the uniform-aperture matched filter is
+   `SNR_int = F·√p/σ = SNR_peak/√p`. Within one frame the defocus — and therefore `p` — is near-constant, so
+   `SNR_int` is a **monotone transform** of `SNR_peak` and every rank statistic (AUC included) is *identical* by
+   construction. Any separation the discriminator found would come from pooling across frames, i.e. it would be
+   measuring *which frame*, not *which star*.
+2. **The project has already measured it and it does not work.** `docs/golden-tier-plausibility-design.md` §2 is
+   titled *"What was ruled out: integrated SNR"* and concludes: *"A 3 px spike at 12σ peak has integrated
+   significance ≈ 12·√3 ≈ 20. A 36 px donut spread at 0.25σ/px has ≈ 8. Integrated SNR is the statistically
+   correct ranking and it still puts the spike on top… **No purely significance-based statistic can fix this.**"*
+   That design **supersedes** F16's proposal by name. Re-running it would be re-treading a fenced result.
+3. **At extreme defocus it over-claims catastrophically.** On `D08` frame 00, `TruthIndex 0` has
+   `FluxElectrons = 28192`, `KernelPeakFraction = 0.000716`, `PeakSnr = 11.58`. Inverting the policy's own
+   arithmetic gives `σ_bg = 1.742 e⁻`, hence `SNR_int = 11.58/√0.000716 = 433`. A 3.5σ cut on `SNR_int` would
+   declare essentially **all 126** stars on that frame "detectable by physics" — on a frame where the detector
+   found **10 and 4 of them were junk**. It fails exactly as badly in the opposite direction from the statistic
+   it was meant to correct.
+
+### 2.3 The donut mechanism is REFUTED on the one dataset that has been read, and the controller's own table refutes it
+
+The controller's second message already conceded this; the design records the refutation because it constrains
+wave 28. `/mnt/d/hf_w26/pd08/F31_truth_rescore.txt` shows the golden-false-but-real detections **peak at best
+focus** (38 of 38 at `f14000`, where `KernelPeakFraction` is at its *maximum* and the donut argument is at its
+weakest), while the **junk is 11 of 11 on the two extreme wing frames (3 at `f13672`, 8 at `f14328`) and zero on
+the seven interior frames** — the corrected count of §0.1, and the split is `golden eval`'s own per-frame `FP`
+column.
+
+A defocus-donut mechanism predicts the real-but-omitted share should *rise* toward the wings. It goes to
+**zero**. The donut argument cuts both ways — at extreme defocus the golden under-lists *and* the detector
+under-finds, and what is left over is junk. **The dominant mechanism is the peak-vs-integrating statistic at all
+defocus, not defocus itself**, and §2.1 shows that too is downstream of the mis-assigned side.
+
+### 2.4 The chance-coincidence prior does not generalise from D08, and this is the wave's whole point
+
+Wave 26 priced coincidence at **0.30 expected on D08** and called it "nearly dead". `D08` carries **126** truth
+stars on a 6248×4176 frame — **4.8 stars per megapixel**, the second-sparsest dataset in the bank.
+`D18_m24_deep_shed` carries **27 219** on the same frame geometry: **1 043 per megapixel, a factor of 217**.
+Generalising a coincidence rate from `D08` to the bank is the single most dangerous inference available here, and
+the brief's framing invited it. §4.2 makes the density spread a first-class part of the satisfiability analysis.
+
+### 2.5 The recall half is NOT wave 27's, and the reason is in source, not in scheduling
+
+The brief asked whether wave 27 should also re-denominate recall. **No — and not merely for budget.**
+`TruthProtection.cs` states its scope explicitly: *"Recall is deliberately untouched … a protected star is not
+promoted to a required find."* Recall's denominator is the golden's `stars` list at tier ≥ high, which is
+untouched by anything in this wave. **Backlog item 8 (wide-field recall, `recall@high` 0.183 on the 40 mm rig) is
+therefore fully open and completely unaffected by wave 27's verdict, in either direction.** Pulling it in would
+add a second, independent question to a wave whose first question has a reachable FAIL end — and would require
+choosing new tier boundaries *with the data in hand*, which is precisely what the [F14](followups.md) fence
+forbids. **Priced in §10; assigned to wave 28.**
+
+### 2.6 Item (D) — re-scoring 7 datasets at `--detection-binning 2` — is IN wave 27, on a measured price
+
+The controller first ranked (D) into wave 28, then withdrew that ranking after measuring the rate. **I agree with
+the withdrawal, and I would have argued for it anyway on the second ground below.**
+
+* **The price collapsed by an order of magnitude.** `golden eval` is **6 s** (`D06`) to **12 s** (`D08`) per
+  9-frame cell on B15 — against the charter's nearest rate, `optimize --per-run --max-evals 250` at ~5.2 m/run,
+  **~30× more**. Seven cells is **~2 minutes**, not "a small arm". §10 adds the measured rate as a labelled row,
+  because the charter's §5 budget table has **no `golden eval` row at all** and the next wave would otherwise
+  price a golden-eval arm off the `optimize` rate — [F21](followups.md)'s recorded error, in the other direction.
+* **`git diff --name-only 29665a62..HEAD -- '*.cs'` is 0 lines** (`/mnt/d/hf_w27/prov_b15_to_head_cs.txt`):
+  B15's tree and HEAD are **C#-identical**. So a factor-2 re-score on B15 is **fully comparable with `table18` at
+  zero build cost**, which removes the "different instrument" objection I would otherwise have raised — the only
+  thing that changes is the one flag under examination.
+
+**What survives of my original objection, and it becomes a design constraint rather than a deferral:** (D) *is*
+a different instrument from (B)'s population, so **(D) is scored separately, as `RULE D27`, and never folded into
+`RULE T27`.** (B) reads `table18` and only `table18`. §5.7.
+
+---
+
+## 3. WHAT WAVE 27 SHIPS AND MEASURES
+
+| half | what | binary? | gate reach | price |
+|---|---|---|---|---|
+| **(A) VISIBILITY** | `golden eval` emits `scoringMode`, `protectedStars`, `scoredFraction` — mirroring `bank-verify`, which already reports them | **yes, a build** | **NO** — see §6.4 | ~75 m |
+| **(B) SOUNDNESS** | `RULE T27` — is the correction sound or saturated, across 20 datasets, 180 frames | **no** — pure Python on artifacts on disk | n/a | ~95 m |
+| **(C) THE RECORD** | three documents corrected in place | no | n/a | ~20 m |
+| **(D) THE BINNING ROW** | `RULE D27` — re-score the 7 `derived=2, scored=1` datasets at their own factor on B15 | **no** — B15 is on disk and C#-identical to HEAD | n/a | ~25 m (2 m of it compute) |
+
+**If the wave overruns, (A) is cut first.** (B) carries the finding, (C) is owed unconditionally and nearly free,
+(D) is now the cheapest compute in the wave at ~2 minutes, and (A) is a reporting improvement that will still be
+true next wave — and is the only item needing a build. Stated here so the decision is pre-registered rather than
+made under time pressure.
+
+---
+
+## 4. RULE T27 — the soundness rule
+
+### 4.1 Statistics, all three fixed here
+
+Per dataset `d`, pooled over its 9 frames.
+
+Let, per frame `f`:
+
+* `D(f)` = the detections — the rows of `detected_f<F>.csv`, read as the **`cx,cy` centroid columns**, not the
+  `x,y` bounding-box origin ([F68](followups.md) part 5; `GoldenMatch` centre-mode tests the detection's centre
+  against the golden rect, so `cx,cy` is the live copy).
+* `TP(f)` = detections paired to a golden `stars` rect by `GoldenMatch.Match` in centre mode.
+* `U(f)` = detections removed by `GoldenMatch.ExcludeUnresolved` against the golden's `unresolved` rects, using
+  the product's **`Covers`** predicate (centre-in-box **OR** IoU(rect, detection bbox) > 0 — the dilated one;
+  F31 records this asymmetry as *"small (≤0.011), systematic, one-directional"* and the product deliberately
+  keeps it for `unresolved`).
+* `R(f)` = the **at-risk pool** = `D(f)` minus `TP(f)` minus `U(f)`. These are the detections that would be false
+  positives if protection did not exist.
+* `P(f)` = the members of `R(f)` protected by `TruthProtection` — within **12.0 px** (Euclidean, centroid
+  predicate) of a truth entry whose `Tier ∈ {omitted, merged-into}`, positioned at
+  **`BinnedCenterX`/`BinnedCenterY`** (never `Star.CxPixels`/`CyPixels` — §5.1).
+* `FP(f)` = `R(f)` minus `P(f)`.
+
+| # | statistic | definition | why |
+|---|---|---|---|
+| **S1** | `A_all(d)` | mean over the 9 frames of the fraction of frame area covered by the **union** of (golden `stars` rects ∪ golden `unresolved` rects ∪ 12 px discs about the protection catalogue) | the probability that a **uniformly random** detection cannot be scored a false positive. Analytic, **needs no null**. This is the saturation statistic |
+| **S2** | `precisionNull(d)` | precision recomputed with the **detections** wraparound-translated by `TruthProtection.ShiftForNullControl` and the reference left in place | **the product's own shipped null**, already reported on all 51 `bank-verify` config rows under a `precisionNullMax` gate. F31's measured sound range is **0.000–0.012** |
+| **S3** | `chanceProtected(d)` | `Σ_f \|P_null(f)\| ÷ Σ_f \|R_null(f)\|` under the same translation — the fraction of the shifted at-risk pool the **unshifted** catalogue still protects | how much of the correction survives when correspondence is destroyed — i.e. how much of it is coincidence |
+
+**Reported alongside, not thresholded:** `A_golden(d)` and `A_protOnly(d)` (S1's decomposition, so the reader
+can see whether coverage is the reference doing its job or the correction over-reaching); `scoredFraction(d) =
+Σ(|TP| + |FP|) ÷ Σ|D|` (the size of the invisible correction — half (A)'s motivation, measured); `precision_prot`
+and `precision_unprot` (the published bracket); and the chance-corrected point estimate
+`precision_corr = Σ|TP| ÷ (Σ|TP| + Σ|FP| + chanceProtected·Σ|P|)`.
+
+**S3 is the statistic the brief's `excess` form would have got wrong, and catching it is why this section exists.**
+The natural-looking statistic *"what fraction of granted protections survive the null"*,
+`(p_obs − p_null)/(1 − p_null)`, is **degenerate on this population**: FP = 0 on 19 of 20 datasets, so
+`p_obs = |P|/|R| = 1` on 19 of 20, and the expression collapses to `(1 − p_null)/(1 − p_null) ≡ 1` **whatever the
+data say**. It is an unsatisfiable clause and it would have passed silently. S3 avoids it by asking the question
+of the pool rather than of the granted set.
+
+### 4.2 Bars, and why each is reachable at BOTH ends
+
+All three bars are **0.25**, deliberately: one number, one meaning — *"a decorrelated or random object scores a
+quarter as well as the real one."*
+
+| bar | fires when | inherited from |
+|---|---|---|
+| **SATURATED-BY-AREA(d)** | `A_all(d) ≥ 0.25` | — (analytic) |
+| **SATURATED-BY-NULL(d)** | `precisionNull(d) ≥ 0.25` | **F31's published sound range 0.000–0.012** — the bar is >20× the demonstrated sound regime and is **not fitted to anything in this wave** |
+| **CHANCE-DOMINATED(d)** | `chanceProtected(d) ≥ 0.25` | — |
+
+**Reachability, from reference characterisation only (truth counts and frame geometry; none of S1/S2/S3 has been
+read):**
+
+| dataset | truth stars, frame 00 | frame (binned px) | stars / Mpx | 12 px discs alone would cover ≤ |
+|---|---|---|---|---|
+| `D18_m24_deep_shed` | **27 219** | 6248×4176 | **1 043** | **0.47** |
+| `D01_ultrawide_40mm` | **19 267** | 6248×4176 | 738 | **0.33** |
+| `D04_esprit_550mm` | 7 525 | 6248×4176 | 288 | 0.13 |
+| `D19_cygnus_deep_shed` | 4 961 | 9576×6388 | 81 | 0.04 |
+| `D02_rich_135mm` | 3 604 | 6248×4176 | 138 | 0.06 |
+| … | … | … | … | … |
+| `D08_c11_2800mm` | 126 | 6248×4176 | 4.8 | 0.002 |
+| `D10_rc16_3250mm_sparse` | **26** | 3008×3008 | **2.9** | **0.001** |
+
+* **The FAIL end (SATURATED) is reachable.** `D18`'s protection discs alone reach 0.47 of the frame before a
+  single golden `stars` rect is added, and `D01` carries **~12 265 golden `stars` boxes per frame**
+  (110 384 across 9 frames, from its own `table18` log's `TP + FN`) whose half-widths grow with defocus.
+* **The PASS end (SOUND) is reachable.** `D10` has 26 truth stars over 9.05 Mpx; its coverage cannot exceed
+  ~0.001 by arithmetic, so it **cannot** fire any bar. Fifteen of the twenty datasets sit below 100 stars/Mpx.
+* **Neither branch is foreclosed by the population.** The bank spans a factor of **360** in areal density
+  (`D10` 2.9 → `D18` 1 043 stars/Mpx), which is why a per-dataset verdict is meaningful and a bank mean would be
+  worthless. **The bank mean is therefore forbidden by this design (§4.5).**
+
+**Declared:** the bars are informed by the reference's density spread, which is a property of the renderer's
+catalogue and the frame geometry — *reference characterisation*. **None of S1, S2 or S3 has been computed on any
+dataset at pre-registration time.** The bars are fixed here and may not move.
+
+### 4.3 The null construction — USE THE ONE THAT ALREADY SHIPS, and bound its single-draw variance
+
+**An earlier draft of this design specified a displacement null from scratch. That draft was wrong and is
+withdrawn**: `TruthProtection.ShiftForNullControl` (`TruthProtection.cs:264-289`) already implements exactly this
+control, already ships, and is already reported on all 51 `bank-verify` config rows. *The cheapest instrument is
+the one already printed.* Inventing a second one would have produced a statistic that could not be compared with
+the product's.
+
+**The shipped construction, adopted verbatim.** The **DETECTIONS** are wraparound-translated by
+`(NullShiftX, NullShiftY) = (317, 211)` px — `Wrap(v, extent) = ((v % extent) + extent) % extent` — and re-scored
+against the **unshifted** reference. Note the convention carefully: the product shifts the *detections*, not the
+catalogue. **This design adopts the product's convention exactly**, because §6.3's `S27-1` compares the two
+routes' numbers and a convention mismatch would make that comparison meaningless. (On a torus the two are
+equivalent for a translation-invariant statistic, but the golden rects have finite extent and the frame is not
+literally periodic, so "approximately equivalent" is not good enough for a byte-level route comparison.)
+
+**Is it adequate at `D01`'s ~12 265 golden stars per frame? — the controller asked, and the answer is
+"decorrelation yes, variance no."**
+
+| property | verdict | reasoning |
+|---|---|---|
+| **decorrelates** | **YES, everywhere** | 317 px is **26×** the 12.0 px match radius and far larger than any PSF the bank renders; it is 16.5 % of the narrow axis on the smallest frame (1920×1080) and 3.3 % on the largest (9576×6388) — large enough to destroy correspondence, small enough that no object leaves the frame |
+| **not grid-aligned** | **YES** | 317 and 211 are both prime and neither divides any frame dimension in the bank |
+| **preserves count, density, clustering** | **YES** | wraparound creates and destroys nothing |
+| **single draw** | **NO — this is the inadequacy** | one offset is a **sample of size 1**. At `D10`'s 2.9 stars/Mpx `precisionNull` is a near-zero binomial and one draw is plenty; at `D01`'s 738 and `D18`'s 1 043 it is a **high-variance single draw**, and nothing in the shipped control can distinguish *"this offset landed unluckily"* from *"the field is saturated"*. `bank-verify`'s `precisionNullMax` maxes over **config rows**, not over offsets, so it does not close this |
+
+**Resolution, fixed here.** The **product** keeps its single shipped offset — wave 27 does **not** change shipped
+null behaviour, because that would change every `bank-verify` number in the series. The **independent Python
+scorer** computes the same statistic at **`K = 4` offsets**, the product's plus three more:
+
+```
+Δ1 = (317, 211)   <- the product's, verbatim      Δ3 = (317, -211)
+Δ2 = (-317, -211)                                 Δ4 = (-317, 211)
+```
+
+All four are the same magnitude (so the decorrelation argument transfers unchanged), all four are sign variants
+(so no new constant is invented and nothing is tuned), and `Δ1` is shared with the product so **`S27-1`'s route
+comparison is exact at `Δ1`**.
+
+* **The rule reads the value at `Δ1`** — the product's own offset — so the verdict is a statement about the
+  control that actually ships.
+* **The max − min spread over the four** is reported and NOT thresholded, as the single-draw variance bound the
+  product cannot give. **If the spread on any dataset exceeds that dataset's own `Δ1` value, the shipped null is
+  recorded as UNDER-POWERED on that dataset** and the dataset becomes a named caveat rather than a verdict input.
+  That is a finding about the product's control, and it is the honest form of the controller's question.
+
+**`A_all` (S1) is computed by rasterising every rect and disc onto a fixed lattice of stride 4 px, offset
+(2, 2)** — deterministic, no sampling seed, no null needed. The bank's smallest golden box is `w = 2·⌈4⌉ = 8 px`
+(`MinBoxHalfWidthPixels = 4.0`), so a minimal box receives 4 lattice probes in expectation; the estimator is
+unbiased in expectation with variance negligible against a 0.25 bar. The stride is fixed here and may not be
+tuned after the data. `A_all` is the **mechanistic explanation** for whatever `precisionNull` reports, and the
+two must agree in direction — a high `precisionNull` with a low `A_all` would mean the null is measuring
+something other than coverage, and is called out.
+
+**`A_all` (S1) is computed by rasterising every rect and disc onto a fixed lattice of stride 4 px, offset
+(2, 2)** — deterministic, no sampling seed. The bank's smallest golden box is `w = 2·⌈4⌉ = 8 px`
+(`MinBoxHalfWidthPixels = 4.0`), so a minimal box receives 4 lattice probes in expectation; the estimator is
+unbiased in expectation with variance that is negligible against a 0.25 bar. The stride is fixed here and may not
+be tuned after the data.
+
+### 4.4 Populations — [F68](followups.md)'s five parts, per clause
+
+| clause | population (ARTIFACT) | population (FIELD, and WHICH COPY) | statistic | aggregation | empty-set answer |
+|---|---|---|---|---|---|
+| **T27-V0** reproduction | the 20 `/mnt/d/hf_w25/table18/<DS>.log` files, paths **from the manifest only** | the `OVERALL:` line's `TP=`, `FP=`, `FN=` — the **product's** fields, not the frames CSV's (both exist; the CSV is per-frame and would need re-summing, which is a second route and therefore a second bug) | exact integer equality | per dataset; verdict is a **count of datasets**, `20 of 20` required | a missing/unparsable `OVERALL:` line ⇒ that dataset is **COULD-NOT-LOOK**, named, and T27 is `T-UNEVALUATED` |
+| **T27-V1** coordinates | the 180 `*.truth.json` + the 180 `detected_f*.csv` | `BinnedCenterX/Y` **vs** `Star.CxPixels/CyPixels` — both copies read, deliberately, and compared | match rate at 12.0 px | per dataset | a frame with 0 detections contributes 0/0 and is excluded from that dataset's rate, counted in `frames_no_detections` |
+| **T27-V3** pairing | the 180 manifest rows | the sidecar's own `focuserPosition` **field**, never the filename | equality with the manifest's `<F>` | count | any row unpaired ⇒ `T-UNEVALUATED` |
+| **S1** `A_all` | 180 frames | golden `stars[]` + `unresolved[]` rects (`x,y,w,h`); truth `BinnedCenterX/Y` where `Tier ∈ {omitted, merged-into}` | covered lattice fraction | **mean over the 9 frames** (frames within a dataset have identical area, so the mean is exact) | a frame with an empty catalogue ⇒ `A = 0` for that frame, and it still counts in the mean |
+| **S2** `precisionNull` | 180 frames | as S1 plus `D(f)` | `ΣTP_null ÷ (ΣTP_null + ΣFP_null)` | **pooled counts, then the ratio** | `ΣTP_null + ΣFP_null = 0` ⇒ `precisionNull = 0.0` by definition (no detection could be scored), reported with a `†` |
+| **S3** `chanceProtected` | 180 frames | as S1 plus `R(f)` | `Σ\|P_null\| ÷ Σ\|R\|` | **pooled counts, then the ratio** | `Σ\|R\| = 0` ⇒ **`n/a`**; the dataset leaves S3's denominator and the denominator prints as `k of 19` |
+
+**Aggregation, stated once and binding everywhere:** every dataset-level ratio is **pooled counts then ratio**,
+never a mean of per-frame ratios. The bank's frames differ in detection count by more than an order of magnitude
+within a single dataset (`D08`: 10 detections at the wing, 119 at focus), and a mean-of-ratios would be dominated
+by the sparse wing frames. **The bank-level statement is a COUNT OF DATASETS crossing a bar, never a mean of
+dataset ratios** — the density spread of §4.2 makes a bank mean meaningless.
+
+### 4.5 The verdict population: 19 datasets, D08 excluded, and the count is COMPUTED
+
+**`D08_c11_2800mm` is NOT BLIND.** Its per-frame truth-match table is published in
+`/mnt/d/hf_w26/pd08/F31_truth_rescore.txt` and quoted verbatim in the owner's results table; its `table18`
+`OVERALL:` line is quoted in §0 of this design. Under the [F14](followups.md) / [RULE D20](waves22+-handoff-prompt.md)
+fence, **no verdict may be harvested from a population already read.**
+
+* **Verdict population: the 19 datasets other than `D08`.** The literal `19` is **COMPUTED** by the scorer as
+  `len(manifest_datasets) − len(NOT_BLIND)` where `NOT_BLIND = {"D08_c11_2800mm"}` is a named constant, and is
+  **asserted equal to 19** at run time. It is never typed into an output string.
+* **`D08` is carried as a labelled, reported-not-thresholded consistency check.** Its S1/S2/S3 are printed in the
+  same table under a `[not blind]` marker and are excluded from every count.
+* `D08` **does** participate in `T27-V0` (reproduction) and `T27-V1` (coordinates) — those are validity gates on
+  the *scorer*, not on the wave's hypothesis, and a scorer that cannot reproduce a published log is broken
+  regardless of blindness.
+
+### 4.6 The verdict tree
+
+Counts below are over the **19-dataset verdict population**. `SAT(d)` ⟺ `SATURATED-BY-AREA(d)` **or**
+`SATURATED-BY-NULL(d)`. `CHANCE(d)` ⟺ `CHANCE-DOMINATED(d)`.
+
+| # | condition | verdict | what the owner gets |
+|---|---|---|---|
+| 1 | any of `T27-V0`, `T27-V1`, `T27-V3`, `T27-V4` fails | **`T-UNEVALUATED`** | nothing is claimed. **Do NOT repair the rule and re-score** — a scorer that cannot reproduce the published numbers cannot be trusted to measure a null on them, and the F14 fence applies to the repair-and-harvest pattern |
+| 2 | gates pass; `SAT` count **= 0** and `CHANCE` count **= 0** | **`T-SOUND`** | the precision column is honest as published. The banner comes off with no replacement caveat. F83 proceeds on real numbers |
+| 3 | gates pass; `1 ≤ SAT + CHANCE ≤ 4` (union of the named sets) | **`T-SOUND-WITH-NAMED-EXCEPTIONS`** | the column is honest except on the named datasets, which are annotated **in place** in the results table as uninformative, each with its `A_all` / `precisionNull` / `chanceProtected` printed |
+| 4 | gates pass; `SAT` count **≥ 5** | **`T-SATURATED`** | the precision column is an **UPPER** bound on the dense fields. Every `1.000` there is uninformative. F83's precision-term question becomes largely moot on this bank. The results table's precision column is re-annotated, and `TruthProtection` is recommended (costed, **not shipped**) a density guard |
+| 5 | gates pass; `CHANCE` count **≥ 5** and `SAT` count **< 5** | **`T-CHANCE-DOMINATED`** | the protections are largely coincidental. The correct precision lies between `precision_unprot` and `precision_prot` and neither is publishable alone; the wave publishes the **bracket** and `precision_corr` per dataset |
+| 6 | every dataset in the verdict population is COULD-NOT-LOOK | **`T-COULD-NOT-LOOK`** | named per dataset with its reason, emitted **before any field read** (§7) |
+
+**Predicted answer, recorded now so the rule can be wrong** ([RULE R24](waves22+-handoff-prompt.md)'s lesson —
+a rule with a predicted answer is a rule that can be wrong):
+
+> **Prediction P-W27.** `T-SOUND-WITH-NAMED-EXCEPTIONS`, with the exceptions drawn from
+> `{D18_m24_deep_shed, D01_ultrawide_40mm}` and at most one other. Mechanism: coverage scales with areal density,
+> the bank spans 360× in density, and only the top two datasets have the density to reach a 0.25 bar on the disc
+> term alone. **If `D04_esprit_550mm` or `D02_rich_135mm` also fires, the mechanism is not density alone and the
+> results owe a second explanation.** If `D10`/`D06` fire, the scorer is wrong and `T27-V0` should have caught
+> it.
+
+---
+
+## 5. VALIDITY GATES
+
+### 5.1 `T27-V1` — COORDINATE SPACE AND BINNING. **Get this wrong and every number in the wave is wrong.**
+
+**The decision, fixed here.** The 12.0 px match radius is expressed in **captured (binned) pixels** — the space
+in which the FITS, the golden boxes, `detected_f*.csv` and `BinnedCenterX/Y` all live. Detections are matched
+against **`BinnedCenterX`/`BinnedCenterY`**, never against `Star.CxPixels`/`CyPixels`.
+
+Justification, from source and from the published logs:
+
+* `GoldenFromTruth.Build` transforms every star to captured pixels (`ToBinnedCoordinate`, `(c+0.5)/bin − 0.5`)
+  and emits `GoldenStarBox` in that space; `TruthProtection.BuildProtectionBoxes` reads `d.BinnedCenterX/Y`
+  directly.
+* `truthModel.captureBinning` is **2** on exactly the two `*_afbin2` datasets and **1** on the other eighteen —
+  **the count 2 is COMPUTED from the 20 `synthetic_meta.json` files at run time, never typed.**
+* `table18` scored **every** dataset at `DetectionBinning = 1` (the logs' own
+  `NOTE: … derived detection binning is 2 … but it is being scored at 1`), so **no software-binning rescale is in
+  play anywhere in this wave.**
+
+**The gate, with its FAIL end run and printed, not hypothesised.** For every dataset the scorer matches `D` to
+the full truth list at 12.0 px **twice** — once on `BinnedCenterX/Y`, once on `Star.CxPixels/CyPixels` — and:
+
+| clause | requirement |
+|---|---|
+| **V1-a** | on the **18** `captureBinning = 1` datasets the two match rates are **bit-identical** (`repr()` equality). The transform is the identity at `bin = 1`; any difference means the reader is wrong |
+| **V1-b** | on the **2** `captureBinning = 2` datasets (`D11_rc10_585_afbin2`, `D12_c14_585_afbin2`) the binned rate exceeds the native rate by **≥ 0.30 absolute** |
+
+**V1-b's native arm IS the demonstrated FAIL end** — it is executed on real artifacts and its (low) rate is
+printed beside the (high) binned rate in the same table. A gate whose FAIL end is a paragraph is not a gate.
+
+### 5.2 `T27-V2` — the detection-binning discrepancy: DECIDED, and deliberately NOT repaired
+
+The `table18` logs record `derived = 2, scored = 1` on **7 of 20** datasets (`D08, D09, D10, D12, D14, D15,
+D17`) and `derived = 1, scored = 1` on the other 13. **The count 7 and the dataset list are COMPUTED from the
+logs' own `NOTE:` lines at run time, never typed.**
+
+**Decision, fixed before the data: `RULE T27` is scored on `table18` AS PUBLISHED, at factor 1, and the
+discrepancy is NOT repaired inside T27.**
+
+1. All 20 were scored the same way, so the precision column is **internally comparable** — which is all
+   `RULE T27`'s question needs.
+2. The detections on disk are the ones the owner's table was built from. Re-scoring at factor 2 produces a
+   **different table**, not a check on this one.
+3. Changing the instrument inside a soundness wave would confound T27's verdict with the change.
+
+The factor-2 re-score is a **separate rule on a separate population** — `RULE D27`, §5.7 — and its result may not
+be substituted into T27's inputs. §4.6's verdict is additionally **reported split 13 / 7** so the two rules can
+be read against each other.
+
+On those 7 rows the owner's table's **precision/recall** and its **binning** columns are measured under
+contradictory assumptions: precision/recall at software factor **1**, the binning recommendation from wave 25's
+S1 arm at factor **2** (a different instrument, already labelled as such in the table's own header). `RULE D27`
+exists to say whether that matters.
+
+### 5.3 `T27-V0` — REPRODUCTION, and its FAIL end is the (A) measurement
+
+The scorer, reading paths **only** from the manifest, must reproduce `table18`'s published per-dataset `TP`,
+`FP`, `FN` **exactly**, on **20 of 20**.
+
+* **PASS end:** exact integer equality, 20 of 20.
+* **FAIL end, demonstrated on real artifacts:** the same scorer invoked `--protection off` must **differ** from
+  the published numbers on ≥ 1 dataset. This is not a contrived mutant — **it is simultaneously the FAIL-end
+  demonstration and the measurement of the correction's size**, which is half (A)'s justification. One
+  computation, two duties.
+* If `T27-V0` fails, the verdict is `T-UNEVALUATED` and the wave stops. Fixing an outright bug in the *reader* is
+  permitted once and must be recorded; if it still fails, **that is the finding**.
+
+`T27-V0` is what checks this design's reading of `GoldenMatch.Match` / `ExcludeUnresolved` / `ExcludeProtected`
+semantics. Nothing else in the wave needs to assume they were read correctly.
+
+### 5.4 `T27-V3` — SIDECAR PAIRING
+
+Every manifest row's `detected_f<F>.csv` pairs with a `*.truth.json` and a `*.golden.json` whose
+**`focuserPosition` field** (from the sidecar, never parsed from the filename) equals `<F>`. **Assert 180 of
+180.** FAIL end: a self-test fixture mutates one row's focuser and the check must refuse.
+
+### 5.5 `T27-V4` — FINGERPRINT, class 4 (this wave's denominators)
+
+Taken **before** any analysis, per *a control written after the arm is not a control*:
+
+* `/mnt/d/hf_w27/fp_table18_BEFORE.txt` — 400 files (20 × [9 `detected_f*.csv` + 9 `false_negatives_f*.csv` +
+  `golden_eval.txt` + `golden_eval_frames.csv`]) plus the 20 `.log` files.
+* `/mnt/d/hf_w27/fp_sidecars_BEFORE.txt` — 180 `*.truth.json` + 180 `*.golden.json` + 20 `synthetic_meta.json`.
+
+Both taken with `-print0 | sort -z | xargs -0 sha256sum` — **`xargs` splits on the space in `/mnt/d/Autofocus
+Bank`, and a fingerprint written the naive way once recorded 20 landings instead of 42.** Population sizes are
+asserted **inside** each file. Matching `*_AFTER.txt` files are written at the wave's close and **kept**. Any
+difference ⇒ the wave's denominators moved under it ⇒ `T-UNEVALUATED`.
+
+### 5.6 `T27-V5` — THE PATH TRAP. `table18`, not `table`.
+
+**`/mnt/d/hf_w25/table/` also exists, also holds 20 datasets × 9 frames, and is WRONG.** It sourced params from
+`D:\SyntheticAutofocusBank\<DS>\attempt01\` instead of `D:\hf_w18\seedA0\<DS>\attempt01\optimized_settings.json`
+and gives different numbers (`D01` `recall@all` **0.209** against the published **0.123**). A scorer pointed at
+it would produce a **plausible, wrong wave**. This is [F74](followups.md)'s path trap wearing a different hat.
+
+**The guard:** the manifest driver asserts, for every one of the 20 logs, that the `params:` line contains the
+literal `D:\hf_w18\seedA0\` **and** that the root basename is `table18`; and the scorer asserts the same on the
+manifest header before reading a single field. The near-miss root is named in the manifest header as
+`NEAR_MISS_ROOT=/mnt/d/hf_w25/table` so a future reader cannot rediscover it by accident.
+
+### 5.6a `RULE R27` — REPRODUCIBILITY of the population. **ADOPTED, and it is a DECLARED DEVIATION.**
+
+**`RULE R27 = R-IDENTICAL`.** B15 regenerates the entire published `table18` population byte for byte:
+**20 cells, 420 files, 0 differences, 0 could-not-look** (`/mnt/d/hf_w27/repro_all_score.txt`). Driver
+`repro_all_w27.sh` self-tests PASS with its comparator demonstrated in **both** directions; scorer
+`score_repro_w27.py` self-tests **6 of 6** with `--out` mandatory and refusing; paths flow through
+`repro_all_manifest.tsv` (20 of 20 rows) and are rebuilt nowhere.
+
+**This ran BEFORE pre-registration, and the design says so rather than presenting it as registered.** The
+deviation is declared, not laundered:
+
+* **Why adopting it is legitimate.** `R27` is a **determinism control on the instrument**, not a test of the
+  wave's hypothesis. It reads no statistic in T27's verdict tree and could not have been steered by knowing the
+  answer — a byte-comparison of a regenerated population has exactly one interesting outcome and the wave's
+  hypothesis is indifferent to it. This is the `Q26-V0`/`Q26-V5` shape.
+* **Why it still matters that it was early.** *A self-test that runs AFTER the thing it guards is not a guard* —
+  here the reverse risk applies, so the honest statement is that `R27` was **opportunistic rather than
+  pre-registered**, and the results document must say so in the same sentence it quotes `R-IDENTICAL`.
+* **Its FAIL end IS demonstrated** — the controller reports the comparator shown failing in both directions in
+  `repro_all_w27.sh`'s own self-test, which is what makes `0 differences` a measurement rather than a
+  tautology. *A control that cannot fail is not a control.*
+
+**What `R27` buys the wave, and it is load-bearing for two other rules:**
+
+1. Half (B) may treat the 180 `detected_f*.csv` as a **stable population** rather than a historical accident.
+2. **`S27-4` becomes attributable.** Without `R27`, a byte difference between B16 and `table18` could be the
+   treatment *or* run-to-run noise. With `R-IDENTICAL` in hand, **any difference is the treatment.** This is the
+   exact inverse of wave 19's `R-DETERMINISTIC` complaint (*"the two build trees were C#-identical, so it
+   measures the noise floor and not whether a code change can move a landing"*) — there the identity was the
+   defect; here the identity is the baseline and the difference is the treatment.
+
+### 5.7 `RULE D27` — the factor-2 re-score (item D)
+
+**Question.** On the 7 datasets whose *derived* detection binning is 2, does scoring at the optimizer's own
+factor move the owner's published precision/recall?
+
+**Population.** The 7 datasets named by the `table18` logs' own `NOTE:` lines — `D08, D09, D10, D12, D14, D15,
+D17` — **the list and the count 7 COMPUTED from those lines, never typed**. 7 × 9 = **63 frames**, asserted.
+Re-scored on **B15** (`/mnt/d/hf_w25/exe`, `TestApp.dll` sha256 `2fb0c8fd…`), **no build**, into
+`/mnt/d/hf_w27/table18_b2/`, deriving the invocation from `/mnt/d/hf_w25/table_arm18_w25.sh:62` — **and running
+the derivation pre-flight on the result**, because that is exactly the `sed`-derivation path
+[F80](followups.md) exists for.
+
+**Verdict population: the 6 datasets other than `D08`** (`D08` is in the 7 and is not blind). The **6 is
+COMPUTED** as `len(D27_POP) − len(NOT_BLIND ∩ D27_POP)`.
+
+**Statistic.** Per dataset: `Δprecision` and `Δrecall@all` and `Δrecall@high`, factor 2 minus the published
+factor 1, from each run's own `OVERALL:` line.
+
+**Bar.** `MOVED(d)` ⟺ `|Δprecision| ≥ 0.01` **or** `|Δrecall@all| ≥ 0.01`. 0.01 is the last digit the owner's
+table prints, so a move below it cannot change a published number; a move at or above it can.
+
+| condition (over the 6-dataset verdict population) | verdict |
+|---|---|
+| `D27-V1` or `D27-V2` fails | **`D-UNEVALUATED`** |
+| gates pass; `MOVED` count = 0 | **`D-NO-CHANGE`** — the 7 rows stand as published; the derived/scored discrepancy is cosmetic and the log's `NOTE:` can be read as informational |
+| gates pass; `1 ≤ MOVED ≤ 6` | **`D-MOVED`** — the named rows are re-stated in the results table at the optimizer's own factor, with both values printed and the factor labelled on each |
+
+**`D27-V1` — the `PixelScale` gate, with a demonstrated FAIL end.** `GoldenEvalRunner.cs:258-261` sets
+`p.PixelScale = effectivePixelScale × detectionBinningFactor`; the recorded gotcha is that omitting the factor
+produces a **plausible wrong answer**. The gate: each factor-2 log must print the `; detectionBinning 2` suffix
+on its `pixelScale:` line **and** must NOT print the `derived … but it is being scored at 1` NOTE.
+**FAIL end, run and printed:** one dataset (`D09_c14_3800mm`) is additionally re-run **without**
+`--detection-binning`, and the NOTE must reappear and the `pixelScale:` line must differ. ~10 s.
+
+**`D27-V2` — the coordinate-collapse guard.** The golden boxes are in captured pixels and are unchanged by
+software binning. If detections came back in half-scale coordinates, essentially none would match. Require
+`recall@all ≥ 0.25` on all 7 at factor 2. **Reachable both ways:** the published factor-1 values on these 7 are
+0.978 / 0.949 / 0.965 / 0.705 / 0.641 / 0.961 / 0.875, all far above 0.25, so PASS is expected; and a coordinate
+break would drive them to ~0, so FAIL is reachable by the exact defect the gate exists for.
+
+**Blindness.** `D08`'s factor-1 numbers are published; its factor-2 numbers are **not**, so `D08` may be
+*measured* here but is excluded from the verdict count and printed `[not blind]`.
+
+---
+
+## 6. HALF (A) — the shippable harness defect
+
+### 6.1 The defect — and it is FOUR disclosures, not one
+
+> **`bank-verify` carries four truth-related honesty disclosures. `golden eval` — the instrument that produced
+> the owner's published results table — carries NONE of them.**
+
+| disclosure | `bank-verify` | what it is | `golden eval` |
+|---|---|---|---|
+| `scoringMode` + `protectedStars` | `:287-306`, `:344` | whether truth protection was applied at all, and how much was available | **absent** |
+| `precisionNull` | `:478-489`, `:513` | the chance null. Its own comment: *"A metric reading 1.000 with a null near 0 is measuring; one reading 1.000 with a high null is **saturated**, which is how the first cut of the F31 repair failed."* | **absent** |
+| `truthViolations` | `:470-474`, `:517-521` | a scored FP sitting on a real rendered star — *"has an exact answer and the answer must be 0"* | **absent** |
+| `scoredFraction` | `:510-512` | how much of the detection set the precision ratio actually judged — *"at Sensitivity 0 that reaches ~57 % on D17"* | **absent** |
+
+`GoldenEvalRunner.WriteReports` is **not even passed the truth dispositions**. So every number in
+`docs/synthetic-af-bank-results-table.md` was produced by a truth-protected instrument that cannot say it was
+truth-protected, cannot say what chance alone would have scored, cannot say whether any FP sits on a real star,
+and cannot say what fraction of the detections it judged. **That is the whole of wave 26's misreading,
+mechanised.** A grep of `/mnt/d/hf_w25/table18/*.log`, `golden_eval.txt` and `golden_eval_frames.csv` for
+`protected` / `scoringMode` / `precisionNull` returns **zero hits**.
+
+**A null WAS generalised — but only in the sibling.** `precisionNull`'s wraparound ships in `bank-verify` and is
+reported on all 51 config rows under a `precisionNullMax` gate. The separate *coordinate-alignment* null (F31's
+100 % / 2.3 % / 0 %) is **`D09` only and has never been re-run**. `golden eval` implements **neither**. **So the
+owner's 20 rows have never been null-tested.** That is the gap, stated precisely, and it is why half (B) exists.
+
+### 6.2 The change — a PORT, not a design
+
+All four are already written, already tested and already shipped in the sibling. Port them into
+`GoldenEvalRunner` — console line, `golden_eval.txt`, `golden_eval_frames.csv` — reusing `bank-verify`'s wording
+verbatim so the two harnesses cannot drift apart. Honour the house rule stated one line from the change site,
+`GoldenEvalRunner.cs:669`: *"Report the mode actually used — a hardcoded label here silently misattributes every
+stored report."*
+
+**Plus one doc-comment-only fix, and the reason it is doc-comment-ONLY is a preservation constraint.**
+`GoldenFromTruth.cs:34-36` (`Omitted` — *"a detector reporting something at its location should be scored as a
+false positive"*) flatly contradicts `:76-84` (`UnresolvedSnr` — *"scoring a detection there as a false positive
+would be punishing a detector for something the reference itself cannot certify either way"*). That contradiction
+is §2.1's mis-assigned side, in source.
+
+Worse, `:744-748` **writes the wrong version into every golden sidecar's `Reason` field**, so the pre-repair
+policy is sitting on disk in all **180** `*.golden.json` in the bank — and it is the single most likely thing
+that actually misled wave 26.
+
+**Decision, fixed here: fix the two XML doc comments; do NOT change the `Reason` string generation, and do NOT
+regenerate the sidecars.** Three reasons, in this order:
+
+1. **Regenerating 180 goldens collides with fingerprint class 2 preservation** and would invalidate every
+   precision/recall number this series has published. That is a catastrophic price for a diagnostic string.
+2. Changing only the *generator* string would make future sidecars disagree with the 180 on disk — a silent
+   divergence, which is the same class of defect being fixed.
+3. Nothing reads `Reason` programmatically; it is a debugging aid.
+
+The on-disk hazard is instead **registered as a named caveat** (§9) so the next reader of a `*.golden.json`
+`Reason` field is warned in the register rather than misled by the file.
+
+### 6.3 `RULE S27` — and the ship is NOT what the rule decides
+
+Per the charter's *"ship unconditionally where the ship is not what the rule decides"*: the reporting gap is
+established from **source** (one harness reports it, the other does not) and confirmed by a **grep of the
+published logs returning zero**. Its correctness does not depend on T27's verdict. **(A) ships unconditionally,
+under a correctness rule, not a value rule.**
+
+| clause | requirement | FAIL end |
+|---|---|---|
+| **S27-1** | the four new fields appear in **all three** sinks on all 20 datasets, and their values equal `score_t27_w27.py`'s **independently computed** `protectedStars` / `scoredFraction` / `precisionNull` (at `Δ1`) / `truthViolations`, on **20 of 20** | a disagreement is a **finding about one of the two routes**, named, and (A) does not ship until the wave says which is right. This is [F79](followups.md)'s lesson made structural: two routes to the same statistic, compared, **and never assumed to compute the same statistic** |
+| **S27-2** | every new NUnit test shown **RED against a named mutant** — `M-S1` deletes the `protectedStars` accumulation; `M-S2` hard-codes `scoringMode = "golden"`; `M-S3` returns the unshifted detections from the null path | a mutant that does not turn its test red means the test does not reach the code |
+| **S27-3** | `TestAppOutputAsciiTests` green — the new console output must be ASCII | — |
+| **S27-4** | **do-no-harm, provable by BYTES.** B16 re-runs all 20 `table18` cells. Required: every `detected_f*.csv` and `false_negatives_f*.csv` **byte-identical** to `table18`'s (**360 of 360**), and `TP`/`FP`/`FN` unchanged on **20 of 20**. Only the new fields may differ | if any byte of a detection artifact moves, or any of the 60 counts moves, the change was not report-only and **does not ship**. *A reporting change that moves a score is a bug*, and this makes that statement falsifiable rather than argued |
+| **S27-5** | `truthViolations = 0` on **20 of 20** | `bank-verify`'s own comment: this *"has an exact answer and the answer must be 0"*. A non-zero value means a detection was charged as an FP while sitting on a real rendered star — the exact defect F31 repaired — and is a **product finding**, not a scoring nuisance |
+
+**Two controls, and the wave needs BOTH because they answer different questions.** `T27-V6` (§5.6a) establishes
+*"B15 reproduces `table18`"* — determinism of the instrument. `S27-4` establishes *"B16 equals B15 modulo the new
+fields"* — do-no-harm of the treatment. **Without the first, a `S27-4` difference is unattributable**: it could
+be the change or it could be run-to-run noise. Wave 19's `R-DETERMINISTIC` was a **null arm** precisely because
+its two trees were C#-identical and it therefore measured the noise floor instead of a treatment. **Here the
+inverse holds and it is a gift: `git diff --name-only 29665a62..HEAD -- '*.cs'` is 0 lines
+(`/mnt/d/hf_w27/prov_b15_to_head_cs.txt`), so B15's tree and HEAD are C#-identical and B16 = B15 + exactly (A)
+and nothing else. The difference IS the treatment** — the cleanest two-binary provenance this series has had.
+
+### 6.4 Does the gate REACH this code? **No — and here is the check that does.**
+
+A report-only change in `GoldenEvalRunner` is in no `optimize` search path; `OptimizationDiagnosticRunner` never
+calls `GoldenEvalRunner`. Naming the 42-minute gate beside it would be **claiming a control the wave does not
+have**. The checks that DO reach it are `S27-2`'s two mutant-killed tests and `S27-4`'s before/after log on a
+named dataset.
+
+**But wave 26's honest-skip conditions do not all hold here** — wave 27 *builds*, which trips reversal condition
+1 (*"any C# changes"*). So the gate is **owed** unless the reversal is discharged on a principled, checkable
+basis. This design pre-registers that basis:
+
+> **`Q27-V1` — the reach-scoped discharge.** The gate is owed when the C# diff touches code the gate's own path
+> can reach. Compute `git diff --name-only <B15 tree>..HEAD -- '*.cs'` (**reading B15's tree hash out of
+> `/mnt/d/hf_w25/binary_provenance_w25.txt`, never assuming the previous wave's HEAD** — wave 24 got this base
+> wrong and it mattered) and intersect it with the **reachable set**: everything under
+> `Joko.NINA.Plugins.HocusFocus/`, plus `TestApp/{OptimizationDiagnosticRunner,HarnessSettingsStore,
+> OptimizationRunDiscovery,ParamsDump,StubBehaviorSelectors,DiagnosticUtil,Program}.cs`.
+> **Empty intersection ⇒ the gate is discharged**, replaced by hash identity + BuildId novelty (`Q27-V0`, wave
+> 26's `Q26-V0` shape) **and** `S27-4`'s byte-identical `OVERALL:` line, which measures the wave's *actual* risk
+> on the *actual* instrument and is a strictly sharper control for this change than an `optimize` gate is.
+> **Non-empty intersection ⇒ the full 42 m gate runs.**
+>
+> **`Q27-V1`'s FAIL end is demonstrated**, not asserted: the same check is run against `<B14 tree>..HEAD`, a diff
+> known to include plugin files, and must return a **non-empty** intersection and refuse.
+
+**If `Q27-V1` discharges and the controller nevertheless has budget, run the gate anyway** — but the wave must
+not report a gate it did not run, and must not call the discharge a pass. Both prices are in §10.
+
+### 6.5 Binary discipline for (A)
+
+Build into `/mnt/d/hf_w27/exe`. Record **dll** sha256s (`TestApp.dll`, the plugin dll) — **never the apphost;
+`TestApp.exe` is byte-identical across six distinct published binaries** ([F66](followups.md)) — plus the
+`BuildId`, asserted **novel against the sixteen** recorded ids. Run
+`find Joko.NINA.Plugins -name '*.cs' -newermt '<build mtime>'` and record that it is **empty**. Never rebuild
+mid-wave. B15 stays at `/mnt/d/hf_w25/exe` (`TestApp.dll` sha256
+`2fb0c8fdb26f11f9c912dce6d3bc3b599e8b9abab7ee4fdd0a61ace0aac42e67`) and is **not** rebuilt.
+
+---
+
+## 7. COULD-NOT-LOOK STATES, with the guard BEFORE any field read
+
+Every one of these is emitted by the scorer **before** it reads the field in question, and each is a named state
+rather than a zero:
+
+| state | guard, and it runs first | consequence |
+|---|---|---|
+| `CNL-MANIFEST` | the manifest is absent, or its header lacks `ROOT=/mnt/d/hf_w25/table18`, or its row count ≠ 180 | the scorer **refuses**, rc = 3, no output file written |
+| `CNL-LOG` | a dataset's `.log` has no parsable `OVERALL:` line | that dataset is named and `T27-V0` fails ⇒ `T-UNEVALUATED` |
+| `CNL-SIDECAR` | a `*.truth.json` or `*.golden.json` is missing, unparsable, or its `focuserPosition` disagrees with the manifest | `T27-V3` fails ⇒ `T-UNEVALUATED` |
+| `CNL-NODET` | a frame's `detected_f*.csv` has a header but zero data rows | the frame is counted in `frames_no_detections`, contributes 0 to every numerator **and** denominator, and is named |
+| `CNL-EMPTYPOOL` | `Σ\|R(d)\| = 0` for a dataset | `chanceProtected = n/a`; the dataset leaves S3's denominator, which prints as `k of 19` with `k` **computed** |
+| `CNL-NONFINITE` | any `BinnedCenterX/Y`, box coordinate or `PeakSnr` is NaN/Inf — **and Newtonsoft writes these as the STRINGS `"NaN"`/`"Infinity"`** | the entry is excluded, counted, and named. [F79](followups.md)'s mirror |
+| `CNL-DIMS` | a frame's FITS header yields no `NAXIS1`/`NAXIS2` | `A_all` is `n/a` for that frame; if any frame of a dataset is affected, the dataset's S1 is `n/a` and it leaves S1's denominator |
+
+---
+
+## 8. HALF (C) — the register corrections, owed unconditionally
+
+Three documents state as open something that shipped on 2026-08-03. Each is corrected **in place, where the owner
+can see it**, with the correction visible rather than a silent rewrite.
+
+| # | file | what changes |
+|---|---|---|
+| **C1** | `docs/synthetic-af-bank-results-table.md` | the `## READ THE PRECISION COLUMN AS A LOWER BOUND` section (lines 7–24) is **replaced**. New banner: the column is already truth-corrected (`TruthProtection`, shipped 2026-08-03); `D08`'s `0.966` is honest, with `TP=308 FP=11 FN=7` quoted from its own log; the 91.3 % figure measured the **pre-repair** metric and is withdrawn as a caveat on this table; and whatever `RULE T27` returns is stated with its named exceptions. The *"13 genuine junk detections"* paragraph and the *"recall is unaffected"* paragraph are **kept** — both are correct |
+| **C2** | `docs/followups.md`, [F84](followups.md) item (2) | corrected in place: the truth re-score is **not owed**, it shipped; the 91.3 % measurement is re-labelled as a measurement of the pre-repair metric; F31 is cited as `Done` with its own next-step-(1) quote |
+| **C3** | `docs/waves22+-handoff-prompt.md` `:171,172,188` | backlog item **1** is struck with the reason (the pattern the file already uses for the struck old item 1), and replaced by wave 27's own items. The line *"F23 and F83 are BOTH undecidable"* is corrected: a truth-based pass exists and F31 already re-measured F23 (*"F23 void as written"*) |
+| **C4** | `docs/waves27+-autonomous-prompt.md` `:154-160` | **the LIVE charter propagates the false claim verbatim** and is corrected in place, or a successor run will re-open item 1 for a third time |
+
+**The authority for (C) is `docs/wave27-register-correction-survey.md`** — a line-anchored inventory of
+**5 FALSE, 3 STALE, 3 MISLEADING, 2 historical-annotate-in-place, 1 source contradiction, 2 gaps** and
+**8 correct-and-load-bearing** statements. Read it before making a single edit; it names every line. The three
+most load-bearing are the results-table banner at `:7-21` (four distinct false statements),
+`waves22+-handoff-prompt.md:171,172,188`, and `waves27+-autonomous-prompt.md:154-160`.
+
+**No published NUMBER is wrong.** All 20 source reports verify. **Only the interpretive banner is false** — so
+(C) is a correction of readings, not of measurements, and no table cell moves except the two the junk-count
+correction touches (§0.1).
+
+**The controller makes the edits; this design and the survey specify which lines change so the edit is mechanical
+rather than interpretive.**
+
+---
+
+## 9. WHAT GOES IN THE REGISTER
+
+A new entry is owed regardless of T27's verdict, because §0 is a finding on its own:
+
+> **F85 — A closed, shipped correction was re-measured as an open defect, because two fields share a name.**
+> `golden eval`'s `FP` and a Python re-derivation from the golden's `stars` list alone are both "false
+> positives": **11** and **150** on the same detections. Wave 26 read the second and compared it against the
+> first, concluding the owner's precision column was a lower bound when it was already corrected. The proximate
+> cause is that **`GoldenEvalRunner` applies `TruthProtection` and never reports that it did**, while
+> `BankVerifyRunner` reports it in three places. [F68](followups.md) part 1 and [F79](followups.md)'s
+> more-than-one-route shape, in one incident. **Remedy (A).**
+
+> **F86 — the golden sidecars on disk carry the PRE-REPAIR policy in their own words.**
+> `GoldenFromTruth.cs:744-748` writes *"a detection here should count as a false positive"* into the `Reason`
+> field of every `omitted` component, and that string is sitting in all **180** `*.golden.json` in the bank. The
+> behaviour it describes was repaired on 2026-08-03 and the string was not, because it is a diagnostic field
+> nothing reads programmatically. **It is the single most likely thing that actually misled wave 26.** Wave 27
+> fixes the two contradicting XML doc comments (`:34-36` vs `:76-84`) and **deliberately does NOT regenerate the
+> sidecars** — that would collide with fingerprint class 2 preservation and invalidate every published
+> precision/recall number in the series (§6.2). **Anyone reading a `Reason` field must read this entry first.**
+
+`RULE T27`'s verdict is appended to F31 (whose repair it audits) and to [F83](followups.md) (whose decision it
+gates). If the verdict is `T-SATURATED` or `T-CHANCE-DOMINATED`, **F31 is REOPENED** with the density guard as
+its costed next step. `RULE D27`'s verdict is appended to [F62](followups.md) (the no-`BestJ`-across-factors
+landmine) and to the results table's binning column.
+
+---
+
+## 10. BUDGET, and what is not run
+
+Hard stop **2026-08-14T00:45:17Z**. Estimates are recorded so the controller can record actuals against them
+(*price the payoff in both directions and record estimate AND actual*).
+
+**A rate the charter's §5 budget table does not have, added here as MEASURED so the next wave does not price a
+golden-eval arm off the `optimize` rate** — [F21](followups.md)'s recorded error, which under-reserved wave 23 by
+3.5× in the other direction:
+
+| instrument | rate | how measured |
+|---|---|---|
+| **`golden eval`, the FULL 20-dataset arm, `table18` settings, B15** | **349 s (~6 m)** | **MEASURED**, controller, 2026-08-13 — the whole arm |
+| **`golden eval`, one 9-frame cell** | **6 s (`D06`) – 46 s (`D01`)**, mean ~17 s | **MEASURED**. The spread tracks star count, not frame count: `D01` carries ~12 265 golden stars/frame |
+| for comparison, `optimize --per-run --max-evals 250` | ~5.2 m/run | charter §5 — **~18× the whole arm**. Never price `golden eval` from it |
+
+**Price a cell from the RANGE, not the mean** — `D01` is 7.7× `D06`, so a 7-cell arm's price depends entirely on
+which 7. [F21](followups.md)'s lesson, in the cheap direction this time.
+
+| step | estimate | notes |
+|---|---|---|
+| pre-flight `verify_derivation_w27.py` (blocking) + `layout_w27_selftest.sh` | **10 m** | must run **before** anything else |
+| manifest driver + `T27_MANIFEST_READY` | **5 m** | zero TestApp minutes |
+| `score_t27_w27.py --self-test` (both directions) | **10 m** | |
+| **`T27-V0` reproduction + `--protection off` FAIL end** | **15 m** | pure Python, 180 frames |
+| **`T27-V1` coordinate gate (both arms)** | **10 m** | |
+| **`RULE R27`** — B15 regenerates `table18` | **DONE, 349 s** | `R-IDENTICAL`, 20 cells / 420 files / 0 diffs. **Ran before pre-registration — declared as a deviation, §5.6a** |
+| **(B) S1/S2/S3 across 180 frames × 4 null offsets** | **40 m** | numpy rasterisation; the dominant cost is `D01`/`D18`'s ~12 k objects per frame |
+| **(B) total** | **~95 m** | **zero TestApp minutes** for the Python route |
+| **(D)** `RULE D27` — 7 cells at `--detection-binning 2` on B15 + `D27-V1` FAIL-end run | **~25 m** (of which **~2 m is compute**) | measured rate above; the cost is the gate and the write-up, not the runs |
+| (A) code + tests + three mutants | **50 m** | four disclosures, ported |
+| (A) build + provenance + `Q27-V1` + **B16 re-run of all 20 cells** (`S27-4`) | **35 m** | the 20-cell re-run is **~4 m** at the measured rate |
+| **(A) total** | **~85 m** | |
+| (C) document corrections, per `docs/wave27-register-correction-survey.md` | **30 m** | 5 FALSE + 3 STALE + 3 MISLEADING + 2 annotate-in-place |
+| full suite by COUNT (baseline **3973**, verified on this branch at HEAD, `/mnt/d/hf_w27/SUITE_BEFORE_3973.txt`) | **5 m** | (A) adds tests; **name the delta before anything is called green** |
+| results + register + commit + push + CI by COUNT | **45 m** | |
+| **TOTAL** | **~5 h** | against ~11.5 h remaining to the **00:45:17Z** stop |
+| *optional* full 42 m gate, if `Q27-V1` does not discharge | **+42 m** | affordable; run it if `Q27-V1` does not discharge |
+
+**Do NOT cut scope for time — the budget is not the binding constraint.** ~5 h of work against ~11.5 h remaining.
+**Cut only what the evidence does not support.** If the wave nonetheless overruns, the order is fixed here so it
+is not decided under pressure: (D) first (self-contained, census already taken, wave 28 inherits it whole), then
+(A)'s *build* half with (A)'s code+tests committed as a costed recommendation. **(B) and (C) are never cut** —
+(B) carries the finding, (C) is owed unconditionally.
+
+**(D) is IN.** One line: it costs ~2 minutes of compute on a binary already on disk, it is the only item that
+touches a *published* column of the owner's table, and deferring a two-minute item is how wave 19 lost `RULE C19`
+its verdict — *an item under two minutes is never dropped.*
+
+**What is NOT run, and its price:**
+
+| not run | price | why |
+|---|---|---|
+| **item 8** — recall on WIDE fields, re-denominated | **unpriced; needs a design** | untouched by wave 27 by construction (§2.5). Choosing new tier boundaries with the data in hand is behind the F14 fence, so it needs its own pre-registration |
+| regenerating the 180 `*.golden.json` to fix the `Reason` string | ~15 m of compute, **unbounded cost in credibility** | collides with fingerprint class 2 preservation and would invalidate every published precision/recall number in the series. §6.2 |
+| changing the shipped null to multiple offsets | ~20 m | would change every `bank-verify` number in the series. The variance bound is computed in the **scorer** instead, §4.3 |
+| the coordinate-alignment null (F31's 100 % / 2.3 % / 0 %) beyond `D09` | ~15 m | `T27-V1` answers the same question more directly, on all 20, with a run FAIL end |
+| the integrated-SNR discriminator | ~30 m | **rejected on the merits**, §2.2 — degenerate within-frame, already measured and superseded by `docs/golden-tier-plausibility-design.md` §2 |
+| a truth-based **recall** denominator | ~30 m marginal | `TruthProtection` leaves recall untouched *by design*; wave 27 has nothing to say about it and saying it anyway would be scope drift |
+
+---
+
+## 11. INSTRUMENT DISCIPLINE
+
+Every instrument lives in `/mnt/d/hf_w27/` with **LF endings**.
+
+* **`verify_derivation_w27.py` is a BLOCKING pre-flight** and runs before anything else. Widened from
+  `/mnt/d/hf_w26/verify_derivation_w26.py`. Its FAIL fixture is **pinned in source to the named root
+  `/mnt/d/hf_w26`** — *a regression fixture that is "whatever came before" has a shelf life of one wave*, and
+  wave 26 had to pin its own for exactly this reason. Its token pattern matches identifier tokens with **both an
+  optional `_prefix` and an optional `_suffix`**, because **`\b` cannot see `_`** and every marker, function and
+  path in this series is underscore-joined ([F80](followups.md), three demonstrated gaps).
+* **`score_t27_w27.py` REFUSES without `--out`** (rc = 2, nothing written). A stdout redirect puts the evidence
+  in a job-scoped temp directory that is deleted without ceremony; wave 25 lost its scoring artifact twice.
+* **Self-tests are never dispatched from a SOURCED file.** `layout_w27.sh` contains *no* `--self-test`
+  dispatcher; `layout_w27_selftest.sh` sources it and runs the checks. Wave 26's fired inside its caller's
+  `source` line, terminated it, and printed a clean PASS. **Read the OUTPUT, not the exit code** — every
+  self-test in this wave prints an explicit `SELFTEST … <n> of <n>` line and the plan checks that line.
+* **The driver writes the manifest; the scorer reads paths ONLY from it** and never rebuilds one from a template
+  ([F74](followups.md)). *A fallback rooted at the same wrong parent is not a second chance.*
+* **The interlock's writer is the code that computes the verdict.** `T27_MANIFEST_READY` is written by the
+  manifest driver, last, only after the 180/20/9 assertion passes. `T27_PASSED` is written by
+  `score_t27_w27.py` itself on `rc == 0` and only then — so the FAIL end is *unable* to leave one behind
+  ([F75](followups.md): an interlock whose writer is a human is a note).
+* **Assert the POPULATION SIZE everywhere**, and use `-print0 | sort -z | xargs -0` — `xargs` splits on the space
+  in `/mnt/d/Autofocus Bank`.
+* **Every ordinal and count in a derived instrument's output is COMPUTED, never typed** — `19`, `18`, `2`, `7`,
+  `20`, `180` all derive from the manifest or the metas at run time and are asserted.
+* Keep logs **ASCII**. Newtonsoft writes NaN/Infinity as the **strings** `"NaN"`/`"Infinity"`.
+
+---
+
+## 12. SATISFIABILITY SUMMARY — both branches, every clause
+
+| clause | PASS reachable? | FAIL reachable? | how it was checked |
+|---|---|---|---|
+| `T27-V0` reproduction | yes — the semantics are fully read from `GoldenEvalRunner.cs`/`GoldenMatch`/`TruthProtection` | **yes, and it is RUN** — `--protection off` on the same artifacts | executed, not argued |
+| `T27-V1-a` (bin 1 identity) | yes — the transform is provably the identity at `bin = 1` | yes — any reader error breaks it | 18 datasets |
+| `T27-V1-b` (bin 2 separation) | yes | **yes, and it is RUN** — the native arm on `D11`/`D12` is the FAIL end, printed | 2 datasets |
+| `T27-V3` pairing | yes | yes — self-test fixture mutates a row | |
+| `T27-V4` fingerprint | yes | yes — any byte change | BEFORE files already taken |
+| `T27-V5` path trap | yes | yes — `/mnt/d/hf_w25/table` exists and gives different numbers | the near-miss is real and named |
+| **S1 `A_all ≥ 0.25`** | **yes** — `D10` cannot exceed ~0.001 by arithmetic | **yes** — `D18`'s discs alone reach 0.47 | §4.2 density table |
+| **S2 `precisionNull ≥ 0.25`** | **yes** — F31 measured 0.000–0.012 on a sound metric | **yes** — on a saturated reference a decorrelated catalogue still protects | F31's published control |
+| **S3 `chanceProtected ≥ 0.25`** | **yes** — sparse datasets must be ~0 | **yes** — `D18`'s conditional coverage exceeds its 0.47 marginal | §4.2 |
+| ~~`excess = (p_obs − p_null)/(1 − p_null)`~~ | — | **NO — identically 1 on 19 of 20 datasets** | **REJECTED at design time as unsatisfiable, §4.1.** An unsatisfiable clause is a FINDING; this one is recorded here rather than shipped and discovered |
+| `T27-V6` reproducibility | **yes — already measured**, `D06`/`D08` 20 of 20 byte-identical | **yes, and it is OWED and RUN** — `D06` at `--match-radius 6` must break byte-identity | ~6 s |
+| `S27-1` route agreement (4 fields × 20 datasets) | yes | yes — a disagreement blocks the ship and is a finding about one route | |
+| `S27-2` mutants | yes | yes by construction | three named mutants |
+| `S27-4` byte-identity, 360 artifacts + 60 counts | yes — B15 and HEAD are C#-identical, so B16 = B15 + (A) exactly | yes — any moved byte or count blocks the ship | the strongest form available |
+| `S27-5` `truthViolations = 0` | yes — F31's repair guarantees it | yes — a non-zero value is a product finding | |
+| **`D27` `MOVED` at 0.01** | yes — the flag may be inert | yes — 0.01 is the last digit the table prints | 6-dataset verdict population |
+| `D27-V1` `PixelScale` carries the factor | yes | **yes, and it is RUN** — `D09` re-run *without* the flag must show the NOTE return and the `pixelScale:` line differ | executed |
+| `D27-V2` coordinate collapse | yes — published factor-1 recalls are 0.64–0.98, far above 0.25 | yes — a coordinate break drives recall to ~0 | |
+| `Q27-V1` reach-scoped discharge | yes — the diff is expected to be `GoldenEvalRunner.cs` + tests | **yes, and it is RUN** — the same check against `<B14 tree>..HEAD` must refuse | executed |
+
+**One clause was found unsatisfiable at pre-registration and is recorded as a finding rather than repaired into
+the wave** (§4.1). That is the discipline working before the data rather than after.

--- a/docs/synthetic-af-bank-followups-wave27-design.md
+++ b/docs/synthetic-af-bank-followups-wave27-design.md
@@ -897,7 +897,7 @@ Every instrument lives in `/mnt/d/hf_w27/` with **LF endings**.
 | **S2 `precisionNull ≥ 0.25`** | **yes** — F31 measured 0.000–0.012 on a sound metric | **yes** — on a saturated reference a decorrelated catalogue still protects | F31's published control |
 | **S3 `chanceProtected ≥ 0.25`** | **yes** — sparse datasets must be ~0 | **yes** — `D18`'s conditional coverage exceeds its 0.47 marginal | §4.2 |
 | ~~`excess = (p_obs − p_null)/(1 − p_null)`~~ | — | **NO — identically 1 on 19 of 20 datasets** | **REJECTED at design time as unsatisfiable, §4.1.** An unsatisfiable clause is a FINDING; this one is recorded here rather than shipped and discovered |
-| `T27-V6` reproducibility | **yes — already measured**, `D06`/`D08` 20 of 20 byte-identical | **yes, and it is OWED and RUN** — `D06` at `--match-radius 6` must break byte-identity | ~6 s |
+| `RULE R27` reproducibility | **yes — MEASURED, `R-IDENTICAL`**, 20 cells / 420 files / 0 diffs | **yes** — the comparator is demonstrated failing in both directions in `repro_all_w27.sh`'s own self-test | **ran before pre-registration; declared as a deviation, §5.6a** |
 | `S27-1` route agreement (4 fields × 20 datasets) | yes | yes — a disagreement blocks the ship and is a finding about one route | |
 | `S27-2` mutants | yes | yes by construction | three named mutants |
 | `S27-4` byte-identity, 360 artifacts + 60 counts | yes — B15 and HEAD are C#-identical, so B16 = B15 + (A) exactly | yes — any moved byte or count blocks the ship | the strongest form available |

--- a/docs/synthetic-af-bank-followups-wave27-results.md
+++ b/docs/synthetic-af-bank-followups-wave27-results.md
@@ -1,0 +1,1135 @@
+# Wave 27 — results
+
+## THE TIMESTAMPS, AND THE SEQUENCE — what was open, and what closed after it
+
+Wave 19's write-up was falsified by an artifact written 33 seconds before its own commit. So the roll call is
+taken **at an instant**, a row open at that instant is marked open **in place**, and when a row closes later the
+record shows the sequence rather than being rewritten.
+
+### Timestamp 1 — the first analysis pass
+
+```
+$ ls -la --time-style=full-iso /mnt/d/hf_w27/
+drwxrwxrwx  ...  2026-08-13 10:08:24.877146600 -0400 .
+   returned at 2026-08-13T10:09:14-04:00  (= 2026-08-13T14:09:14Z)
+```
+
+| row | state at **14:09:14Z** | later |
+|---|---|---|
+| `RULE T27` | **CLOSED** — `T27_PASSED` written 10:07:55 by the scorer itself | — |
+| `RULE D27` | **CLOSED** 09:31:37 | — |
+| `RULE R27` | **CLOSED** 09:14:37 | — |
+| `RULE S27-4` | **CLOSED** 10:02:40 | — |
+| `Q27-V1` | **CLOSED** 09:55:16 | — |
+| `RULE V27` | **CLOSED** 09:25:17 | — |
+| **full suite, AFTER** | **OPEN** — `suite_AFTER.marker` held `SUITE_AFTER_START 14:08:24Z` and **no `SUITE_EXIT=` line**; `suite_AFTER.log` was still growing (3 302 B at 10:08:34 → 3 342 B at 10:11:09) | **closed 10:12:15** |
+| **`T27-V4` fingerprint (class 4)** | **OPEN** — no `fp_table18_AFTER.txt`, no `fp_sidecars_AFTER.txt` existed | **closed 10:27:33 — and its first attempt was WRONG**, §7.1 |
+| **`score_t27_w27.py` self-test** | **NO ARTIFACT** — `t27_selftest.txt` did not exist; no file in the root contained `SELFTEST T27` | **closed 10:26:22**, §7.2 |
+| **`S27-2` mutants** | **NO ARTIFACT** — no run record of any mutant turning its tests red | **partly closed 10:26:22 — `M-S3` only**, §7.4 |
+| **`S27-1` route agreement** | **NOT ADJUDICATED**, by the scorer's own printed statement | **still not adjudicated**, §7.3 |
+| **half (A) itself** | **UNCOMMITTED** — 4 modified + 2 untracked files at `HEAD e95b7b0` | **still uncommitted**, §5.4 |
+
+**The AFTER suite, recorded as post-timestamp and not folded into the table above:** it closed at
+`2026-08-13 10:12:15 -0400` with `SUITE_EXIT=0`, `Failed: 0, Passed: 3992, Total: 3992`. Baseline was **3 973**
+(`SUITE_BEFORE_3973.txt`), so the delta is **+19**, and `TruthDisclosureTests.cs` carries exactly **19**
+`[Test]` attributes. The delta is named, as the design required, and it accounts for itself exactly. That is a
+statement about 10:12:15, not about 10:09:14.
+
+### Timestamp 2 — after the controller closed four of the open rows
+
+```
+$ ls -la --time-style=full-iso /mnt/d/hf_w27/
+drwxrwxrwx  ...  2026-08-13 10:26:41.832595800 -0400 .
+   returned at 2026-08-13T10:28:48-04:00  (= 2026-08-13T14:28:48Z)
+```
+
+Nothing was mid-write at that instant: the two most recent artifacts are `s27_score.txt` (10:27:52, the
+controller's annotation) and `fp_table18_AFTER.txt` (10:27:33), both complete, and no process was running.
+
+| closed between the two timestamps | new state | artifact |
+|---|---|---|
+| **`T27-V4`** | **`PRESERVED` — 800 of 800 byte-identical, 0 moved, 0 could-not-look.** **`RULE T27` now rests on 4 of its 4 gates.** Its *first* sweep returned a **false `VIOLATED`** — §7.1 | `fp_table18_AFTER.txt` |
+| **scorer self-test** | **`SELFTEST T27 72 of 72`**, plus an evidenced `--out` refusal | `t27_selftest.txt`, `t27_out_refusal.txt` |
+| **`S27-2`, `M-S3` only** | **RED, as designed**: `Failed: 3, Passed: 16, Total: 19`, the three named | `s27_2_mutant_MS3.log` |
+| **the contradictory `R27` banner** | annotated at the top of the file, with the artifact left otherwise intact | `s27_score.txt` |
+| **`TIMING.tsv`** | four missing rows filled in | `TIMING.tsv`, §10 |
+
+**Still open at timestamp 2, and marked open here:** `S27-1`'s route agreement (§7.3); `M-S1` / `M-S2a` /
+`M-S2b` mutant records (§7.4); half (A)'s commit (§5.4); and — the one that matters most — **the `S3`
+denominator contradiction, which is verdict-determining and cannot be closed by running anything** (below).
+
+---
+
+## THE HEADLINE METHODOLOGICAL FINDING: the design contradicts itself, and the contradiction changes the verdict
+
+**Applying the pre-registered design as written returns two different verdicts about the owner's precision
+column, depending on which of its two definitions of `S3`'s denominator a reader uses.**
+
+| where in the design | denominator | `SAT` | `CHANCE` | **verdict** |
+|---|---|---|---|---|
+| **§4.1**, statistics table | `Σ_f \|P_null(f)\| ÷ Σ_f \|R_null(f)\|` — the **shifted** at-risk pool | 1 (`D18`) | **0** | **`T-SOUND-WITH-NAMED-EXCEPTIONS`** |
+| **§4.4**, population table | `Σ\|P_null\| ÷ Σ\|R\|` — the **unshifted** at-risk pool | 1 (`D18`) | **6** | **`T-CHANCE-DOMINATED`** (clause 5) |
+
+The scorer computed §4.1's and **printed both**, naming the discrepancy rather than choosing silently. **This
+document does not choose either**, and the reason is not fastidiousness: choosing now, with both columns in
+hand, is repair-with-data-in-hand and the [F14](followups.md) fence forbids it.
+
+**The one piece of independent evidence that bears on it, recorded as diagnostic and NOT as authority:** under
+§4.4 three datasets return values **above 1.0** (`D17` = 10.0000, `D07` = 2.0000, `D12` = 1.0556), which no
+quantity the design describes as *"the fraction of the shifted at-risk pool the unshifted catalogue still
+protects"* can take — its numerator is drawn from the shifted pool and its denominator from the unshifted one, so
+it is not a fraction of any pool. That is diagnostic that §4.1 is the intended reading. **Diagnostic is not
+authority.** The next wave must **fix the rule first, in a pre-registration, and re-score afterwards** — on a
+population measured after the fix, not on this one. Full working in §8.2.
+
+---
+
+## §0 — What this document is allowed to say
+
+Every number below is quoted from an artifact in `/mnt/d/hf_w27/` or from a file in the repository, and each is
+cited. The pre-registered rules in `docs/synthetic-af-bank-followups-wave27-design.md` are **applied as
+written**. Where a rule turned out to be unsatisfiable, internally inconsistent, or gap-ridden, that is reported
+as a **finding** (§8) — it is not repaired, and no repaired version is scored.
+
+**Verdicts, in one table.**
+
+| rule | verdict | population | artifact |
+|---|---|---|---|
+| **`RULE T27`** | **`T-SOUND-WITH-NAMED-EXCEPTIONS`** | 19 datasets (D08 not blind) | `t27_score.txt` |
+| **`RULE D27`** | **`D-MOVED`, 6 of 6** | 6 datasets (D08 not blind) | `d27_score_controller.txt` |
+| **`RULE R27`** | **`R-IDENTICAL`** — 20 cells, 420 files, 0 diffs | 20 datasets | `repro_all_score.txt` |
+| **`RULE S27-4`** | **PASS** — 360/360 bytes, 20/20 counts, 20/20 sinks changed | 20 datasets | `s27_4_score.txt` |
+| **`Q27-V1`** | **GATE DISCHARGED**, FAIL end run | B15→B16 diff | `q27_v1.txt` |
+| **`RULE V27`** | **`V-CLEAN`** | 6 instruments | `vdrift_w27_FINAL.txt` |
+| `T27-V0` / `V1` / `V3` | pass / pass / pass | 20 / 20 / 180 rows | `t27_score.txt` |
+| **`T27-V4`** | **`PRESERVED`** — 800 of 800 byte-identical *(taken after timestamp 1; first sweep was a false `VIOLATED`, §7.1)* | 800 files | `fp_table18_AFTER.txt` |
+
+---
+
+## §1 — The headline is a correction to the backlog: item 1 was already done
+
+**The assigned top backlog item — *"re-measure precision against `*.truth.json`, not `*.golden.json`"* — shipped
+on 2026-08-03, ten days before it was written into the backlog.** Verified independently of the design:
+
+```
+$ git log --diff-filter=A -- Joko.NINA.Plugins/TestApp/SynthBank/TruthProtection.cs
+aaf26e8 2026-08-03 14:57:13 -0400 fix(bank-verify): stop charging false positives for real stars the golden dropped (F31)
+```
+
+Wave 26's `91.3 %` counted a **pre-repair** quantity. Its 150 decomposes as **50 `unresolved` + 89
+truth-protected + 11 surviving**, and the decomposition is now confirmed by a route the design did not use to
+derive it. The scorer's `--protection off` arm — which is simultaneously `T27-V0`'s demonstrated FAIL end and the
+measurement of the correction's size, one computation with two duties — reports:
+
+```
+D08_c11_2800mm  published TP=308 FP=11 FN=7   scorer TP=308 FP=100 FN=7   dFP=+89
+```
+— `t27_v0_failend.txt`
+
+**`+89` on the nose**, against the design's separately-derived 89. Two routes, one number. Across the whole
+population the same arm reports that **protection removed 350 detections from the false-positive pool**, and it
+names all ten datasets that carry any of it:
+
+| dataset | dFP with protection off |
+|---|---|
+| `D16_esprit550_ha3` | **+103** |
+| `D08_c11_2800mm` | **+89** *(not blind)* |
+| `D11_rc10_585_afbin2` | +44 |
+| `D05_tec140_1000mm` | +42 |
+| `D12_c14_585_afbin2` | +36 |
+| `D15_cdk20_3454mm_e47` | +18 |
+| `D09_c14_3800mm` | +11 |
+| `D07_rc10_2000mm` | +5 |
+| `D10_rc16_3250mm_sparse`, `D17_cdk14_oiii5` | +1 each |
+| **total** | **350** |
+
+The other **ten** datasets reproduce exactly even with protection off — they had no at-risk detection at all.
+That fact is load-bearing again in §8.2.
+
+**The banner on the owner's deliverable was false in the opposite direction from the truth.** It claimed the
+precision column was a **lower** bound; the column is already truth-corrected, so `1.000` is a **ceiling**. It
+was withdrawn in place in commit `e95b7b0`, together with the junk-count correction (**11, not 13**).
+
+---
+
+## §2 — `RULE T27` = **`T-SOUND-WITH-NAMED-EXCEPTIONS`**
+
+> `>>> RULE T27 = T-SOUND-WITH-NAMED-EXCEPTIONS -- honest except on ('D18_m24_deep_shed',), which are annotated in place as uninformative`
+> — `t27_score.txt`
+
+**Verdict population 19**, computed as `len(manifest_datasets) − len(NOT_BLIND)` and asserted, with
+`D08_c11_2800mm` measured and excluded. **`SAT` = 1, `CHANCE` = 0, union = 1, could-not-look = 0.** Clause 3 of
+the pre-registered tree (`1 ≤ SAT + CHANCE ≤ 4`).
+
+### 2.1 The gates, all three passed, both FAIL ends run
+
+| gate | result | FAIL end |
+|---|---|---|
+| **`T27-V0`** reproduction | **exact on 20 of 20**, 0 could-not-look | **RUN**: `--protection off` differs on 10 of 20 (`t27_v0_failend.txt`, rc non-zero by design) |
+| **`T27-V1`** coordinates | **V1-a bit-identical on 18 of 18**; **V1-b separated on 2 of 2** | **RUN**: the native arm on `D11` (1.000000 vs **0.002463**) and `D12` (1.000000 vs **0.025070**), both far past the 0.30 bar (`t27_v1_failend.txt`) |
+| **`T27-V3`** pairing | **180 of 180** | see §8.4 — the clause as written names a field that does not exist |
+| **`T27-V4`** fingerprint | **`PRESERVED` — 800 of 800 byte-identical, 0 moved** *(taken after timestamp 1)* | its own first sweep returned a **false `VIOLATED`**, caught by the population assertion — §7.1 |
+
+**All four gates now pass, so the verdict below stands on the full pre-registered set.** At timestamp 1 it stood
+on three of four, and that is recorded rather than overwritten.
+
+`T27-V1`'s `D08` row is worth naming: its binned and native rates are both `0.971616` — **identical, therefore
+passing V1-a**, but not 1.0. At `captureBinning = 1` the transform is the identity, so a rate below 1 is a
+property of the truth catalogue and the 12 px radius, not of the reader. The gate is doing exactly what it was
+built to do: it tests *agreement between the two copies*, not the absolute rate.
+
+### 2.2 `D18_m24_deep_shed` is `SATURATED-BY-NULL`, exactly where the design predicted the FAIL end was reachable
+
+| statistic | `D18` | bar |
+|---|---|---|
+| `precisionNull` (at the product's own `Δ1`) | **0.2820** | ≥ 0.25 → **fires** |
+| `A_all` | 0.2372 | ≥ 0.25 → does not fire |
+| `A_golden` / `A_protOnly` | 0.0435 / **0.1938** | — |
+| `chanceProtected` (§4.1 form) | 0.1312 | ≥ 0.25 → does not fire |
+| `Δ1` spread over the four offsets | 0.0158 | — |
+
+**The two statistics agree in direction, which the design required.** `A_all` at 0.2372 sits just under the same
+0.25 bar the null crosses — coverage is the mechanism, and **`A_protOnly` (0.1938) is four and a half times
+`A_golden` (0.0435)**, so on the densest field in the bank the correction's own discs, not the reference's boxes,
+are what fills the frame. `D18` carries 27 219 truth stars on a 6 248×4 176 frame — 1 043 stars/Mpx, the density
+the design named in advance as the one place a 0.25 bar was reachable.
+
+### 2.3 `D01_ultrawide_40mm` is the near-miss and must be named as such
+
+| statistic | `D01` |
+|---|---|
+| `precisionNull` | **0.2182** — **0.0068 below the bar** |
+| `A_all` / `A_golden` / `A_protOnly` | 0.1105 / 0.0360 / 0.0745 |
+| `Δ1` spread | 0.0115 |
+
+**The spread over the four offsets is 0.0115, and the distance to the bar is 0.0068.** A different single draw
+from the same family of offsets could have put `D01` over the bar. The rule reads `Δ1` because `Δ1` is what
+ships, and the rule is applied as written — but a reader who treats `D01` as "clean" is reading a margin
+narrower than the instrument's own single-draw variance. **`D01` is named as an exception-adjacent dataset, not
+a clean one.** The next densest, `D12` (`A_all` 0.1239), does not come close on the null (0.0199).
+
+### 2.4 The prediction was recorded in advance, and it was right
+
+> **Prediction P-W27.** `T-SOUND-WITH-NAMED-EXCEPTIONS`, with the exceptions drawn from
+> `{D18_m24_deep_shed, D01_ultrawide_40mm}` and at most one other. — design §4.6
+
+**Confirmed.** `D18` fired, `D01` is the near-miss, no third dataset came near. The design's two falsifiers both
+held: `D04`/`D02` did **not** fire (`A_all` 0.0522 / 0.0105; `precisionNull` 0.1175 / 0.0712), so the mechanism
+is density alone and no second explanation is owed; and `D10`/`D06` did **not** fire (`A_all` 0.0050 / 0.0026),
+so `T27-V0` is not covering for a broken scorer.
+
+### 2.5 What the owner gets
+
+**The precision column is honest as published, on 18 of the 19 blind datasets.** `D18`'s `1.000` is
+uninformative and must be annotated in place with its `A_all` 0.2372 / `precisionNull` 0.2820 / `chanceProtected`
+0.1312. `D01`'s `1.000` carries the near-miss caveat of §2.3. **`D08`'s `0.966` stands as honest at factor 1** —
+and see §4.3 for what happens to it at the optimizer's own factor.
+
+---
+
+## §3 — `scoredFraction` is the quiet finding, and no reader could see it before half (A)
+
+`scoredFraction = Σ(|TP| + |FP|) ÷ Σ|D|` — the fraction of the detections that entered the precision ratio at
+all. It was **reported alongside, not thresholded**, so it moves no verdict. It is nonetheless the most
+consequential number in `t27_score.txt`:
+
+| dataset | `scoredFraction` | published precision |
+|---|---|---|
+| **`D12_c14_585_afbin2`** | **0.6462** | 1.000 |
+| **`D08_c11_2800mm`** | **0.6965** | 0.966 |
+| **`D11_rc10_585_afbin2`** | **0.7315** | 1.000 |
+| **`D16_esprit550_ha3`** | **0.7438** | 1.000 |
+| **`D15_cdk20_3454mm_e47`** | **0.7531** | 1.000 |
+| **`D09_c14_3800mm`** | **0.8132** | 1.000 |
+| `D10_rc16_3250mm_sparse` | 0.8605 | 1.000 |
+| `D17_cdk14_oiii5` | 0.9100 | 1.000 |
+| the other twelve | 0.9413 – 0.9948 | — |
+
+**More than a third of `D12`'s detections never entered its precision ratio, and its published precision is
+`1.000`.** The number is a ratio over the two-thirds that were judged; the other third was neither confirmed nor
+charged. That is not wrong — it is the documented behaviour of `ExcludeUnresolved` plus `TruthProtection` — but
+**until half (A) it was unreportable**: a grep of `/mnt/d/hf_w25/table18/*.log`, `golden_eval.txt` and
+`golden_eval_frames.csv` for `scoringMode` / `protected` / `precisionNull` returns zero hits. The instrument that
+produced the owner's table could not say what fraction of the detections it had judged.
+
+**This is the strongest single argument for half (A) and it is now measured rather than argued.**
+
+### 3.1 `NULL-UNDER-POWERED` — a state the design did not anticipate, on 7 datasets
+
+The design fixed the rule: *"if the spread on any dataset exceeds that dataset's own `Δ1` value, the shipped null
+is recorded as UNDER-POWERED on that dataset and the dataset becomes a named caveat rather than a verdict
+input"* (§4.3). It fired on **seven**: `D08` *(not blind)*, `D09`, `D11`, `D12`, `D13`, `D14`, `D16` — six of
+them inside the verdict population.
+
+**What it means for those rows.** On each, the four sign-variant offsets disagree with one another by more than
+the value the rule reads. `D09` is the clearest: `precisionNull` = 0.0000 at `Δ1`, spread **0.0148**. The
+shipped single-offset control cannot distinguish *"this dataset has no chance protection"* from *"this offset
+landed in a quiet corner"*. **On those six the `precisionNull` column is a draw, not a measurement**, and the
+correct reading of a `SOUND` result there is *"not shown to be saturated"*, never *"shown to be sound"*.
+
+**It does not move the verdict**, and the check that it does not is worth stating: `D18`, the only dataset that
+fires a bar, is **not** under-powered (0.2820 against a spread of 0.0158, an 18:1 ratio). Removing all six
+under-powered datasets from the verdict population leaves `SAT` = 1, `CHANCE` = 0 and clause 3 still selected.
+
+**But the design never says what the count denominator becomes when a dataset is demoted to "named caveat rather
+than verdict input", and that is a gap** (§8.5). It is inert this wave only because the demoted six were all
+non-firing.
+
+### 3.2 Two `CNL-NODET` frames, named and not subtracted
+
+```
+CNL-NODET : 2
+    D12_c14_585_afbin2 f19436  the detection dump has a header and zero data rows
+    D12_c14_585_afbin2 f20564  the detection dump has a header and zero data rows
+```
+
+Both are `D12`'s extreme wing frames. They contribute 0 to every numerator **and** every denominator and are
+counted in `frames_no_detections`, per §4.4 and §7. They are named here rather than quietly folded away —
+`D12` is also the dataset with the lowest `scoredFraction` in the bank, and a reader comparing `D12` against
+anything else is comparing 7 frames' detections against another dataset's 9.
+
+---
+
+## §4 — `RULE D27` = **`D-MOVED`, 6 of 6**
+
+> `>>> RULE D27 = D-MOVED (6 of 6)` — `d27_score_controller.txt`
+
+Seven published rows were scored at detection binning **1** while the optimizer's own physics-derived factor is
+**2**; `golden eval` printed *"Pass `--detection-binning` to score it at its own factor"* on every one of them
+and nobody acted. Re-scored on **B15** (`TestApp.dll` sha256 `2fb0c8fd…`, **no build**), 7 cells / 63 frames,
+`13:29:15Z → 13:30:04Z` — **49 seconds of compute**.
+
+### 4.1 Both gates passed, and `D27-V1`'s FAIL end was run on a real cell
+
+| gate | result |
+|---|---|
+| **`D27-V1`** `PixelScale` carries the factor | logs printing `; detectionBinning 2`: **7 of 7**; logs still printing the `scored at 1` NOTE: **0 of 7** |
+| **`D27-V1` FAIL END, RUN** | `D09` re-run *without* `--detection-binning` (`pinprobe/D09.log`): **NOTE present = True** |
+| **`D27-V2`** coordinate collapse | min `recall@all` at factor 2 = **0.729** (bar 0.25) |
+
+### 4.2 The moves, all six
+
+| dataset | factor 1 (published) | factor 2 | delta |
+|---|---|---|---|
+| **`D14_cdk14_2563mm_e47`** | `Rall 0.641` `Rhi 0.862` | **`Rall 0.937`** `Rhi 0.995` | **+0.296** |
+| **`D17_cdk14_oiii5`** | `Rall 0.875` | `Rall 1.000` | **+0.125** |
+| `D09_c14_3800mm` | `Rall 0.949` `Rhi 0.911` | `Rall 0.991` **`Rhi 1.000`** | +0.042 |
+| `D10_rc16_3250mm_sparse` | `Rall 0.965` | `Rall 1.000` | +0.035 |
+| `D12_c14_585_afbin2` | `Rall 0.705` `Rhi 0.720` | `Rall 0.729` `Rhi 0.776` | +0.024 |
+| **`D15_cdk20_3454mm_e47`** | `Rall 0.961` `Rhi 0.920` | `Rall 0.949` **`Rhi 0.885`** | **−0.012** |
+
+Precision moved on none of the six (`dP = +0.000` throughout). **`D15` moved the wrong way** and is the reason
+the bar was two-sided: at the optimizer's own factor `D15` finds *fewer* high-tier stars. `D-MOVED` is not
+`D-BETTER`.
+
+### 4.3 `D08` is not blind, and its factor-2 number needs a careful sentence
+
+`D08` was measured and excluded from the count, as required. At factor 2 it reads:
+
+```
+OVERALL: TP=315 FP=1 FN=0  precision=0.997 recall=1.000   (table18_b2/D08_c11_2800mm.log)
+OVERALL: TP=308 FP=11 FN=7 precision=0.966 recall=0.978   (published, factor 1)
+```
+
+**Ten of the eleven "genuine wing-frame junk" detections do not survive at binning 2.** The junk is a
+factor-1 artifact.
+
+**And the withdrawn banner's number reappears by coincidence, which must be said out loud so nobody mistakes it
+for vindication.** The banner claimed *"D08's true precision is nearer 0.997 than the 0.966"* — and factor 2
+gives exactly **0.997**. The banner's reasoning was wrong (it counted a pre-repair FP quantity and inferred a
+lower bound); the agreement of the digits is an accident of a different, legitimate instrument change. **The
+banner stays withdrawn.**
+
+**Consequence for the record, flagged not fixed:** commit `e95b7b0` states that `F83`'s caveat 3 is discharged
+in its own favour because *"the +0.034 is real"*. That is true **at factor 1**. At the optimizer's own factor the
+same dataset's precision cost is **+0.003**. Any future quotation of `+0.034` must carry its factor label, or it
+will be read as factor-independent when `RULE D27` — run in the same commit — shows it is not.
+
+---
+
+## §5 — Half (A): the port ships, proved at byte level, with the gate discharged rather than skipped
+
+### 5.1 `RULE S27-4` = **PASS**, and the port is **not inert**
+
+```
+detection artifacts byte-identical : 360 of 360
+TP/FP/FN unchanged                 : 20 of 20 datasets
+report sinks CHANGED (expected)    : 20 of 20 datasets
+>>> S27-4 = PASS -- the change is report-only, proved at byte level
+>>> and the port is NOT INERT: 20 of 20 report sinks changed
+```
+— `s27_4_score.txt`
+
+The raw byte comparison behind it (`s27_score.txt`) reports **420 files compared, 380 identical, 40 differ** —
+and the 40 are **exactly the two report sinks × 20 datasets**, every one named in the artifact. *That is the
+port working.* A reporting change that moved a score would have been a bug, and `S27-4` makes that statement
+falsifiable rather than argued: 360 detection artifacts and 60 counts, unmoved.
+
+### 5.2 `Q27-V1` = **GATE DISCHARGED**, with its FAIL end run
+
+The 42-minute `optimize` gate is **owed** whenever the wave builds. It was discharged on the pre-registered
+reach-scoped basis, not skipped:
+
+```
+--- INTERSECTION (B16) --- (empty)
+>>> Q27-V1 = GATE DISCHARGED: no changed file is reachable by the gate's path.
+
+=== Q27-V1 FAIL END, RUN: the same check against the B14 tree ===
+intersection is NON-EMPTY (2 files) ... StarDetectionOptimizerWizardVM.cs, StepSizeRecommender.cs
+>>> FAIL END DEMONSTRATED: the same predicate REFUSES on a diff that reaches the gate.
+```
+— `q27_v1.txt`
+
+**The discharge is not a pass and is not reported as one.** What replaces it is `Q27-V0`-shape hash identity plus
+`S27-4`'s byte-identical detection artifacts — a strictly sharper control *for this change* than an `optimize`
+gate would have been, because it measures the actual instrument on the actual population.
+
+### 5.3 Binary discipline
+
+`binary_provenance_w27.txt`, `13:54:46Z`: B16 `TestApp.dll` **`2d8e11f4…`**, plugin dll **`01ba4b36…`**, both
+distinct from B15's `2fb0c8fd…` / `3fd1fc4b…`; the shipped `synthetic-bank-spec.json` unchanged; **`find … -name
+'*.cs' -newermt <build mtime>` empty**; the apphost recorded for the record only, per [F66](followups.md).
+
+### 5.4 Half (A) is written and tested but **not committed**
+
+At the timestamp — and now — the working tree carries 4 modified files (`BankVerifyRunner.cs`,
+`GoldenEvalRunner.cs`, `GoldenFromTruth.cs`, the test `.csproj`) and 2 untracked
+(`TestApp/SynthBank/TruthDisclosure.cs`, `Tests/Golden/TruthDisclosureTests.cs`) against `HEAD e95b7b0`, which
+carries only halves (C) and (D). **The port is proved and unshipped.** Marked open in place.
+
+### 5.5 `M-S2` reaches two sites, unequally guarded — say so plainly
+
+`M-S2` (hard-code `scoringMode = "golden"`) has two change sites, and only one is guarded behaviourally.
+
+* **The shared helper `TruthDisclosure.ScoringMode`/`ScoringLine`** is killed by real behaviour: three tests
+  exercise it in both directions (`ScoringMode_SaysTruthProtected_IffAFrameCarriedATruthSidecar`,
+  `ScoringLine_IsBankVerifysWording_Verbatim_InBothDirections`,
+  `ReportLines_SayTheModeIsGoldenAlone_WhenNoSidecarExists`).
+* **The `GoldenEvalRunner` call site is guarded only by a SOURCE-TEXT assertion.** `TruthDisclosureWiringTests`
+  reads `GoldenEvalRunner.cs` off disk, strips comments, and asserts
+  `Does.Not.Contain("scoringMode = \"golden\"")`. Its own class doc states the reason: the runner *"cannot be
+  linked into this project (it loads NINA rendered images)"*.
+
+**A source-text assertion catches the literal it was told to look for and nothing else.** A mutant that
+hard-coded the label with different spacing, a different quote style, or through a local variable would pass
+this test while producing exactly the defect. The guard is honest about being textual — it is the same mechanism
+`TestAppOutputAsciiTests` uses — but it is **not** a behavioural mutant kill, and the two must not be counted as
+one. The tests do read defensively: `ReadTestAppSource` fails rather than skips when the file is absent or
+suspiciously short (*"a test that cannot look must not pass"*).
+
+---
+
+## §6 — The controls
+
+### 6.1 `RULE R27` = **`R-IDENTICAL`**, and it ran **before** pre-registration
+
+**20 cells, 420 files compared, 420 byte-identical, 0 differences, 0 could-not-look** (`repro_all_score.txt`).
+`golden_eval.txt` is compared with its `reports ->` line removed — that line embeds the `--out` path and differs
+by construction; the ignored substring is declared in source and self-test [3] demonstrates that a change
+*outside* it is still caught, so the filter is not a blanket.
+
+**Declared deviation, not laundered.** `R27` ran at `13:14:24Z`, before the pre-registration commit `df68232`.
+The reasoning is recorded in `CONTROLLER_NOTE.md` §7 and adopted by design §5.6a: it is a determinism control on
+the instrument, reads no statistic in T27's verdict tree, and a byte-comparison of a regenerated population has
+exactly one interesting outcome. **It is reported as opportunistic rather than pre-registered, in the same
+sentence that quotes `R-IDENTICAL`.**
+
+What it buys is real and it is load-bearing twice: half (B) may treat the 180 `detected_f*.csv` as a stable
+population, and **`S27-4` becomes attributable** — with `R-IDENTICAL` in hand, any byte difference between B16
+and `table18` is the treatment and cannot be run-to-run noise.
+
+### 6.2 `RULE V27` = **`V-CLEAN`**, after the pre-flight caught a fourth gap in itself (§7.5)
+
+`vdrift_w27_FINAL.txt`: 6 files checked, `V27-A` 3 of 3 siblings resolve, `V27-B` **0** unlicensed
+previous-wave tokens, `V27-C` **0** typed ordinals. Re-run after (D) (`v27_d27.txt`, 7 files) and after (A)
+(`v27_s27.txt`, 9 files) — `V-CLEAN` on both. Self-test PASS with all six clause groups including the new
+`[6]`, which demonstrates both ends: *"the block is exempt (line 3) and the file after it is NOT (line 7)"* and
+*"the DEFINITION of `HISTORICAL_BLOCKS` opens nothing — it is not an instance of itself"*.
+
+### 6.3 Layout and manifest
+
+`layout_selftest.txt`: **`SELFTEST LAYOUT27 16 of 16`**, including four explicit FAIL ends (`assert_count`
+rejecting a mismatch; the population assertion rejecting 19 datasets; the near-miss root named and refused).
+`T27_MANIFEST_READY`: `datasets=20 rows=180 b2=7 root=/mnt/d/hf_w25/table18`. The `T27-V5` path trap held —
+every artifact header names `/mnt/d/hf_w25/table18` and declares `/mnt/d/hf_w25/table` as the refused near miss.
+
+---
+
+## §7 — FINDINGS: each is a defect in an instrument or a rule. Reported, not repaired
+
+### SEVERITY 1 — the control that was missing, then wrong, then right
+
+#### 7.1 `T27-V4` (fingerprint class 4): **absent at timestamp 1, falsely `VIOLATED` on its first sweep, `PRESERVED` on its second**
+
+**At timestamp 1 the gate had not been taken.** Design §5.5 requires AFTER fingerprints *"written at the wave's
+close and kept"*, with any difference forcing `T-UNEVALUATED`; neither file existed. Verdict-tree clause 1 names
+`T27-V4` alongside `V0`/`V1`/`V3`, so `RULE T27`'s verdict then rested on **three of its four** gates. The
+scorer was scrupulous about not claiming what it had not done:
+
+> `--- T27-V4 : fingerprint (class 4) is taken OUTSIDE this scorer, by the wave's fp driver.`
+> `  This scorer does not evaluate it and does not claim it.`
+
+**The first AFTER sweep then returned `T27-V4 = VIOLATED`, and it was WRONG — an addressability error in the
+instrument, not a deletion in the population.** The AFTER sweep omitted the **20 `.log` files** that the BEFORE
+sweep had captured, so it compared 780 paths against a BEFORE list of 800 and reported the 20 absentees as moved.
+**Nothing on disk had changed.** The only reason it surfaced rather than shipping as a fake violation is the
+design's standing rule that the **population size is asserted inside the file** — the mismatch was arithmetic,
+not a judgement call.
+
+**This is [F74](followups.md)'s shape in the BEFORE/AFTER direction**, and it generalises past this wave: *a
+BEFORE/AFTER control whose two sweeps are built by different expressions is not comparing a population against
+itself; it is comparing two populations, and every difference it reports is unattributable.* Registered as
+[F91](#f91).
+
+**The corrected sweep passes outright** (`fp_table18_AFTER.txt`, taken `14:27:17Z`):
+
+```
+--- class 4a: table18 artifacts, population 400 (expect 400) ---
+BEFORE 800   AFTER 800   compared 800
+missing from AFTER: 0   extra in AFTER: 0   DIFFERING: 0
+>>> T27-V4 = PRESERVED -- 800 of 800 byte-identical, 0 moved, 0 could-not-look
+```
+
+800 = 400 `table18` artifacts + 20 logs + 180 `*.truth.json` + 180 `*.golden.json` + 20 `synthetic_meta.json`,
+matching `fp_table18_BEFORE.txt` + `fp_sidecars_BEFORE.txt` exactly. **`RULE T27` now rests on 4 of its 4
+pre-registered gates.** The wave read `table18` and the bank sidecars and wrote only into `/mnt/d/hf_w27/`, and
+that is now proved rather than assumed.
+
+**Both outcomes are recorded because the sequence is the finding.** A control that reported a false violation
+and was corrected is a stronger record than one that passed first time, provided the false reading is kept.
+
+**Independently corroborating, and it was already in hand:** `RULE R27` proves B15 *regenerates* all 420
+`table18` files byte for byte — a stronger statement than "the bytes have not changed since someone wrote them".
+
+### SEVERITY 2 — instruments whose evidence was not on disk
+
+#### 7.2 The `T27` scorer's self-test had **no artifact at timestamp 1**; it now has one
+
+At timestamp 1, `t27_selftest.txt` did not exist and no file under `/mnt/d/hf_w27/` contained the string
+`SELFTEST T27` — it appeared only at `score_t27_w27.py:1920`, in the code that would print it. The design's §11
+rule is explicit: *"every self-test in this wave prints an explicit `SELFTEST … <n> of <n>` line and the plan
+checks that line"* — **read the OUTPUT, not the exit code**, which is precisely wave 26's lesson about a
+self-test that exited its caller while printing PASS. The self-test had been run and read in the terminal; it
+had **not been captured**, so no reader after the session could check the line.
+
+**Closed at 10:26:22.** `t27_selftest.txt` ends:
+
+```
+SELFTEST T27 72 of 72
+```
+
+and the 72 include both ends of every clause on constructed fixtures — among them
+`T27-V0/FAIL-end-protection-off-DIFFERS`, `T27-V1-b/FAIL-arm-native-copy-collapses`,
+`S27-4/FAIL-end-one-moved-byte-blocks-the-ship`, `S27-1/an-absent-disclosure-is-CNL-FIELD-and-is-NAMED`,
+`null/shifts-the-DETECTIONS-not-the-catalogue`, and `lattice/stride-four-offset-two-and-a-full-cover-reads-one`.
+The `--out` discipline is separately evidenced in `t27_out_refusal.txt`: invoking the scorer without `--out`
+produces `error: the following arguments are required: --out`, **rc 2, nothing written** — wave 25's defect,
+closed and now demonstrated rather than asserted.
+
+**The residual lesson stands and is worth carrying:** a self-test whose output is never redirected to a file is
+a self-test that exists only for the session that ran it. The scoring path made `--out` mandatory; the
+`--self-test` path did not, and that asymmetry is what produced a two-hour gap between the check being run and
+the check being checkable. Contrast the sibling instruments, which captured theirs from the start:
+`layout_selftest.txt` (`16 of 16`) and `vdrift_selftest_FINAL.txt`.
+
+#### 7.3 `S27-1`'s route agreement was **not adjudicated**, by the scorer's own printed statement
+
+```
+S27-1 route agreement is NOT adjudicated here: this scorer does not know the port's chosen
+  wording, and comparing against a guess would be a second route to the same wrong answer.
+  Run --rule T27 --full and compare its per-dataset scoredFraction / precisionNull directly.
+```
+— `score_t27_w27.py:1252-1254`
+
+The refusal is well-reasoned — guessing the port's wording would manufacture exactly the false agreement
+[F79](followups.md) warns about — and the scorer does emit `S27-1 CNL-FIELD` for any disclosure it cannot find
+under a spelling it knows. **But `S27-1` is the clause the design made a ship gate**: *"(A) does not ship until
+the wave says which is right."* No artifact adjudicates it. The comparison it points at is straightforward
+(`t27_score.txt` already carries per-dataset `scoredFraction` and `precisionNull` at `Δ1`, and B16's
+`golden_eval.txt` files exist under `s27_after/`), so this is **~10 minutes of unblocked work**, not a
+re-measurement.
+
+#### 7.4 `S27-2`: **`M-S3` now has a run record; `M-S1`, `M-S2a` and `M-S2b` remain testimony**
+
+At timestamp 1 no artifact recorded any mutant turning a test red. The tests existed and were well-aimed (19,
+each doc-commented with the mutant it kills) and the suite was green at 3 992 — but *green tests are not a mutant
+kill*, and the design's FAIL end for `S27-2` is *"a mutant that does not turn its test red means the test does
+not reach the code."*
+
+**`M-S3` is now evidenced** (`s27_2_mutant_MS3.log`, 10:26:22), re-verified by the controller rather than
+inherited from the implementing agent. Returning the unshifted detections from the null path turns exactly three
+tests red:
+
+```
+Failed!  - Failed: 3, Passed: 16, Skipped: 0, Total: 19
+  PrecisionNull_IsWhatChanceAloneScores_NotTheLivePrecision
+  ReportLines_CarryAllFourDisclosures_PlusTheExercisedCount
+  CsvHeaderAndRow_AgreeOnFieldCountAndOrder
+```
+
+and the failure text shows the defect directly — the report block prints `precisionNull: 0.500` where the fixture
+requires `0.000`, i.e. **the null has become the live precision**, which is the whole point of `M-S3`. The
+mutant reaches the code.
+
+**Three qualifications, all of which keep this short of a clean `S27-2` pass:**
+
+1. **`M-S1`, `M-S2a` and `M-S2b` have no artifact.** They remain agent testimony. Given [F89](#f89) — a
+   mutation harness that restored with `cp -p` and silently re-measured the mutant — untested testimony from
+   that harness is exactly the class of claim that needs an artifact.
+2. **The restore verification is also testimony.** The controller reports sha256 `7f3306ad…` before and after
+   and a green re-run; **neither is in `s27_2_mutant_MS3.log`**, which contains only the RED run.
+3. **The reported green re-run is `21/21`, but the RED run's own artifact says `Total: 19`.** A restore check
+   that runs a different-sized population than the mutant run is not a restore check *of that population*. The
+   discrepancy is unexplained by any artifact and is flagged, not resolved.
+
+Related and unchanged: **§5.5's finding that `M-S2`'s second site is guarded only by a source-text assertion**.
+Price to close the remainder: **~10 minutes** (three mutants, one build each, output redirected).
+
+### SEVERITY 2 — a checker that had disabled itself
+
+#### 7.5 [F80](followups.md)'s checker had a **FOURTH** gap, and this one had switched the check **OFF**
+
+`in_historical_block()` scanned backwards for any line *containing* a `HISTORICAL_BLOCKS` token and treated it
+as opening a historical literal — **but the line that DEFINES `HISTORICAL_BLOCKS` contains every one of those
+tokens.** From that definition line to EOF, `V27-B` was off.
+
+**The evidence, both ends, on disk:**
+
+| | artifact | reading |
+|---|---|---|
+| **before** | `vdrift_w27_run1.txt` | header prints **`=== RULE V26 ===`** on a wave-27 root; `V26-B: unlicensed previous-wave tokens: **0**`; verdict **`V-CLEAN`** |
+| **after** | `vdrift_w27_run2.txt` | **32** `[V26-B]` findings, every one on `verify_derivation_w27.py` itself; verdict `V-DRIFT: 32 finding(s). BLOCKING` |
+| **raw** | `verify_derivation_w27.py.bak` | the pre-repair file contains **69** literal `V26` occurrences; the repaired file contains **2** |
+| **fixture** | `vdrift_selftest_FINAL.txt` `[5b]` | the design's pinned `/mnt/d/hf_w26` root refuses with **255** `V27-B` findings |
+
+**The checker declared itself clean while printing the previous wave's rule name in its own banner.** That is
+the exact defect F80 exists to catch, catching nothing, on itself.
+
+**The class is new, and it is not the `_`-word-boundary family of the first three gaps:**
+
+> **A rule that describes itself must exclude itself from its own population, or it launders its own subject.**
+
+The first three gaps were about a *pattern* being too narrow (`\b` cannot see `_`). This one is about a
+*population* silently containing the instrument, so the instrument's own definition of what to look for became a
+licence to stop looking. Closed, with self-test clause `[6]` demonstrating both ends. Two FAIL fixtures are now
+pinned — `hf_w24` (kept) and the design's `hf_w26` (**added**, not swapped).
+
+**Two figures in the controller's first account were challenged and are corrected here, with the controller's
+agreement:**
+
+* **"53 surviving `V26` tokens" is withdrawn.** It was a `grep -c` of *lines* containing `V26` taken before the
+  repair — **a third quantity**, neither the findings count nor the occurrence count, and not evidenced as
+  stated. **Quote instead: 32 findings after the repair, over 69 raw `V26` occurrences** in
+  `verify_derivation_w27.py.bak`.
+* **"204 → 255" becomes "255, plus testimony."** The **255** is on disk (`vdrift_selftest_FINAL.txt` `[5b]`) and
+  stands. The **204** was really read, in the pre-repair run's stdout — but **that artifact was not kept**
+  (`vdrift_selftest_run2.txt` has no `[5b]` clause; it was added later), so it is testimony, not evidence, and
+  is labelled as such.
+
+**Neither figure is load-bearing, and that is the point worth keeping.** The fully-evidenced fact needs no
+count at all: **the checker certified its own file `V-CLEAN` while printing the previous wave's rule name in its
+own banner, on a wave-27 root.** `vdrift_w27_run1.txt` against `vdrift_w27_run2.txt` proves it outright.
+
+### SEVERITY 3 — traps worth registering
+
+#### 7.6 `git diff --name-only <tree>` does **not** list untracked files
+
+A two-binary provenance diff can therefore silently omit an entire new source file. **It did here**:
+`binary_provenance_w27.txt`'s tracked diff lists 3 files, and `TruthDisclosure.cs` — the whole substance of half
+(A) — is **not among them**, because it was untracked at build time. `q27_v1.txt` takes the **union** of the
+tracked diff and `git ls-files --others`, and reports 5 files. Had `Q27-V1` used the tracked diff alone, it
+would have computed its reachability intersection over a change set missing the new file. **This belongs beside
+[F66](followups.md)** — same shape, different mechanism: a provenance instrument that reports confidently on an
+incomplete population.
+
+#### 7.7 A mutation harness that restores with `cp -p` restores the **pre-mutation MTIME**
+
+MSBuild then skips the recompile and the next run silently re-measures the mutant. It made a correctly-restored
+tree look broken. Remedy: `touch` after every restore; sha256 still guards the content.
+
+**Reported as a controller process finding: no artifact in `/mnt/d/hf_w27/` records it.** It is registered
+because the failure mode is real, general, and expensive — a mutation arm that cannot restore is a mutation arm
+whose results are all suspect — but a reader should know its evidence is testimony, not a file. It is also the
+likeliest reason §7.4 has no artifact.
+
+#### 7.8 A reused scorer emitted **the other rule's verdict banner** — now annotated
+
+`s27_score.txt` — the raw byte comparison behind `S27-4` — is `score_repro_w27.py`, the **`RULE R27`
+comparator**, pointed at the S27 population. That scorer emits its own rule name **unconditionally**, so its
+last line reads `>>> RULE R27 = R-DIFFERS (40 files)`.
+
+**For a period the record carried two contradictory `R27` verdicts**: `R-IDENTICAL` in `repro_all_score.txt`
+(the real `R27`, B15 vs `table18`) and `R-DIFFERS` here (a different comparison entirely, B16 vs `table18`).
+Both computations are correct about their own populations — the 40 differing files are exactly the two report
+sinks × 20 datasets, which is half (A) working — but a reader grepping `RULE R27 =` found a contradiction.
+
+**Closed at 10:27:52 by annotation, not by deletion**, which is the right repair: the file now opens with a
+controller banner reading *"THIS FILE'S `>>> RULE R27 = R-DIFFERS` BANNER IS WRONG FOR THIS ARTIFACT AND MUST NOT
+BE QUOTED"*, explains the reuse, and points at `s27_4_score.txt` as the scored clause. The wrong banner is left
+in place at the foot of the file so the record shows what happened.
+
+**The lesson, and it belongs with [F74](followups.md)'s family rather than [F80](followups.md)'s:**
+
+> **Reuse the computation, never the banner — or the artifact lies about which rule it evaluated.**
+
+F80's class is *prose that stops describing the instrument*. This is sharper and more dangerous: the
+**verdict line itself** — the one line a future reader greps for — was correct for the code and wrong for the
+run. Registered as [F90](#f90).
+
+---
+
+## §8 — What the design left unsatisfiable or gap-ridden
+
+**Each is reported, not repaired. None was re-decided to make a verdict land.** The common remedy is the same in
+every case and it has an order: **fix the rule first, in a pre-registration, and re-score afterwards — on a
+population measured after the fix.** Repairing a rule with this wave's columns in hand, then harvesting a verdict
+from the same numbers, is the pattern the [F14](followups.md) / [RULE D20](waves22+-handoff-prompt.md) fence
+exists to forbid.
+
+| # | defect | fired this wave? | verdict-determining? |
+|---|---|---|---|
+| §8.2 | **`S3`'s denominator is defined twice, incompatibly** | **yes** | **YES — `T-SOUND-WITH-NAMED-EXCEPTIONS` vs `T-CHANCE-DOMINATED`** |
+| §8.1 | the verdict tree has an uncovered region | no | would be, if it fired |
+| §8.3 | `CNL-EMPTYPOOL` is unreachable under the denominator used | n/a | no |
+| §8.4 | `T27-V3` names a field one sidecar does not have | yes | no |
+| §8.5 | a demoted dataset's effect on the count denominator is undefined | yes (6 datasets) | no, this wave only |
+| §8.6 | `S27-1` names four fields; five ship | yes | no — blocks a ship clause |
+| §8.7 | one clause found unsatisfiable **at pre-registration** | n/a | the discipline working |
+
+### 8.1 The verdict tree has a **GAP**, and the scorer emits `T-TREE-GAP` for it
+
+`SAT = 3, CHANCE = 3` disjoint (union 6) matches **no clause**: clause 3 caps the union at 4, clause 4 needs
+`SAT ≥ 5`, clause 5 needs `CHANCE ≥ 5`. The scorer refuses to paper over it:
+
+```python
+verdict = "T-TREE-GAP"
+tail = ("the PRE-REGISTERED verdict tree does not cover SAT=%d CHANCE=%d union=%d. An incomplete rule"
+        " is a FINDING, not something to repair and re-score.")
+```
+— `score_t27_w27.py:1040-1042`
+
+**It did not fire this wave** (`SAT = 1`, `CHANCE = 0`). It is a real defect and the whole uncovered region is
+reachable: any outcome with `3 ≤ union ≤ 9` where neither set alone reaches 5 falls into it.
+
+### 8.2 `S3`'s denominator is inconsistent **inside the design**, and the discrepancy is **VERDICT-DETERMINING**
+
+| where | denominator |
+|---|---|
+| §4.1, statistics table | `Σ_f \|P_null(f)\| ÷ Σ_f \|R_null(f)\|` — the **shifted** at-risk pool |
+| §4.4, population table | `Σ\|P_null\| ÷ Σ\|R\|` — the **unshifted** at-risk pool |
+
+The scorer used §4.1's and **printed both**, naming the discrepancy rather than choosing silently. Applying the
+pre-registered tree to each:
+
+| | `SAT` | `CHANCE` | union | verdict |
+|---|---|---|---|---|
+| **§4.1 denominator (used)** | 1 (`D18`) | **0** | 1 | **`T-SOUND-WITH-NAMED-EXCEPTIONS`** |
+| **§4.4 denominator (as printed)** | 1 (`D18`) | **6** — `D17` 10.0000, `D07` 2.0000, `D12` 1.0556, `D05` 0.7381, `D09` 0.4545, `D16` 0.4078 | 7 | **`T-CHANCE-DOMINATED`** (clause 5) |
+
+**Two readings of one pre-registered document return two different verdicts about the owner's precision
+column.** This is **the single most important methodological finding of the wave** — stated in the headline
+above, and repeated here with its working. It must not be resolved by picking the one that reads better.
+
+What can be said without re-deciding: under §4.4 three datasets return values **above 1.0** (`D17` = 10.0000,
+`D07` = 2.0000, `D12` = 1.0556), which no quantity the design describes as *"the fraction of the shifted at-risk
+pool the unshifted catalogue still protects"* can take — its numerator is drawn from the shifted pool and its
+denominator from the unshifted one, so it is not a fraction of any pool. **That is diagnostic that §4.1 is the
+intended reading. Diagnostic is not authority.** The `T-CHANCE-DOMINATED` branch is recorded as **live** until a
+pre-registration closes it, and the closing must come **before** the re-score, not after.
+
+Also note the internal consistency the two forms expose: under §4.4 exactly **ten** datasets return `n/a`
+(`Σ|R| = 0`), and they are exactly the ten the `--protection off` arm reproduced exactly (§1). The two
+independent computations agree about which datasets had no at-risk detections.
+
+### 8.3 `CNL-EMPTYPOOL` is **unreachable** under the denominator that was used
+
+Design §7 defines `CNL-EMPTYPOOL` (`Σ|R(d)| = 0` ⇒ `chanceProtected = n/a`, the dataset leaves S3's denominator,
+which prints as `k of 19` with `k` computed). Under §4.1's `R_null` denominator the pool is never empty, so the
+state never fires and **no `k of 19` line was ever printed**. A pre-registered could-not-look state that the
+chosen statistic cannot emit is a dead clause. Under §4.4 it would have fired on 10 of 20 and printed `9 of 19`.
+Same root cause as §8.2.
+
+### 8.4 `T27-V3` names a field that does not exist on one of the two sidecars
+
+Design §5.4 requires each row's `detected_f<F>.csv` to pair with a `*.truth.json` **and** a `*.golden.json`
+*"whose `focuserPosition` field (from the sidecar, never parsed from the filename) equals `<F>`"*. The scorer
+reports:
+
+> `paired 180 of 180 manifest rows (the truth sidecar carries no focuserPosition field; it is paired`
+> `  through the manifest's own FITS column, and the GOLDEN's field is what is asserted)`
+
+**The clause is unsatisfiable as written for the truth sidecar** — the field is not there to check. The scorer
+named the substitution in place instead of silently weakening the gate, which is the right behaviour, and the
+golden's field *is* asserted on all 180. But the pairing of the truth sidecar rests on the manifest's FITS
+column, which is one route, not two — a weaker guarantee than the clause promises, and the FAIL-end fixture
+(mutating a row's focuser) exercises the golden half only.
+
+### 8.5 A demoted dataset's effect on the count denominator is undefined
+
+§4.3 says an `UNDER-POWERED` dataset *"becomes a named caveat rather than a verdict input"*, but the verdict tree
+counts over "the 19-dataset verdict population" and nothing says whether a demoted dataset leaves that
+denominator. Six of the 19 were demoted (§3.1). **Inert this wave** — all six were non-firing, so `SAT` and
+`CHANCE` are unchanged either way — but on a run where an under-powered dataset fired a bar, the verdict would
+depend on an unwritten rule.
+
+### 8.6 `S27-1` names four fields; the port emits **five**
+
+The clause checks `protectedStars` / `scoredFraction` / `precisionNull` / `truthViolations`. The port also emits
+**`protectedDetections`** — protection *exercised*, as against `protectedStars`' protection *available* — and
+`TruthDisclosure.cs:128` states why it was added: *"(`protectedStars`) without exercise is not readable as a
+correction size."* **It is the one number a reader actually needs, and it is outside `S27-1`'s population, so it
+ships unchecked by that clause.**
+
+**It is single-routed, and this document does not repair the clause with the data in hand.** For the record: a
+candidate second route exists — the `--protection off` arm's per-dataset `dFP` (§1) is the same quantity by a
+different path, and its total is 350 — but that comparison was **not pre-registered and was not performed**, and
+running it now and declaring agreement would be exactly the repair-and-harvest pattern the [F14](followups.md)
+fence forbids. **Priced for wave 28: ~10 minutes**, pre-registered as a clause, not asserted here.
+
+### 8.7 One clause was found unsatisfiable **at pre-registration**, and that is the discipline working
+
+The design rejected `excess = (p_obs − p_null)/(1 − p_null)` before any data, on the ground that `FP = 0` on 19
+of 20 datasets forces `p_obs = 1` and collapses the expression to `≡ 1` whatever the data say. **The published
+`FP` column confirms the premise exactly**: `t27_score.txt`'s `T27-V0` table shows `FP = 0` on 19 of 20, `D08`
+alone at 11. The clause would have passed silently on every dataset. Catching it before the wave rather than
+after is the one place this series' machinery worked as designed with no cost at all.
+
+### 8.8 Minor: a legend for a marker that never appears
+
+`t27_score.txt` prints `legend: (e) marks precisionNull = 0 BY DEFINITION (no detection could be scored), not
+measured` — the ASCII stand-in for the design's `†`. **No row carries it.** All five printed zeros (`D06`,
+`D08`, `D09`, `D10`, `D16`) are therefore *measured* zeros, not definitional ones. Harmless, but a reader
+scanning for the marker should know it is absent because nothing qualified, not because it was forgotten.
+
+---
+
+## §9 — The register entries §9 calls for, ready to paste into `docs/followups.md`
+
+### F85 — A closed, shipped correction was re-measured as an open defect, because two fields share a name
+
+**Status:** **Done** (2026-08-13, wave 27) — the disclosure gap is fixed; the register contradiction is
+corrected in place · relates to [F31](#f31), [F68](#f68) part 1, [F79](#f79), [F84](#f84)
+
+`golden eval`'s `FP` and a Python re-derivation from the golden's `stars` list alone are **both** "false
+positives": **11** and **150** on the same detections. Wave 26 read the second and compared it against the
+first, concluding the owner's precision column was a lower bound when it was already truth-corrected. The 150
+decomposes as **50** excluded by the golden's own `unresolved` boxes + **89** excluded by `TruthProtection` +
+**11** surviving genuine wing-frame junk; its `137` ("within 12 px of ANY truth star") is a **third** quantity,
+neither of the other two. **The junk count is 11, not 13** — two of the "13" sit inside an `unresolved` box.
+
+**Proximate cause:** `GoldenEvalRunner` applied `TruthProtection` and never reported that it did, while
+`BankVerifyRunner` reported it in three places. A grep of the 20 published logs, `golden_eval.txt` and
+`golden_eval_frames.csv` for `scoringMode` / `protected` / `precisionNull` returned **zero hits**.
+
+**Independent confirmation of the 89:** `score_t27_w27.py --protection off` gives `D08` FP `11 → 100`
+(`/mnt/d/hf_w27/t27_v0_failend.txt`), and **350** across the population.
+
+**Remedy, shipped:** `TestApp/SynthBank/TruthDisclosure.cs` ports all four of `bank-verify`'s disclosures into
+`golden eval` — `scoringMode` + `protectedStars`, `precisionNull`, `truthViolations`, `scoredFraction` — plus a
+fifth, `protectedDetections` (protection *exercised*). Wording is shared between the two harnesses so they
+cannot drift apart. **`RULE S27-4` proves the change is report-only at byte level: 360 of 360 detection
+artifacts byte-identical, `TP`/`FP`/`FN` unchanged on 20 of 20, and 20 of 20 report sinks changed** (so the port
+is not inert). **Open sub-item:** `S27-1`'s route agreement was not adjudicated, and `protectedDetections` is
+single-routed — see wave 27 results §7.3 and §8.6.
+
+### F86 — The golden sidecars on disk carry the PRE-REPAIR policy in their own words
+
+**Status:** **Open — a named caveat, deliberately not fixed** (2026-08-13, wave 27) · relates to [F31](#f31),
+[F85](#f85)
+
+`GoldenFromTruth.cs:744-748` writes *"a detection here should count as a false positive"* into the `Reason`
+field of every `omitted` component, and that string is sitting in **all 180 `*.golden.json` in the bank**. The
+behaviour it describes was repaired on **2026-08-03** and the string was not, because it is a diagnostic field
+nothing reads programmatically. **It is the single most likely thing that actually misled wave 26.**
+
+Wave 27 fixes the two contradicting XML doc comments (`GoldenFromTruth.cs:34-36` *"a detector reporting
+something at its location should be scored as a false positive"* vs `:76-84` *"scoring a detection there as a
+false positive would be punishing a detector for something the reference itself cannot certify either way"*) and
+**deliberately does NOT regenerate the sidecars**, for three reasons in this order:
+
+1. regenerating 180 goldens collides with **fingerprint class 2 preservation** and would invalidate every
+   precision/recall number this series has published;
+2. changing only the generator string would make future sidecars disagree with the 180 on disk — a silent
+   divergence, the same class of defect being fixed;
+3. nothing reads `Reason` programmatically.
+
+**Anyone reading a `Reason` field in a `*.golden.json` must read this entry first.** The correct policy is:
+`omitted` and `unresolved` are both *visibility* judgements, visibility bears on **recall**, and a rendered star
+is not a false positive at any SNR.
+
+### F87 — A rule that describes itself must exclude itself from its own population, or it launders its own subject
+
+**Status:** **Done** (2026-08-13, wave 27) — closed with a both-ends self-test · a **fourth** gap in
+[F80](#f80)'s checker, and a **new class**, not the `_`-word-boundary family
+
+`verify_derivation_w27.py`'s `in_historical_block()` scanned backwards for any line *containing* a
+`HISTORICAL_BLOCKS` token and treated it as opening a historical literal — **but the line that DEFINES
+`HISTORICAL_BLOCKS` contains every one of those tokens**, so from that line to EOF the `V27-B` clause was
+switched **off**.
+
+**Evidence, both ends:** before the repair the checker reported **`V-CLEAN`, 0 unlicensed tokens** on its own
+file **while printing `=== RULE V26 ===` as its banner on a wave-27 root** (`/mnt/d/hf_w27/vdrift_w27_run1.txt`);
+after the repair it reported **32 findings on itself** (`vdrift_w27_run2.txt`, the pre-repair copy is preserved
+as `verify_derivation_w27.py.bak` and contains **69** literal `V26` occurrences), and **255** on the pinned
+`/mnt/d/hf_w26` fixture (`vdrift_selftest_FINAL.txt` `[5b]`). *(A "53 tokens" figure quoted during the wave was
+a `grep -c` of lines, a third quantity, and is withdrawn; a pre-repair "204" on the `hf_w26` fixture was read but
+its artifact was not kept, so it is testimony. **Neither is load-bearing** — the run1-versus-run2 pair proves the
+defect without any count.)*
+
+**The lesson, and it generalises past this checker:** the first three F80 gaps were a *pattern* being too narrow.
+This one is a *population* silently containing the instrument, so the instrument's own definition of what to look
+for became a licence to stop looking. **Any self-describing rule must state whether its own source is in its
+population, and prove the answer with a fixture.** Closed with self-test clause `[6]`, which demonstrates that a
+real historical block is exempt, that the file after it is not, and that the definition line opens nothing. Two
+FAIL fixtures are now pinned: `hf_w24` (kept) and `hf_w26` (added, not swapped).
+
+### F88 — `git diff --name-only <tree>` omits UNTRACKED files, so a two-binary provenance diff can miss a whole new source file
+
+**Status:** **Open — remedy known and applied once** (2026-08-13, wave 27) · belongs beside [F66](#f66)
+
+Wave 27's B16 adds `TestApp/SynthBank/TruthDisclosure.cs` — the entire substance of the change — and it was
+**untracked at build time**, so `binary_provenance_w27.txt`'s tracked diff lists 3 files and omits it.
+`Q27-V1`, which intersects the change set against the `optimize` gate's reachable set to decide whether a
+42-minute gate is owed, would have computed that intersection over an incomplete population.
+
+**Remedy, applied:** take the **union** of `git diff --name-only <tree> -- '*.cs'` and `git ls-files --others
+--exclude-standard -- '*.cs'`. `q27_v1.txt` does this and reports 5 files.
+
+**Same shape as [F66](#f66):** a provenance instrument reporting confidently on a population that silently
+excludes the thing under examination. Every future two-binary provenance step must take the union.
+
+### F89 — A mutation harness that restores with `cp -p` restores the pre-mutation MTIME, and MSBuild then skips the recompile
+
+**Status:** **Open — remedy known** (2026-08-13, wave 27, controller process finding; **no artifact**)
+
+`cp -p` preserves mtime. After a mutant is restored with it, MSBuild sees a source no newer than its object and
+**skips the rebuild**, so the next run silently re-measures the mutant. In wave 27 it made a correctly-restored
+tree look broken.
+
+**Remedy:** `touch` the file after every restore; keep the sha256 check, which guards content but says nothing
+about mtime. **Recorded honestly: this finding's evidence is the controller's account, not a file.** One mutant
+(`M-S3`) was subsequently re-verified with its run record kept (`s27_2_mutant_MS3.log`, 3 red of 19); `M-S1`,
+`M-S2a` and `M-S2b` remain testimony, and this defect is the likeliest reason their records were lost.
+
+### F90 — Reuse the computation, never the banner, or the artifact lies about which rule it evaluated
+
+**Status:** **Open — remedy known, one instance annotated** (2026-08-13, wave 27) · belongs with
+[F74](#f74)'s family, not [F80](#f80)'s
+
+`score_repro_w27.py` — the `RULE R27` comparator — was reused to perform wave 27's `S27-4` byte comparison. It
+emits its own rule name **unconditionally**, so `/mnt/d/hf_w27/s27_score.txt` ends
+`>>> RULE R27 = R-DIFFERS (40 files)` while `/mnt/d/hf_w27/repro_all_score.txt` ends
+`>>> RULE R27 = R-IDENTICAL`. **For a period the record carried two contradictory verdicts for the same rule
+name**, on two different populations, and a reader grepping `RULE R27 =` would have found the contradiction with
+no way to tell which was which.
+
+**This is sharper than F80's prose drift.** F80 is about *commentary* that stops describing the instrument.
+Here the **verdict line itself** — the one line a future reader greps — was correct for the code and wrong for
+the run.
+
+**Remedy:** a reusable scorer must take its rule label as an **argument** and assert it against the manifest it
+was handed, exactly as this series already computes every ordinal rather than typing it. **Fixed for wave 27 by
+annotation, not deletion**: `s27_score.txt` now opens with a banner saying its own verdict line must not be
+quoted and naming `s27_4_score.txt` as the scored clause, with the wrong line left in place at the foot so the
+record shows what happened.
+
+### F91 — A BEFORE/AFTER control whose two sweeps are built by different expressions reports a FALSE violation
+
+**Status:** **Done** (2026-08-13, wave 27) — caught by the population assertion, corrected, both readings kept ·
+[F74](#f74)'s shape in the BEFORE/AFTER direction
+
+Wave 27's first `T27-V4` AFTER sweep returned **`T27-V4 = VIOLATED`**. **Nothing on disk had changed.** The
+AFTER expression omitted the **20 `.log` files** that the BEFORE expression had captured, so it compared 780
+paths against a BEFORE list of 800 and reported the 20 absentees as moved. A fingerprint gate is the control
+that decides whether a wave's denominators moved under it; a false `VIOLATED` there forces `T-UNEVALUATED` on a
+wave whose population was in fact untouched.
+
+**The only reason it surfaced** is the standing rule that the **population size is asserted inside the file** —
+`BEFORE 800 / AFTER 780` is arithmetic, not a judgement call. The corrected sweep reads **`BEFORE 800 AFTER 800
+compared 800 … DIFFERING: 0 → T27-V4 = PRESERVED`**.
+
+**The rule, general:** *a BEFORE/AFTER control must build both populations from the SAME expression.* Two
+expressions intended to describe one population are two populations, and every difference the control reports is
+then unattributable — in either direction. Prefer one function, called twice, with the population size asserted
+equal before any hash is compared.
+
+### Amendments owed to existing entries
+
+* **[F31](#f31)** — append `RULE T27`'s verdict: **the repair it made is SOUND on 18 of the 19 blind datasets,
+  saturated on `D18_m24_deep_shed` alone (`precisionNull` 0.2820, `A_all` 0.2372, `A_protOnly` 0.1938), with
+  `D01_ultrawide_40mm` a named near-miss at 0.2182.** F31 is **not** reopened — the verdict is neither
+  `T-SATURATED` nor `T-CHANCE-DOMINATED`, so the density guard is not triggered. Also record that F31's null was
+  demonstrated on one dataset (`D09`) and is now generalised to 20, at four offsets, and that the shipped
+  single-offset control is **under-powered on 7 of them**.
+* **[F83](#f83)** — the decision proceeds on real numbers. **Caveat 3's `+0.034` must carry a factor label**: it
+  is `+0.034` at detection binning 1 and `+0.003` at binning 2, where `D08` reads `P=0.997 FP=1` (§4.3).
+* **[F62](#f62)** — append `RULE D27` = `D-MOVED`, 6 of 6: scoring at the optimizer's own detection-binning
+  factor moves `recall@all` by up to **+0.296** (`D14`) and by **−0.012** on `D15`. The no-`BestJ`-across-factors
+  landmine now has a measured magnitude on the recall side.
+* **[F21](#f21)** — add the measured `golden eval` rate (§10) so no future wave prices a golden-eval arm off the
+  `optimize` rate.
+* **[F80](#f80)** — cross-reference [F87](#f87) as the fourth gap and the first of a new class; and add the
+  reuse-direction case from wave 27 results §7.8, where a scorer re-aimed at a new population kept the original
+  rule's verdict banner, so `s27_score.txt` claims `RULE R27 = R-DIFFERS` while `repro_all_score.txt` claims
+  `RULE R27 = R-IDENTICAL`.
+* **`docs/synthetic-af-bank-results-table.md`** — annotate `D18`'s precision cell in place as **uninformative**
+  with its three statistics; annotate `D01` with the near-miss; add the `scoredFraction` column or at minimum
+  the six low rows of §3; re-state the seven `RULE D27` rows at both factors with each labelled.
+
+---
+
+## §10 — Estimate vs actual, which is itself a deliverable ([F21](followups.md))
+
+From `/mnt/d/hf_w27/TIMING.tsv`:
+
+| step | est (m) | actual (m) | note |
+|---|---|---|---|
+| 0 pre-registration | 10 | **8** | committed `df68232`, pushed |
+| 1 pre-flight `V27` | 10 | **26** | **OVERRUN ×2.6** — found and closed the fourth F80 gap (§7.5) |
+| 2 layout + manifest | 5 | **4** | layout 16 of 16; manifest 180/20/9, b2=7 |
+| 3 scorer (agent) | 10 | **—** | *"in flight"* — **still never closed** |
+| 4 `RULE T27` (B) | 95 | **22** | **UNDERRUN ×4.3** — `T-SOUND-WITH-NAMED-EXCEPTIONS`; scorer `--full` 80 s |
+| 5 `RULE D27` | 25 | **14** | `D-MOVED` 6 of 6; both gates PASS, V1 FAIL end run |
+| 6 half (A) port | 50 | **46** | 19 tests, 4 mutants; controller re-verified `M-S3` |
+| 7 B16 + `Q27-V1` + `S27-4` | 35 | **18** | gate DISCHARGED with FAIL end; 360/360 bytes identical |
+| 8 half (C) corrections | 20 | **18** | 7 documents corrected in place |
+| 8 suite by COUNT *(duplicate ordinal)* | 5 | **5** | 3 992 (was 3 973), +19 named, `SUITE_EXIT=0` |
+| **rows with both figures** | **250** | **161** | **~36 % under**, and the shape is the finding below |
+
+**The dominant term is half (B), estimated at 95 m and delivered in 22.** The design priced the S1/S2/S3 arm at
+40 m for *"numpy rasterisation; the dominant cost is `D01`/`D18`'s ~12 k objects per frame"* and the whole of (B)
+at ~95 m; the scorer's `--full` pass ran in **80 seconds**. **This is [F21](followups.md) in the cheap direction
+for the second wave running** — the same error the design warned about when it added the measured `golden eval`
+rate. The lesson generalises past `golden eval`: **a pure-Python arm over artifacts already on disk is
+consistently over-priced by this series by a factor of 3–4**, and over-reserving it is what pushes genuinely
+expensive items (item 8) out of a wave.
+
+**The bookkeeping itself was partly undelivered at timestamp 1 and was largely closed after it.** At timestamp 1
+`TIMING.tsv` carried six rows and four estimates had no actual; four rows (`4`, `6`, `7`, suite) were filled in
+at 10:14:37. Two residuals remain, both minor and both recorded rather than fixed: **step 3's actual is still
+`-`**, and **two rows share the ordinal `8`** — the same typed-ordinal hazard `V27-C` exists to catch, in a
+hand-maintained file the checker does not read. The results write-up is still unpriced, by construction.
+
+**The one rate the charter's §5 budget table did not have, now MEASURED and to be carried forward:**
+
+| instrument | rate | how measured |
+|---|---|---|
+| **`golden eval`, full 20-dataset arm, `table18` settings, B15** | **349 s (~6 m)** | measured, whole arm |
+| **`golden eval`, one 9-frame cell** | **6 s (`D06`) – 46 s (`D01`)**, mean ~17 s | measured; the spread tracks star count, not frame count |
+| `RULE D27`, 7 cells at factor 2 | **49 s** | `w27_d27.log`, `13:29:15Z → 13:30:04Z` |
+| for comparison, `optimize --per-run --max-evals 250` | ~5.2 m **per run** | charter §5 — **~18× the whole arm** |
+
+**Price a cell from the RANGE, not the mean.** `D01` is 7.7× `D06`, so a 7-cell arm's price depends entirely on
+which seven.
+
+---
+
+## §11 — What was NOT run, and what it costs
+
+| not run | price to close | status |
+|---|---|---|
+| **the 42 m `optimize` gate** | **42 m** | **DISCHARGED by `Q27-V1`, not skipped silently** — empty intersection with the reachable set, FAIL end demonstrated against the B14 tree. The discharge is **not** reported as a pass; what replaces it is hash identity + `S27-4`'s 360 byte-identical detection artifacts, a sharper control for this change |
+| ~~`T27-V4` AFTER fingerprints~~ | ~~~4 m~~ | **CLOSED after timestamp 1** — `PRESERVED`, 800 of 800, after a false `VIOLATED` on the first sweep (§7.1) |
+| ~~scorer self-test capture~~ | ~~~2 m~~ | **CLOSED after timestamp 1** — `SELFTEST T27 72 of 72`, plus an evidenced `--out` refusal (§7.2) |
+| **`S27-1` route agreement, all five fields** | **~10 m** | **STILL NOT ADJUDICATED** (§7.3). The four registered fields are comparable directly from `t27_score.txt` against `s27_after/*/golden_eval.txt`; the fifth (`protectedDetections`) is **single-routed** and needs a **pre-registered** second route, not a post-hoc one (§8.6) |
+| **`S27-2`: `M-S1` / `M-S2a` / `M-S2b` run records** | **~10 m** | **STILL TESTIMONY** (§7.4). `M-S3` is now evidenced (3 red of 19); the other three are not, and `M-S2`'s runner site is textually guarded only (§5.5) |
+| **settling `S3`'s denominator** | **~30 m, and it must come FIRST** | **CANNOT be closed by running anything** (§8.2) — it is a defect in the rule, and the fix must be pre-registered *before* the re-score |
+| item 8 — **wide-field recall, re-denominated** | **unpriced; needs a design** | untouched by wave 27 **by construction**, see §12 |
+| regenerating the 180 `*.golden.json` for the `Reason` string | ~15 m compute, **unbounded credibility cost** | refused — fingerprint class 2 collision, F86 |
+| changing the shipped null to multiple offsets | ~20 m | refused — would change every `bank-verify` number in the series; the variance bound is computed in the scorer instead |
+| the integrated-SNR discriminator | ~30 m | **rejected on the merits** at pre-registration: degenerate within-frame (`SNR_int = SNR_peak/√p` with `p` near-constant per frame), and already superseded by `docs/golden-tier-plausibility-design.md` §2 |
+| a truth-based **recall** denominator | ~30 m marginal | `TruthProtection` leaves recall untouched *by design* |
+
+---
+
+## §12 — What wave 28 should do, priced, and scored against the owner's three goals
+
+The owner's goals (charter §8): **(1)** optimization + autofocus works across a wide range of setups, bridging
+detected gaps; **(2)** accuracy of step-size recommendations; **(3)** appropriate exposure adjustments and
+avoiding parameters pinned to extremes.
+
+| # | item | price | goals | why now |
+|---|---|---|---|---|
+| **1** | **Item 8 — wide-field recall.** `recall@high` **0.183** (11 400 / 62 411) on the 40 mm rig, `recall@all` **0.123**. Needs its own pre-registration | **design 60 m + arm ~2 h** | **1** ✓✓✓ | **The largest untouched product gap in the bank.** See below — nothing wave 27 measured touches it |
+| **2** | **Close wave 27's two remaining controls** — `S27-1` (incl. the fifth field, pre-registered) and the `M-S1`/`M-S2a`/`M-S2b` mutant records. *(`T27-V4` and the self-test capture closed after timestamp 1.)* | **~20 m total** | instrument | Both gate ship-clauses already relied upon |
+| **3** | **Settle `S3`'s denominator in a pre-registration, THEN re-score** — the fix must precede the measurement, not follow it | **~30 m** (the scoring pass is minutes) | instrument | §8.2 — **two readings of the pre-registered design give two different verdicts about the owner's precision column.** The highest-value instrument item in the series right now |
+| **4** | **Ship half (A)** — it is written, tested (+19), byte-proved and uncommitted | **~20 m** | 1, 3 | §5.4. Every future bank number becomes self-describing |
+| **5** | **Re-state the 7 `RULE D27` rows at both factors** in the results table, each labelled | **~20 m** | 1, 2 | `D14` `recall@all` 0.641 → **0.937** is a published number that is wrong about the configuration the optimizer actually uses |
+| **6** | **Fix the verdict-tree gap** in the next wave's pre-registration (clause for `3 ≤ union ≤ 9` with neither set at 5) | **~10 m** | instrument | §8.1 — inert this wave, live next |
+| **7** | **Multi-offset null in the scorer as a standing statistic** — 7 datasets are under-powered at the shipped single offset | **~20 m** | instrument | §3.1; do **not** change the shipped null |
+
+### 12.1 Item 8 is unaffected by everything wave 27 measured, and this needs saying explicitly
+
+**Three independent reasons, all from source or from this wave's own numbers:**
+
+1. **`TruthProtection` leaves recall untouched by design.** Its own scope statement: *"Recall is deliberately
+   untouched … a protected star is not promoted to a required find."* Recall's denominator is the golden's
+   `stars` list at tier ≥ high, which nothing in wave 27 moved. `RULE T27` is a statement about the **precision**
+   column only.
+2. **`RULE D27` does not reach the wide-field datasets.** Its population is the 7 datasets whose *derived*
+   detection binning is 2. `D01_ultrawide_40mm`, `D02_rich_135mm` and `D03_redcat_250mm` are **factor-1**
+   datasets and are not in it. `D01`'s `recall@all 0.123` is exactly as published.
+3. **`D01`'s precision is `1.000` at an `FP` of 0 and a `scoredFraction` of 0.9678** — it is not a
+   precision-side story at all. `D01` carries **96 760 false negatives** against 13 624 true positives. The gap
+   is entirely recall.
+
+**And the fence still binds.** Choosing new tier boundaries with the data in hand is exactly what
+[F14](followups.md) / [RULE D20](waves22+-handoff-prompt.md) forbid, so item 8 needs its own pre-registration
+before any statistic is read — which is why it is priced at *design 60 m plus arm*, not as an arm.
+
+**Scored against the goals, item 8 is the only candidate that scores ✓✓✓ on goal 1**, and goal 1 is the goal the
+bank exists to serve. Items 2, 3, 6 and 7 score zero on all three goals directly and are justified only as
+instrument work — which the charter permits, but they should be run *because they are cheap and they gate
+claims already made*, not because they advance the product.
+
+---
+
+## §13 — Controller deviations, all recorded, none laundered
+
+| # | deviation | recorded where | assessment |
+|---|---|---|---|
+| 1 | **`RULE R27` ran BEFORE pre-registration** (`13:14:24Z`, against commit `df68232`) | `CONTROLLER_NOTE.md` §7, adopted by design §5.6a | **Legitimate and correctly declared.** A determinism control that reads no statistic in T27's tree; its FAIL end is demonstrated in both directions in `repro_all_w27.sh`'s self-test. Reported as *opportunistic*, in the same sentence as `R-IDENTICAL` |
+| 2 | **The D27 arm dropped the plan's `--settings` pin** and pinned only `--profile-id` | `d27_arm_w27.sh:20-34` | **Correct, and better than the plan.** The published `table18` run passed no `--settings`; adding one alongside `--detection-binning 2` would change two things at once and make every delta unattributable. The charter's pin rule exists for `optimize` arms, where the settings file drives the search |
+| 3 | **The `--profile-id` pin was demonstrated inert first**, not assumed | `pinprobe/`, `d27_arm_w27.sh:32-34` | **Correct in kind; state its `n` precisely.** The demonstration is **one dataset (`D09`), 20 of its 20 artifacts byte-identical** — *not* 20 datasets. By this series' own standing rule, *a control demonstrated on one dataset is a control demonstrated on one dataset* |
+| 4 | **The derivation checker's FAIL fixture kept `hf_w24` and ADDED the design's `hf_w26`** rather than swapping | `vdrift_selftest_FINAL.txt` `[1]`, `[5b]` | **Strictly better than the design asked for.** Two pinned fixtures, neither of which is "whatever came before" |
+| 5 | **`RULE T27` was scored in two arms** (`--gates` then `--full`), and the gates-only artifact prints `RULE T27 = NOT EVALUATED (gates-only run)` | `t27_gates.txt` | **Correct.** A gate a given arm cannot discharge prints as `n/a for this arm`, never as a pass — the scorer has a dedicated `gate_line()` for exactly this |
+
+### 13.1 The controller was wrong twice, and both corrections are in the record
+
+* **The junk count is 11, not 13.** Two of the "13" sit inside a golden `unresolved` box and were already
+  excluded by `ExcludeUnresolved`; `golden eval`'s printed `FP = 11` is the correct figure. Corrected in
+  `CONTROLLER_NOTE.md` §8 and propagated into `docs/synthetic-af-bank-results-table.md`.
+* **The rival-cause framing (a)/(b)/(c) and the integrated-SNR discriminator were both rejected on substance** by
+  the pre-registration agent (design §2). (a) OMISSION and (b) MIS-SPECIFICATION are not rival causes but the
+  same fact at two levels of description; the diagnostic question is a fourth one — **(d) MIS-ASSIGNED SIDE**,
+  decidable from source at zero compute, and it is what `TruthProtection` already fixed. The discriminator is
+  degenerate within a frame and was already superseded by name in
+  `docs/golden-tier-plausibility-design.md` §2.
+
+**Both corrections strengthen rather than weaken the wave's conclusions**, and the second one saved ~30 minutes
+of re-treading a fenced result.
+
+---
+
+## §14 — One-paragraph summary
+
+**The assigned backlog item was already done, and the wave's real product was finding that out and proving the
+shipped correction sound.** `RULE T27` = `T-SOUND-WITH-NAMED-EXCEPTIONS`, now on **4 of 4** gates: the owner's
+precision column is honest as published on 18 of 19 blind datasets, uninformative on `D18_m24_deep_shed`
+(`precisionNull` 0.2820 against a 0.25 bar), with `D01_ultrawide_40mm` a named near-miss at 0.2182 — a margin
+narrower than the shipped null's own single-draw spread. `RULE D27` = `D-MOVED` on 6 of 6: seven published rows
+were scored at the wrong detection binning and `D14`'s `recall@all` moves 0.641 → 0.937. Half (A) is written,
+byte-proved report-only on 360 artifacts, and **still uncommitted**. The quiet finding is `scoredFraction`: a
+third of `D12`'s detections never entered its precision ratio, and no reader could have seen that before this
+wave.
+
+**Between the two timestamps four open rows were closed** — `T27-V4` (`PRESERVED`, 800 of 800, *after a false
+`VIOLATED` that its own population assertion caught*), the scorer's self-test (`72 of 72`), `M-S3`'s red run, and
+the contradictory `R27` banner (annotated, not deleted). **Three things remain open and are marked open in
+place:** `S27-1`'s route agreement, three mutant records that are still testimony, and half (A)'s commit.
+
+**And one finding cannot be closed by running anything: the design defines `S3`'s denominator twice,
+incompatibly, and the two readings return `T-SOUND-WITH-NAMED-EXCEPTIONS` and `T-CHANCE-DOMINATED`
+respectively.** That is the wave's most important methodological result. It is reported, not repaired; the
+evidence that §4.1 is the intended reading is recorded as diagnostic and explicitly not as authority; and the
+next wave must fix the rule **before** it re-scores.

--- a/docs/synthetic-af-bank-followups-wave28-design.md
+++ b/docs/synthetic-af-bank-followups-wave28-design.md
@@ -1,0 +1,601 @@
+# Wave 28 — backlog item 8: recall where the star is smaller than the detector's calibrated band
+
+**Pre-registration. Written before any wave-28 statistic is computed.** Section 2 records where the
+controller's framing is wrong; there are seven such places and four of them change what the wave measures.
+
+---
+
+## 0. THE VESSEL — decided in writing, before any measurement
+
+**Wave 28 opens a fresh branch off `ghilios/synthetic-af-bank-followups-wave27`, named
+`ghilios/synthetic-af-bank-followups-wave28`, and PR #196 stays open on its own branch.**
+
+- PR #195 (`…wave23`, waves 23–26) is **MERGED**.
+- PR #196 (`…wave27`) is **OPEN / MEREABLE** at `915aa50`.
+
+Reason for a fresh branch rather than a fifth section on #196: #196 carries a *single* wave and is
+reviewable as one; the charter's §1a warning is against letting one PR silently accrete waves, which is
+exactly what #195 did. Wave 28 also proposes a **user-visible product change** (§9), and a product change
+should not ride in on a PR whose title says "audit the truth-protection correction".
+
+---
+
+## 1. THE HEADLINE: the item's premise is wrong in three ways, and one of them is the same shape as wave 27's
+
+The backlog calls item 8 *"the item nobody has ever worked"* and *"the LARGEST product gap in the owner's
+table"*. Taking those in order:
+
+### 1.1 It has been worked. Five times. The mechanism the controller asks me to find is already in the register
+
+| entry | status | what it already established about `D01`/wide field |
+|---|---|---|
+| **[F20](followups.md)** | Done | `D01`'s truth HFR per frame `[2.27,1.71,1.15,0.61,0.24,0.61,1.15,1.71,2.27]` px; the middle **5 of 9** at/below `MinHFR=1.2`; `Current settings J: 0` is a cold-start plateau |
+| **[F35](followups.md)** | Done (w3), re-measured w6 | `MinHFR` 1.2→0.1 on `D01`/`D02`/`D03`, **32 configurations, `FP = 0` in all of them**; gain saturates by 0.5; largest gain is **`D03` (+0.192)**, not `D01` (+0.036) |
+| **[F43](followups.md)** | Done (w5) | `D01` at default gate yields **0 accepted stars at best focus** vs 1859–4182 in the wings. *"`MinHFR` is the ONLY axis that rescues it — `MinimumStarBoundingBoxSize` 5→3 changes nothing, `StructureLayers` 4→2 makes it strictly worse."* On the reporter's real 61 MP 19.4″/px rig, **the binding gate is `NoiseClippingMultiplier`, not `Sensitivity`** |
+| **[F44](followups.md)** | Done (w6) | `D01` was rendering starless outside a central patch (ASTAP cell clamp); re-render 8 107 → **19 212** truth stars |
+| **[F22](followups.md)** | Open | The **pixelization floor**: at HFR ≲ 1.1 px measured HFR **over-reads by +26 % to +234 %**; `D01`'s optical vertex `0.231 px` measures `0.77 px` |
+
+**And [F35](followups.md) already published the false-negative attribution the controller presents as the
+wave's free starting point**, three years of waves earlier, in its own words:
+
+> *"**The W class's recall is lost in candidate FORMATION** — the structure map never proposes 49 % of them,
+> and `MinimumStarBoundingBoxSize` rejects another 17 % as `TooSmall` — so anyone expecting the `MinHFR` fix
+> to lift `D01` toward the 0.90 W-class band will be disappointed, and **the band stays missed for a reason
+> this entry does not address**."*
+
+**This is wave 27's headline shape repeating: the assigned item was substantially worked, and the wave's
+first product is finding that out.** What is genuinely un-worked is narrower and is named in §3.
+
+### 1.2 "Wide field" is not the covariate. **In-focus PSF size in detection pixels is**, and the product already says so
+
+`DetectionBinningResolver` states the detector's supported sampling band in source, as a constant and in
+user-facing prose:
+
+```csharp
+/// <summary>The in-focus HFR (in binned pixels) the recommendation aims for: the center of the detector's
+/// calibrated 2-4 px band.</summary>
+public const double TargetHfrPixels = 3.0;
+```
+— `Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/Utility/DetectionBinningResolver.cs:42-44`, prose at `:101-104`
+
+Ranking the bank by **in-focus kernel HFR in captured pixels** (`truthModel.hfrMin`, floored at
+`hfrMinEffective`) rather than by arcsec/px reproduces the recall column and, critically, **puts wave 27's
+`RULE D27` and item 8 on one axis, on opposite sides of the same band**:
+
+| in-focus HFR (px) | datasets | relation to the 2–4 px band | observed |
+|---|---|---|---|
+| **0.700** (all three floored) | `D01`, `D02`, `D03` | **4.3× below** | `recall@high` 0.183 / 0.446 / 0.365 — item 8 |
+| 1.038–1.080 | `D04`, `D16`, `D18`, `D20` | 2× below | 0.855–0.937 |
+| 1.804 | `D05`, `D06`, `D19` | just below | 0.964–0.989 |
+| **3.168–3.477** | `D13`, `D07` | **in band** | 0.973–1.000 |
+| 4.861–10.195 | `D08`–`D12`, `D14`, `D15`, `D17` | above | `RULE D27`: **binning 2 moves them back into band and recall rises**, `D14` `recall@all` 0.641 → **0.937** |
+
+**`RULE D27` measured the upper edge of this band last wave without naming it.** Item 8 is the lower edge.
+The difference between the two edges is the whole product story: **above the band there is a remedy
+(`DetectionBinningResolver` recommends a factor, the user applies it, recall recovers). Below the band there
+is none — you cannot bin fractionally, and the resolver's `Clamp` floors at 1 and says nothing.**
+
+### 1.3 The bank's own generator already declared these three datasets outside the representable regime
+
+```
+dataset                  asec/px  seeing   hfrMin  hfrMinEff
+D01_ultrawide_40mm        19.389    2.50   0.2307      0.700   <- FLOORED
+D02_rich_135mm             5.745    2.50   0.2800      0.700   <- FLOORED
+D03_redcat_250mm           3.102    2.50   0.5766      0.700   <- FLOORED
+D04_esprit_550mm           1.410    2.50   1.0380      1.038
+… 16 more, every one with hfrMin == hfrMinEffective
+```
+
+**Exactly three datasets are floored, and they are exactly the three with the recall gap. 3 of 3 and 17 of
+17.** The renderer refuses to render a PSF below 0.7 px because it cannot; the detector faces the same wall
+one stage later. This separation was sitting in `synthetic_meta.json` the whole time and no wave has quoted
+it.
+
+It also means something the wave must not lose: **`D01`, `D02` and `D03` are all rendered at the SAME
+in-focus PSF (0.700 px) despite pixel scales of 19.4, 5.7 and 3.1 ″/px.** Their `recall@high` differs
+(0.183 / 0.446 / 0.365). **So arcsec/px cannot be what separates them at focus** — which is a direct
+refutation of the controller's ordering-by-pixel-scale, and is why §2.1 rejects that axis.
+
+---
+
+## 2. WHERE THE CONTROLLER'S FRAMING IS WRONG
+
+### 2.1 "At 19.4″/px with 2.5″ seeing a star is sub-pixel, so ask whether the à trous layers can represent a source narrower than one pixel" — **the answer is YES, and the question is the wrong one**
+
+Read from source. `CollectStarCandidates` has **no minimum size at all**:
+
+```csharp
+const float ZERO_THRESHOLD = 0.001f;
+```
+— `StarDetection/StarDetector.cs:1342`; region seeding at `:1356`/`:1370`, `candidates.Add(...)` at `:1425`
+
+**A single surviving pixel produces a 1×1 candidate.** And the wavelet does not erase small sources — it
+does the opposite. The à trous residual is a low-pass at ≈ `2^StructureLayers` px and is **subtracted**, so
+*large* structures are removed and point sources survive. The shipped tooltip says exactly this:
+*"At the default of 4 (2⁴=16), structures larger than 16 pixels in size are excluded"*
+(`Resources/OptionsDataTemplates.xaml:444`).
+
+**So the structure stage's representational capacity is not the limit. The limit is amplitude, and it is one
+line further on.**
+
+### 2.2 The real lower-scale cutoff is the **post-wavelet Gaussian blur**, and it is **welded to a knob that means the opposite thing**. This is the wave's finding
+
+```csharp
+// Step 5: Excluding large structures can cut off the outsides of large stars, or leave holes when far out
+//         of focus. Blurring smooths this out well for structure detection
+CvImageUtility.ConvolveGaussian(structureMap, structureMap, p.StructureLayers * 2 + 1);
+```
+— `StarDetection/StarDetector.cs:631-632`
+
+with
+
+```csharp
+if (sigma <= 0.0) { sigma = 0.159758 * kernelSize; }
+```
+— `Utility/CvImageUtility.cs:80-82`
+
+At the shipped `StructureLayers = 4` the kernel is 9×9 and **σ ≈ 1.44 px**. A 1-px delta is spread over
+σ ≈ 1.44, so its **peak amplitude falls by roughly 1/(2πσ²) ≈ ×0.077** before it is compared against
+
+```csharp
+double binarizeThreshold = structureMapStats.Median + p.NoiseClippingMultiplier * noiseReducedImageNoise.Sigma;
+```
+— `StarDetector.cs:653`
+
+**Three things follow, and all three are new:**
+
+1. **The blur's stated purpose is to help LARGE and defocused stars** (the comment says so), **and its entire
+   cost falls on small ones.** Its width is keyed to `StructureLayers`, a knob about the *upper* scale
+   cutoff. One knob sets two opposing cutoffs.
+2. **It uses raw `p.StructureLayers`, not `EffectiveStructureLayers(p)`.** The defocus/donut boost
+   (`StarDetector.cs:1567-1578`) widens the *residual* and deliberately leaves the blur alone — so the
+   codebase **already decouples them in one direction**, and there is precedent for decoupling the other.
+3. **It explains [F43](followups.md)'s dead end.** F43 measured `StructureLayers 4 → 2` on `D01` as
+   *"strictly worse"* and concluded the axis was useless. But lowering `StructureLayers` moves **both**
+   cutoffs at once: it narrows the blur (helps a 1-px star) *and* makes the residual less smoothed, so
+   `src − residual` retains less of the star (hurts more). **F43's result is confounded in source, and
+   nobody has run the experiment that separates them.**
+
+**This is the one genuinely un-worked mechanism in item 8, it is decidable from source at zero compute, and
+it re-opens an axis the register had closed.**
+
+### 2.3 "The optimizer drives sensitivity UP on wide fields" — **direction confirmed, gate set wrong**
+
+Direction is right and worth recording, because the name reads backwards: `BrightnessSensitivity` is a
+**threshold**, so **higher is LESS permissive**.
+
+```csharp
+var sensitivity = starCandidate.NormalizedBrightness / srcImageNoiseSigma;   // :1834
+if (sensitivity <= p.Sensitivity) { … }                                      // :1851
+```
+— `StarDetector.cs`; corroborated at `IStarDetector.cs:338` (*"Smaller values increase sensitivity"*) and
+`GateRecommender.cs:92` (`LowerToAdmit`).
+
+**But the controller's table attributes the moderate-wide loss to `REJECTED:LowSensitivity` alone, and that
+undercounts it.** Recomputing the shares from the same published blocks:
+
+| | `NO CANDIDATE` | **tunable-gate block**† | of which `LowSensitivity` | `TooSmall` |
+|---|---|---|---|---|
+| `D01` (51 011 high-tier FN) | **84.3 %** | 11.1 % | 1.5 % | 9.5 % |
+| `D02` (14 585) | 25.6 % | **64.6 %** | 40.6 % | 22.2 % |
+| `D03` (2 937) | 6.7 % | **91.3 %** | 53.9 % | 35.1 % |
+
+† `LowSensitivity + TooSmall + TooFlat + TooLowHFR` — the four gates the optimizer holds a knob for.
+
+**`TooSmall` is the #2 gate on `D01` and `D03` and #3 on `D02`, and the controller's split does not mention
+it.** `MinimumStarBoundingBoxSize` landed at **6** on `D01` and `D02` — the highest in the bank — on the two
+rigs with the smallest stars, against a shipped default of 5 and a `WideField` preset that *lowers* it
+(`StarDetectionOptions.cs:209-212`). **The two-mechanism split survives; the second mechanism is the
+four-gate block, not one gate.**
+
+Also worth correcting for the record: the shipped **`WideField` preset does not raise sensitivity**. It
+lowers `StructureLayers` and `MinStarBoundingBoxSize` by one each. The high sensitivity is entirely the
+optimizer's landing.
+
+### 2.4 "This is [F83](followups.md)'s objective from the opposite end — work out what the high sensitivity IS being bought with" — **already answered, and the answer is `J`'s fit term**
+
+[F83](followups.md) (Open, source-derived, zero compute) establishes that on an unlabelled run
+`J = (0.55·sFocus + 0.20·sStars + 0.25·sFit)/(Σw)`, `SMarginalSnr` ships at `0.0`, and *"nothing charges for
+a wrong detection"*. **The corollary the controller wants is the contrapositive and it is equally
+mechanical: nothing charges for a MISSED detection either, beyond `sStars`' count term at weight 0.20.**
+Raising sensitivity trades `sStars` (weight 0.20) against `sFocus` + `sFit` (weight 0.80) — and on a rig
+whose marginal stars are HFR-noise, discarding them tightens the sequence and buys more than the count term
+loses. **The optimizer is behaving correctly for the objective it was given.** No wave-28 measurement is
+needed to establish that, and none is proposed.
+
+**And the remedy the controller is circling is already fenced.** [F84](followups.md): *"any floor on the
+Sensitivity axis alone"* is **KILLED** (clip-axis escape); [F23](followups.md)'s hard floor at 6 was measured
+**worse than doing nothing**; `MarginalSnrStrength` is **FENCED** on void-calibrated evidence. **Wave 28
+proposes nothing on the sensitivity axis.**
+
+### 2.5 "The `NO CANDIDATE` half may be answerable from SOURCE at zero compute — if so, price it at zero" — **agreed, and taken further: TWO of the three halves are zero-compute**
+
+Accepted without reservation, and extended: §2.2 (the welded cutoff) **and** §7 (the shipped message that is
+factually false below the band) are both source findings at zero compute, and the blind empirical test
+(§5, `RULE W28-B`) reads artifacts already on disk. **Wave 28's only compute is one ~8-minute arm.**
+
+### 2.6 "Say which population carries the verdict and keep it distinct from what has been looked at" — **the bank cannot supply a blind wide-field DATASET, and this is a hard structural fact**
+
+Ranked by arcsec/px, the three widest datasets in the bank are `D01` (19.389), `D02` (5.745) and `D03`
+(3.102). **They are exactly the three the controller has read.** The fourth-widest is `D04` at 1.410 ″/px —
+**a factor of 2.2 down from `D03` and 13.8× down from `D01`.**
+
+> **There is no unread dataset anywhere in the bank in the regime where the gap lives. Any dataset-level
+> verdict about wide-field recall is a verdict on rows that have been read.**
+
+That kills the obvious rule shape. **The verdict is therefore relocated to the FRAME**, where a blind
+population does exist: 20 datasets × 9 frames = 180 frames, of which the controller has read the aggregate
+attribution for 5 datasets and this pre-registration has read the per-frame block for 3. **153 frames across
+17 datasets remain unread, and every one carries a published per-frame recall and a published truth PSF
+size.** §5 builds the rule there, and §6 states the blindness ledger exactly.
+
+### 2.7 "Wave 27's `RULE D27` moved recall on 7 rows but `D01`/`D02`/`D03` are factor-1 and unaffected — confirm from the artifacts" — **CONFIRMED, and it is stronger than "unaffected"**
+
+From `/mnt/d/hf_w27/d27_score_controller.txt`, verbatim: `manifest rows: 7`, and the seven are
+`D08 D09 D10 D12 D14 D15 D17`. `D01`, `D02`, `D03` appear nowhere in the file. The controller is right that
+the gap is unchanged.
+
+**The stronger statement, which §1.2 derives:** `D27` is not merely *silent* about the wide-field rows, it is
+**the same measurement from the other side of the same band**. Both are "recall recovers as in-focus PSF
+approaches 2–4 detection pixels". `D27` could act because binning divides; item 8 cannot, because nothing
+multiplies.
+
+---
+
+## 3. WHAT IS ACTUALLY OPEN, AFTER §1 AND §2
+
+| # | open question | reachable how | cost |
+|---|---|---|---|
+| **(i)** | Is the lower-scale cutoff the **blur**, welded to `StructureLayers`? Is [F43](followups.md)'s "fewer layers is worse" a confound? | **source**, then one arm | **0** + arm |
+| **(ii)** | Is the 2–4 px band **real out-of-sample**, or is it a story fitted to three read datasets? | 153 unread frames already on disk | **0** |
+| **(iii)** | Does relieving the **binarization threshold** (`NoiseClippingMultiplier`) convert `NO CANDIDATE` into detections, as [F43](followups.md) measured on a *real* 19.4″/px rig but nobody has measured on the bank? | one no-build arm | **~8 min** |
+| **(iv)** | Does the product **tell** a user their rig is below the band? | source | **0** |
+
+Everything else in item 8 is either done (§1.1) or fenced (§2.4).
+
+---
+
+## 4. `RULE W28-S` — the welded cutoff, decided from source
+
+**Verdict domain:** `S-WELDED` · `S-SEPARATE` · `S-UNEVALUATED`.
+
+Three clauses, each a mechanical assertion against HEAD, each with both branches reachable (any future edit
+flips them — which is the point of writing it as a rule rather than as prose):
+
+| clause | assertion | FAIL end |
+|---|---|---|
+| `S-a` | `StarDetector.cs:632`'s blur width argument is `p.StructureLayers * 2 + 1`, i.e. **raw**, not `effectiveStructureLayers` | the argument is `effectiveStructureLayers` or a dedicated field |
+| `S-b` | no member of `StarDetectorParams` controls the post-wavelet blur width independently of `StructureLayers` | such a member exists |
+| `S-c` | `EffectiveStructureLayers(p)` reaches the **residual** (`:611`, `:619`, `:622`) and **not** the blur | it reaches both |
+
+**F68's five parts.** POPULATION: the single artifact `Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/StarDetector.cs`
+at the wave's HEAD commit, recorded by sha256 in the scorer's output; FIELD: the literal argument
+expressions at the three cited sites. STATISTIC: boolean per clause. AGGREGATION: conjunction — all three.
+EMPTY: the file or a cited line not being present is `S-UNEVALUATED`, **never a pass**. WHICH COPY: there is
+one `ConvolveGaussian` call in `BuildDetectionContextInternal`; the scorer asserts the **count of matching
+call sites is exactly 1** and refuses on any other count, so a second copy cannot be silently read past.
+
+**`S-WELDED` iff all three hold.** I expect it to hold — it holds at the commit I read. **Because I expect
+it to hold, it is NOT a ship gate** (§9): a conjunct known-true at pre-registration is a one-clause rule
+wearing two clauses, and the charter's discipline forbids exactly that.
+
+---
+
+## 5. `RULE W28-B` — the band, tested BLIND on 153 frames nobody has read, at zero compute
+
+**This is the rule that carries the wave's verdict.** It takes the theory built on the three read datasets
+and makes it predict the *sign* of a quantity on 14 datasets whose per-frame numbers this document has not
+opened — and the prediction **flips sign** across the band, which no trivial confound produces.
+
+### 5.1 The prediction
+
+The three read datasets sit **below** the band and their recall **rises with defocus** — worst at best
+focus, because that is where the PSF is smallest:
+
+| | in-focus | ±1 | ±2 | ±3 | ±4 |
+|---|---|---|---|---|---|
+| `D01` per-frame recall | **0.001** | 0.049 | 0.211 | 0.238 | 0.203 |
+| `D02` | **0.006** | 0.220 | **0.791** | 0.456 | 0.228 |
+| `D03` | **0.142** | 0.237 | 0.280 | 0.252 | 0.231 |
+
+Datasets **above** the band must do the **opposite**: their in-focus PSF is already at or past 3 px, so
+defocus takes them *further* out of the band and recall must be **highest at focus**.
+
+### 5.2 The statistics — two routes, and the second removes the reference detector entirely
+
+For each dataset `d`, with `f*` = the frame of minimum `|defocusMicrons|` and `f_lo`/`f_hi` the two extreme
+frames:
+
+```
+Δrecall(d) = R(d,f*) − ½·( R(d,f_lo) + R(d,f_hi) )        route 1: golden-denominated
+Δacc(d)    = A(d,f*) / max(1, ½·( A(d,f_lo) + A(d,f_hi) )) − 1     route 2: DETECTOR ONLY
+```
+
+**Route 2 exists because route 1 has a named confound and route 2 does not.** The golden's per-frame
+denominator is itself PSF-dependent — [F31](followups.md) established that the reference tiers by
+**peak-pixel** SNR, so it *"evaporates toward the sweep wings"*, and on `D01` the golden runs 3 500 at the
+wings against 18 846 at focus. **`Δrecall` therefore mixes detector behaviour with reference behaviour.**
+`Δacc` reads the `acc` column — accepted-star count, pure detector output, no golden involved — and is
+immune to it. **Both are pre-registered; the verdict requires them to AGREE IN SIGN.** A disagreement is a
+finding, not something to average.
+
+### 5.3 The classes and the bars
+
+Class from `K(d) = max(truthModel.hfrMin, truthModel.hfrMinEffective)`, the in-focus kernel HFR in captured
+pixels — and `table18` was scored at detection binning **1** on all 20 rows, so `K(d)` is what the detector saw.
+
+| class | condition | prediction | blind members |
+|---|---|---|---|
+| **LOW** | `K < 1.5` | `Δ < 0` (focus is the WORST frame) | `D04`, `D16`, `D18`, `D20` — **4** |
+| **MID** | `1.5 ≤ K < 2.5` | **none** — reported, excluded from the verdict | `D05`, `D06`, `D19` — 3 |
+| **HIGH** | `K ≥ 2.5` | `Δ > 0` (focus is the BEST frame) | `D07`–`D15`, `D17` — **10** |
+
+`D01`/`D02`/`D03` are **LOW** and are **excluded from the verdict population** (§6) — they are what the
+prediction was built on.
+
+| clause | bar | reachable FAIL |
+|---|---|---|
+| `B-1` | `sign(Δrecall) == sign(Δacc)` on **≥ 13 of 14** | the two routes disagree on ≥ 2 |
+| `B-2` | prediction correct on **≥ 12 of 14** predicted datasets, **and ≥ 1 correct in each of LOW and HIGH** | 3+ wrong, or a class entirely wrong |
+| `B-3` | **all 4 LOW datasets have `Δacc < 0`** | any LOW dataset detects more stars at focus than in its wings — which falsifies the lower edge on data this document has not read |
+
+**`W28-B` = `B-BANDPASS`** iff `B-1` ∧ `B-2` ∧ `B-3`. **`B-REFUTED`** if `B-2` or `B-3` fails.
+**`B-SPLIT`** if `B-1` fails — the two routes disagree, and then neither is quoted.
+
+**Why the FAIL end is genuinely reachable, stated before the data:** the sign flip is a *strong* claim.
+`B-3` in particular is one dataset away from failing at any time, and `D04`/`D16`/`D18`/`D20` sit at
+`K ≈ 1.04–1.08` — only 1.4× below the LOW boundary and **2× above** the 0.700 the prediction was built on.
+If the lower edge is sharper than 1.5 px, `B-3` fails and the wave says the band is narrower than claimed.
+
+### 5.4 F68's five parts, per clause
+
+| part | `B-1` / `B-2` / `B-3` |
+|---|---|
+| **POPULATION** (artifact) | `/mnt/d/hf_w25/table18/<dataset>.log`, the `PER-FRAME (sorted by focuser)` block; and `/mnt/d/SyntheticAutofocusBank/<dataset>/synthetic_meta.json`, `truthModel`. Both **read-only**; wave 28 writes nothing under either root |
+| **POPULATION** (membership) | the 17 datasets excluding `D01`/`D02`/`D03`; **computed** as `set(all) − set(EXCLUDED)` with `EXCLUDED` a named constant, never typed as a list of 17 |
+| **STATISTIC** | `Δrecall` from the `recall` column; `Δacc` from the `acc` column; `K` from `max(hfrMin, hfrMinEffective)` |
+| **AGGREGATION** | count of sign-matches over the 14 predicted datasets; MID's 3 are computed and printed, and **excluded by name from every denominator** |
+| **EMPTY** | a dataset whose log has no `PER-FRAME` block, or fewer than 3 frames, or no `truthModel.perFrame`, is **`CNL-NOFRAMES`**: it leaves the denominator, which prints as `k of 14` with **k computed**, and the wave states which datasets left. A verdict on `k < 10` is **`B-UNDERPOWERED`**, not a pass |
+| **FIELD — which copy** | **The `recall` column of the `PER-FRAME` block is ALL-TIER.** The log also prints `recall@high` — but only in `OVERALL`, never per frame. `Δrecall` is therefore **not** a statement about `recall@high`, and the wave must not write it as one. `Δacc` has no tier at all. The scorer asserts the header line reads exactly `focuser  dsteps  golden  acc   TP   FP   FN   prec   recall   f1` before parsing a single row, and refuses otherwise |
+
+### 5.5 What `B-BANDPASS` would and would not establish
+
+**Would:** that the detector's recall is band-pass in in-focus PSF size with the band where
+`DetectionBinningResolver` says it is, established out-of-sample with a sign flip; and that item 8 and
+`RULE D27` are one phenomenon.
+
+**Would not:** anything about *why* the lower edge is where it is (that is `W28-S`, source), anything about
+whether it is fixable (that is `W28-N`), and anything at all about **real** frames — [F35](followups.md)'s
+standing caveat applies unchanged: *"its real-bank population on this bank is **empty** … the user-facing
+benefit is **unproven on real frames**. Do not claim otherwise."*
+
+---
+
+## 6. BLINDNESS LEDGER — stated once, exactly, before any wave-28 statistic
+
+**READ (and therefore excluded from every wave-28 verdict population):**
+
+| what | by whom | scope of the burn |
+|---|---|---|
+| aggregate high-tier FN attribution, `D01` `D02` `D03` `D07` `D18` | the controller, in the invoking brief | those 5 datasets, that block |
+| full `golden eval` block incl. `PER-FRAME`, `D01` `D02` `D03` | **this document**, §1/§2/§5.1 | those 3 datasets, all fields |
+| `truthModel` (pixel scale, `hfrMin`, `hfrMinEffective`, per-frame kernel HFR) — **all 20 datasets** | **this document**, §1.2/§1.3 | **none** — see below |
+| `d27_score_controller.txt` in full | this document, §2.7 | the 7 `D27` datasets, that file |
+
+**Why reading the truth model on all 20 costs no blindness:** it is **generator configuration**, fixed
+before any detector ran, and it is the rule's **x-axis**. The rule's y-axis — per-frame `recall` and `acc` —
+is unread on 17 datasets. Reading the independent variable is how a population is *stratified*; reading the
+dependent variable is how a rule is *pre-empted*. **The wave must not blur these, and this table exists so a
+later reader can check that it did not.**
+
+**BLIND, and carrying the verdict: the `PER-FRAME` blocks of the 17 datasets other than `D01`/`D02`/`D03` —
+153 frames.** `D07` and `D18` are burned for the aggregate attribution block and blind for `PER-FRAME`;
+`W28-B` reads only `PER-FRAME`, so they stay in. **This distinction is load-bearing and is asserted in the
+scorer**, which refuses to read any `OVERALL` or `ATTRIBUTION` line from the 17.
+
+---
+
+## 7. THE PRODUCT DEFECT, found in source at zero compute, and it needs no wave-28 measurement
+
+Take a rig below the band — `D01` at an in-focus HFR of 0.7 px — and walk
+`DetectionBinningResolver` as it ships:
+
+```
+RecommendFromHfr(0.7)            = Clamp(round(0.7 / 3.0)) = Clamp(0) = 1
+DiffersFromRecommendation(1,0.7) = (1 != 1) = false
+ShouldShowRecommendation(1,0.7)  = !IsUsableHfr(0.7) || false = FALSE
+```
+
+**So the recommendation row is not shown at all.** And if the user finds the tooltip anyway,
+`DescribeRecommendationDetail` takes its `recommended > 1 ? … : …` else-branch
+(`DetectionBinningResolver.cs:100-104`) and tells them:
+
+> *"Star detection is calibrated for in-focus stars of roughly 2 to 4 px, and **0.7 px is already in that
+> range**, so binning is not needed."*
+
+**0.7 px is not in the 2–4 px range. The product states the band correctly and then asserts a value 4.3×
+below it satisfies the band.** The clamp is one-sided — `Clamp` floors at 1 — so *every* under-sampled rig
+takes this branch and is told it is in range.
+
+**This is not a candidate finding awaiting a measurement.** It is a shipped false statement, provable by
+arithmetic on 8 lines of source, on the exact class of rig item 8 is about. It is a ~15-line fix with a unit
+test and no behaviour change.
+
+**Related, and deliberately NOT bundled:** the machinery to say the true thing already exists but is
+**wizard-only** — `HasUndersampledStars` (`StarDetectionOptimizerWizardVM.cs:237-238`) with its text at
+`:2330-2343`, and `MinHfrSeed.IsBelowGate` (`MinHfrSeed.cs:113-120`). **A plain autofocus run is silent.**
+Surfacing it outside the wizard is a larger change and is gated in §9.
+
+---
+
+## 8. `RULE W28-N` — the one arm: does relieving the binarization threshold recover the structure gap?
+
+**The only measurement in the wave, and it can kill the wave's own proposal.**
+
+[F43](followups.md) found that on the reporter's **real** 61 MP 19.4″/px rig *"the binding gate is
+`NoiseClippingMultiplier`, not `Sensitivity`"* — `NC → 1.0` took a starless in-focus frame to 3 511 stars.
+**Nobody has run that on the bank, and `NC` is precisely the bar the blurred sub-pixel star must clear
+(`StarDetector.cs:653`).** If §2.2's amplitude account is right, lowering `NC` must convert
+`NO CANDIDATE` into detections; if it does not, the loss is upstream in the residual subtraction and §2.2 is
+wrong.
+
+**No binary.** `golden eval --params optimized --opt-results <dir>` reads each dataset's
+`optimized_settings.json`; the arm copies the seedA0 tree into `/mnt/d/hf_w28/` and edits **one field**.
+`table18`'s tree and every bank sidecar are read-only.
+
+**Arm:** `D01`, `D02`, `D03` × `NC ∈ {landed, 2.0, 1.0}` = **9 cells**. `NC` landed at 3.8125 on `D01`.
+
+| clause | statistic | bar | FAIL end |
+|---|---|---|---|
+| `N-1` **the edit took effect** | the `key detector knobs:` line each log echoes, field `NoiseClip=` | prints the intended value on **9 of 9** | run one cell from an **unedited** copy and confirm it echoes the landed value — a positive control, on a real cell, not a fixture |
+| `N-2` **the mechanism** | high-tier `NO CANDIDATE (structure gap)` count | at `NC = 1.0`, falls by **≥ 25 %** vs the landed `NC`, on **3 of 3** | it does not fall ⇒ §2.2 is **refuted**, the loss is in the residual, and the wave says so |
+| `N-3` **the cost** | `precision` from `OVERALL` | **≥ 0.90 on 3 of 3** at `NC = 1.0` | precision collapses ⇒ `NC` is not a remedy, and the wave reports it as a dead end **against its own proposal** |
+
+**`W28-N` = `N-RECOVERS`** iff `N-1` ∧ `N-2` ∧ `N-3`. **`N-REFUTED`** if `N-2` fails.
+**`N-COSTED`** if `N-2` holds and `N-3` fails — *the mechanism is real and the lever is unusable*, which is a
+different and more useful result than either pass or fail.
+
+**F68's five parts.** POPULATION: 9 `golden_eval.txt` under `/mnt/d/hf_w28/nc/<dataset>_nc<v>/`; FIELD: for
+`N-2` the count on the `NO CANDIDATE (structure gap)` line **inside the `HIGH TIER ONLY` block** — the log
+prints that identical line twice, once per block, and **the aggregate copy is the wrong one**
+(`GoldenEvalRunner.cs:763` vs `:774`); the scorer anchors on the block header and asserts it consumed
+exactly one. STATISTIC/AGGREGATION: per-dataset ratio, counted over 3. EMPTY: a missing or truncated
+`golden_eval.txt` is `CNL-NOLOG`, leaves the denominator, `k of 3` with k computed; `k < 3` ⇒
+`N-UNDERPOWERED`, never a pass.
+
+**Price.** `golden eval` is **6–46 s per 9-frame cell** and a full 20-dataset arm was **349 s**
+(wave 27's measured rate; the charter's §5 budget table still has **no `golden eval` row** — [F21](followups.md)).
+`D01` is the bank's largest golden (62 411 high-tier stars) and prices at the top of that range. **9 cells ≈
+5–8 minutes**, plus the tree copy and the scorer.
+
+**Deliberately NOT in this arm:** a `StructureLayers` sweep. It is the confounded axis (§2.2) and sweeping it
+without a build would re-measure [F43](followups.md)'s confound and re-learn its wrong lesson. **The
+decoupling experiment needs a build that separates the blur width from the layer count, and it is priced and
+deferred in §11.**
+
+---
+
+## 9. WHAT SHIPS, AND THE SHIP RULE — fixed here, before the data
+
+| # | change | ship rule | both branches reachable? |
+|---|---|---|---|
+| **(1)** | **Fix the false in-band statement** (§7): `DescribeRecommendationDetail` must not assert a sub-band HFR "is already in that range", and `ShouldShowRecommendation` must return true when the measurement is **below** the band | **UNCONDITIONAL** — charter §1a's *"ship unconditionally where the ship is not what the rule decides"*. Its correctness is arithmetic on shipped source and depends on **no** wave-28 statistic | n/a by design, and **said so here rather than dressed as a gate** |
+| **(2)** | **Surface the below-band condition outside the wizard** | **GATED on `W28-B` = `B-BANDPASS`.** If `B-REFUTED` or `B-SPLIT` or `B-UNDERPOWERED`, it does **not** ship and is recorded as a costed recommendation | **YES** — `B-2`/`B-3` are one dataset from failing, on 14 datasets this document has not read |
+| **(3)** | anything on the `Sensitivity` axis | **DOES NOT SHIP.** Fenced by [F84](followups.md)/[F23](followups.md) (§2.4) | n/a — not proposed |
+| **(4)** | decoupling the blur from `StructureLayers` | **DOES NOT SHIP IN WAVE 28.** A detector change of this reach owes a fresh 42 m `optimize` baseline and a re-derivation. §11 | n/a — deferred by price, not by verdict |
+
+**Change (1) is why this wave is worth running even if every rule fails**: a user below the band is currently
+shown nothing, and told they are in range if they look.
+
+**Suite discipline.** Baseline **3973**, verified **by COUNT out of the log**, never by the tick
+([F37](followups.md)). Change (1) adds unit tests for `DescribeRecommendationDetail` and
+`ShouldShowRecommendation` **below**, **inside** and **above** the band — three cases, so the below-band case
+cannot pass by accident. `dotnet test <sln>` does **not** build `TestApp`; it is built separately or a
+compile break never surfaces.
+
+---
+
+## 10. PRICE, PER HALF, AND SCORED AGAINST THE OWNER'S THREE GOALS
+
+| half | what | binary? | compute | wall | goals |
+|---|---|---|---|---|---|
+| **(S)** the welded cutoff | `RULE W28-S`, source | no | **0** | 30 m | **1** ✓✓ |
+| **(B)** the band, blind | `RULE W28-B`, 153 unread frames on disk | no | **~1 min** (parse) | 75 m (scorer + self-test) | **1** ✓✓✓ |
+| **(N)** the `NC` arm | `RULE W28-N`, 9 cells | **no** | **5–8 min** | 60 m | **1** ✓✓ |
+| **(D)** ship (1), the false statement | product + 3 unit tests | build | 0 | 60 m + suite ~4 m | **1** ✓✓, **3** ✓ |
+| **(R)** the record | design + results + register + results-table correction | no | 0 | 45 m | — |
+
+**Total ≈ 4.5 h wall, ≈ 10 minutes of compute**, inside the charter's ~6 h. **The wave is 98 % analysis and
+2 % measurement, and that is the correct shape for an item whose evidence was already on disk.**
+
+**Goal scoring.** Every half scores on **goal 1** (*works across a wide range of setups, bridging detected
+gaps*) — this is the bank's widest-setup failure. (D) also scores **goal 3** (*avoiding parameters pinned to
+extreme values*) obliquely: it is the first product surface that tells a user their rig is outside the
+regime the knobs were calibrated for. **Nothing here scores goal 2.**
+
+---
+
+## 11. IS `D01` A LEGITIMATE CONFIGURATION? — the controller's question, answered, and the answer is not the one asked for
+
+The controller asks whether the honest answer is *"this rig is outside the detector's sampling regime and
+the product should SAY so"*, and offers it as an alternative to a recall fix. **Three corrections:**
+
+1. **The product does not need to decide this — it has already decided it, in `DetectionBinningResolver`'s
+   2–4 px band, and then failed to apply its own decision below the band (§7).** The question is not "should
+   we state a supported range"; the range is stated, in shipped user-facing prose. The question is "why is
+   it enforced on one side only", and the answer is a one-sided `Clamp`.
+2. **`D01` is legitimate as a *rig* and illegitimate as a *demand*.** A 40 mm lens at 19.4″/px is an
+   ordinary wide-field imaging setup and HocusFocus should focus it. But item 8's *statistic* asks the
+   detector to find 18 846 stars in a frame where each is one pixel across, and **finding them would not
+   help**: [F22](followups.md) measures the pixelization floor — below ~1.1 px, HFR **over-reads by up to
+   +234 %**, and `D01`'s 0.231 px optical vertex measures 0.77 px. **Stars recovered below the band carry
+   HFR that cannot resolve the V-curve's vertex.** Recovering them raises `recall@high` and does not
+   necessarily improve focus.
+3. **And the bank already says autofocus on `D01` works**: `BestJ` **0.994825** from a `BaselineJ` of
+   `0.000000`, `σ` 0.1514 from 0.6145 — the largest baseline-to-best move in the table. **So `recall@high =
+   0.183` and a working autofocus coexist on this rig.** The gap is real and it is **not, on this evidence,
+   costing the owner goal 1 on `D01`.** Where it demonstrably *does* cost something is
+   [F82](followups.md) — `D01`'s step-size recommendation **STALLED at 3 against a truth of 9** — and that
+   is goal **2**, is open, is priced at ~45 m + ~10 m, and **is a better-evidenced product gap than item 8
+   is.** Wave 28 does not take it, and says so here so the next wave can.
+
+**So: score both against the goals, as asked.** A recall fix on the structure stage scores goal 1 on a
+dataset whose autofocus already works, costs a detector change and a 42 m re-baseline, and cannot improve
+HFR quality below the pixelization floor. **A diagnostic scores goal 1 on every under-sampled rig, costs 15
+lines, and is the difference between a user seeing nothing and a user seeing the reason.** The diagnostic
+wins on this evidence, and §9(1) ships it.
+
+**Deferred, priced, not run:** the blur/layer decoupling build — **~45 m code, ~10 m arm, and a fresh 42 m
+`optimize` baseline plus re-derivation** if it were ever to ship. Wave 28 measures whether it is worth that
+(via `W28-N`) and does not spend it.
+
+---
+
+## 12. INSTRUMENTS AND CONSTRAINTS
+
+**Location** `/mnt/d/hf_w28/`, **LF endings**, derived from `/mnt/d/hf_w27/`.
+
+**Blocking pre-flight: `verify_derivation_w28.py`**, derived from `verify_derivation_w27.py`. **Carry
+forward [F87](followups.md)'s repair and do not regress it** — `in_historical_block()` must not treat the
+**definition line of `HISTORICAL_BLOCKS`** as opening a historical literal, which is what switched `V27-B`
+off from that line to EOF. **Self-test clause `[6]` is carried forward verbatim in intent**: a real
+historical block is exempt, the file after it is not, and the definition line opens nothing.
+**BOTH pinned FAIL fixtures are kept** — `/mnt/d/hf_w24` **and** `/mnt/d/hf_w26` — neither is "whatever came
+before" ([F80](followups.md)). Token matching by **SHAPE, not enumeration**, both affixes, `_` is a word
+character.
+
+**Standing rules, applied without exception:**
+
+- any scorer taking `--out` **refuses without it** (rc 2, nothing written)
+- `--self-test` is **never dispatched from a sourced file**; every self-test prints `SELFTEST <RULE> <n> of <n>`
+  and its output is **redirected to a file** — a self-test nobody captured exists only for its session
+- **populations asserted inside the file**; **ordinals computed, never typed**
+- paths through a **manifest**, never a template; `-print0 | sort -z | xargs -0`
+- [F88](followups.md): any provenance diff takes the **union** of `git diff --name-only` and
+  `git ls-files --others --exclude-standard`
+- [F89](followups.md): `touch` after every restore
+- [F90](followups.md): **reuse the computation, never the banner** — every scorer takes its rule label as an
+  **argument** and asserts it against the manifest it was handed
+- [F91](followups.md): a BEFORE/AFTER control builds **both** sweeps from **ONE expression** — one function,
+  called twice, population sizes asserted equal before any hash is compared
+- §8.1's verdict-tree gap: **every verdict tree in this wave is checked for total coverage of its outcome
+  space at pre-registration, and prints `<RULE>-TREE-GAP` rather than papering over an uncovered region**
+
+**Arm hygiene:** one `TestApp.exe` at a time; no NINA during a pinned arm; scorers take **WSL paths**;
+`TestApp.exe` gets `< /dev/null`; logs stay ASCII; `--profile-id` pinned on the arm and its inertness stated
+with its `n`, not assumed. `/mnt/d/hf_w25/table18/` and `/mnt/d/SyntheticAutofocusBank/` are **read-only**
+and a fingerprint class over both is taken BEFORE and AFTER **from one expression**.
+
+---
+
+## 13. WHAT WAVE 28 WILL NOT RUN, AND WHAT IT COSTS
+
+| not run | price | why |
+|---|---|---|
+| the blur/layer **decoupling build** | ~45 m + ~10 m arm (+42 m baseline to ship) | §11. `W28-N` decides whether it is worth it |
+| any `StructureLayers` sweep without that build | ~5 m | confounded in source (§2.2); would re-learn [F43](followups.md)'s wrong lesson |
+| [F82](followups.md) — `D01`'s stalled step recommendation | ~45 m + ~10 m | **better-evidenced than item 8** and scores goal 2; named for wave 29 (§11.3) |
+| new datasets rendered between 1.4 and 19.4 ″/px | unpriced, ≥ 1 h render | the only way to get a **blind wide-field dataset** (§2.6). `W28-B`'s frame-level route makes it unnecessary for *this* verdict; it stays the honest fix for the bank's coverage hole |
+| [F83](followups.md)'s `P-D08` at n = 3 (`D01` + `D16` at raised sensitivity) | **~2 min** | *"the cheapest decision-moving measurement left in the register"* — genuinely cheap, but it is a **precision** question on a fenced axis and wave 28 is a recall wave. **Named so it is not lost** |
+| wave 27's open controls (`S27-1`, three mutant records) | ~20 m | instrument debt, scores zero on all three goals; §12 of the wave-27 results prices them |
+| anything on real frames | — | the bank has **no** real under-sampled dataset ([F35](followups.md), [F43](followups.md)). **Every wave-28 conclusion is synthetic-only and must be written that way** |

--- a/docs/synthetic-af-bank-followups-wave28-results.md
+++ b/docs/synthetic-af-bank-followups-wave28-results.md
@@ -1,0 +1,869 @@
+# Wave 28 — results
+
+## THE TIMESTAMP — the roll call, taken at an instant
+
+```
+$ ls -la --time-style=full-iso /mnt/d/hf_w28/
+drwxrwxrwx  ...  2026-08-13 11:47:49.495626200 -0400 .
+   returned at 2026-08-13T11:51:02-04:00  (= 2026-08-13T15:51:02Z)
+```
+
+The most recent artifact at that instant is `fp_AFTER.txt` (`11:50:17`, 45 seconds earlier); the newest before
+it is `w28n_score.txt` (`11:47:05`). No `TestApp.exe` was running — the arm printed `W28N_ARM_END` at
+`15:46:58Z` — and nothing was mid-write.
+
+| row | state at **15:51:02Z** | artifact |
+|---|---|---|
+| `RULE W28-S` | **CLOSED** 11:35:00; self-test captured 11:37:24 | `w28s_score.txt`, `w28s_selftest.txt` |
+| `RULE W28-B` | **CLOSED** 11:39:23; manifest 11:39:14, interlock written | `w28b_score.txt`, `w28b_manifest.tsv`, `W28B_MANIFEST_READY` |
+| `RULE W28-N` | **CLOSED** 11:47:05; arm ended 11:46:58, 10 cells all `exit=0` | `w28n_score.txt`, `w28n_manifest.tsv`, `w28n_arm.log` |
+| **ship (1)** | **CLOSED** — committed `6f2b62b`, suite log 11:38:20 | `suite_AFTER_ship1.log`, `suite_w28.marker` |
+| `RULE V28` (pre-flight) | **CLOSED** 11:06:36, self-test 11:07:42, both FAIL fixtures 11:07:56 / 11:08:04 — **and its verdict is `V-UNEVALUATED`, not the plan's `V-CLEAN`** (§7.3) | `vdrift_w28.txt`, `vdrift_selftest_w28.txt`, `vdrift_failend_B.txt`, `vdrift_failend_C.txt` |
+| `W28-FP` fingerprint | **BOTH SWEEPS CLOSED** — BEFORE 11:13:39, AFTER 11:50:17. **The verdict LINE was never captured to a file** and is recomputed in this document from the two sweeps (§6.2) | `fp_BEFORE.txt`, `fp_AFTER.txt` |
+| ship (1)'s **mutant records** (`M1`–`M6`) | **NO ARTIFACT** — nothing under `/mnt/d/hf_w28/` records a mutant turning a test red; the claim is in the commit message only (§7.6) | — |
+| `fp_w28.sh` **self-test** capture | **NO ARTIFACT** — `SELFTEST W28FP` appears in no file in the root (§7.7) | — |
+| ship (2) | **NOT OWED** — its gate (`W28-B` = `B-BANDPASS`) did not hold, and it did not ship (§5.2) | — |
+
+**Unlike wave 27 at its first timestamp, every scorer's self-test is on disk**: `SELFTEST W28S 35 of 35`,
+`SELFTEST W28B 46 of 46`, `SELFTEST W28N 38 of 38`, plus `SELFTEST W28B-MANIFEST 11 of 11` and
+`SELFTEST W28N-ARM 18 of 18`. Two smaller captures are missing and are named above rather than assumed.
+
+**Vessel.** Wave 28 ran on `ghilios/synthetic-af-bank-followups-wave27` and its two commits (`37a2a06`
+pre-registration, `6f2b62b` ship (1)) sit on **PR #196**, verified `OPEN MERGEABLE` on
+`ghilios/synthetic-af-bank-followups-wave27` at the time of writing. **Design §0 pre-registered a fresh
+`…wave28` branch and #196 staying on its own** — the wave did the opposite. Recorded as a controller deviation
+in §13, not laundered.
+
+---
+
+## §0 — What this document is allowed to say
+
+Every number below is quoted from an artifact under `/mnt/d/hf_w28/`, from `/mnt/d/hf_w25/table18/`, or from a
+file in the repository, and each is cited. The pre-registered rules in
+`docs/synthetic-af-bank-followups-wave28-design.md` are **applied as written**. Where a rule turned out to be
+unsatisfiable, under-specified or gap-ridden, that is reported as a **finding** (§7, §8) — it is not repaired,
+and no repaired version is scored. Wave 28 continues wave 27's branch and PR; this document is its fifth section
+in substance and its own file in form.
+
+**Everything below is synthetic-only.** The bank has no real under-sampled dataset
+([F35](followups.md), [F43](followups.md)); design §13 says every wave-28 conclusion must be written that way,
+and it is.
+
+**Verdicts, in one table.**
+
+| rule | verdict | population | artifact |
+|---|---|---|---|
+| **`RULE W28-S`** | **`S-WELDED`** — 3 of 3 clauses | 2 source files at HEAD, by sha256 | `w28s_score.txt` |
+| **`RULE W28-B`** | **`B-SPLIT`** — and the band-pass hypothesis is **REFUTED on the half item 8 is about** | 14 predicted datasets of 17, `k = 14 of 14` | `w28b_score.txt` |
+| **`RULE W28-N`** | **`N-RECOVERS`** — `k = 3 of 3` | 9 arm cells + 1 control | `w28n_score.txt` |
+| **`W28-FP`** | **`PRESERVED`** — 1 080 of 1 080 byte-identical, 0 moved | 440 `table18` + 640 bank files | `fp_BEFORE.txt` / `fp_AFTER.txt` |
+| **`RULE V28`** | **`V-UNEVALUATED`** over a root of **one file**; self-test **PASS**; both FAIL fixtures evidenced | 1 file checked | `vdrift_w28.txt` |
+| **ship (1)** | **SHIPPED**, unconditional | suite **3997** by COUNT, `SUITE_EXIT=0` | `suite_AFTER_ship1.log` |
+| ship (2) | **DID NOT SHIP** — gated on `B-BANDPASS`, which did not hold | — | — |
+
+---
+
+## §1 — THE HEADLINE: the same intervention splits the two regimes the design split, and one of them does not recover
+
+`RULE W28-N` lowered a single field — `NoiseClippingMultiplier`, the binarization threshold at
+`StarDetector.cs:653` that a blurred sub-pixel star must clear — on the three datasets the generator itself
+flagged as un-renderable below 0.7 px. **The structure gap collapses on all three. The recall does not follow on
+all three.**
+
+| dataset | `K` px | `recall@high` landed → NC 2.0 → **NC 1.0** | `recall@all` landed → **NC 1.0** | high-tier `NO CANDIDATE` landed → **NC 1.0** | precision at 1.0 |
+|---|---|---|---|---|---|
+| `D01_ultrawide_40mm` | 0.700 | 0.183 → 0.189 → **0.195** | 0.123 → **0.183** | 42 991 → **8 931** (**−79.2 %**) | **1.000** |
+| `D02_rich_135mm` | 0.700 | 0.446 → 0.523 → **0.687** | 0.377 → **0.598** | 3 732 → **1 071** (**−71.3 %**) | **1.000** |
+| `D03_redcat_250mm` | 0.700 | 0.365 → 0.389 → **0.549** | 0.238 → **0.364** | 197 → **7** (**−96.4 %**) | **1.000** |
+
+— read off `nc/<dataset>_nc<v>/attempt01/golden_eval.txt`; counts in parentheses are the
+`FALSE-NEGATIVE ATTRIBUTION, HIGH TIER ONLY` block, never the aggregate copy.
+
+**`D02` gains +0.241 of `recall@high` and `D03` +0.184 — a quarter and a fifth of the scale — at no measured
+precision cost. `D01` does not.** Its `NO CANDIDATE` count falls by 79.2 % — 34 060 high-tier golden stars that
+now form candidates where they formed none before — and its `recall@high` moves **+0.012**, from 11 400 to
+12 162 of 62 411.
+
+### 1.1 Where `D01`'s loss actually lives, and the sentence this wave is not allowed to write
+
+The high-tier attribution block accounts for the missing 34 060 exactly:
+
+| high-tier FN, `D01` | landed (`NC` 3.8125) | **`NC` 1.0** | Δ |
+|---|---|---|---|
+| `NO CANDIDATE (structure gap)` | 42 991 | 8 931 | **−34 060** |
+| `REJECTED:TooDistorted` | 1 010 | 14 876 | **+13 866** |
+| `REJECTED:LowSensitivity` | 786 | 13 612 | **+12 826** |
+| `REJECTED:TooSmall` | 4 857 | 11 372 | **+6 515** |
+| `ACCEPTED-elsewhere` | 462 | 701 | +239 |
+| `REJECTED:OnBorder` | 17 | 77 | +60 |
+| `REJECTED:Contaminated` | 692 | 533 | −159 |
+| `REJECTED:NotCentered` | 196 | 147 | −49 |
+| **total high-tier FN** | **51 011** | **50 249** | **−762** |
+
+**33 298 of the 34 060 newly formed high-tier candidates — 97.8 % — were re-rejected by a later gate. 762
+became detections.** `D01`'s attribution profile inverts: `NO CANDIDATE` falls from **84.3 %** of its high-tier
+loss to **17.8 %**, while the three gates that moved — `TooSmall` + `TooDistorted` + `LowSensitivity` — rise from
+**13.0 %** (6 653 of 51 011) to **79.3 %** (39 860 of 50 249). **At `NC` 1.0 `D01` looks like `D02` and `D03` did
+at their landed settings** (design §2.3: tunable-gate block 64.6 % and 91.3 %).
+
+**So the mechanism §2.2 proposed is real and it is not the whole story on the extreme rig.** The amplitude
+account is confirmed — relieve the binarization threshold and the candidates form — and on `D01` the loss simply
+moves one stage downstream. Its recovered stars are also mostly not high-tier: of `D01`'s **+6 552** total
+true positives, **+762** are high tier and **+5 729** are medium tier.
+
+**This wave did NOT localise `D01`'s residual loss, and cannot from these artifacts.** The gates fire in
+sequence — `TooSmall` (`StarDetector.cs:1757`) → `OnBorder` (`:1766`) → `TooDistorted` (`:1807`) → `Degenerate`
+(`:1823`) → `LowSensitivity` (`:1854`) — so the attribution is **first-rejection-wins** and the three counts are
+an ordering, not independent shares. 11 372 stars never reached the distortion test at all. Identifying which
+gate binds needs an arm that opens them one at a time; it is priced in §12 and it is **not** claimed here.
+
+**And [F22](followups.md) still stands over the whole question:** below ~1.1 px, measured HFR over-reads by
++26 % to +234 %, and `D01`'s 0.231 px optical vertex measures 0.77 px. **Stars recovered below the band carry an
+HFR that cannot resolve the V-curve's vertex.** Raising `D01`'s `recall@high` is not the same as improving its
+focus, and the bank already reports `BestJ` 0.994825 on `D01` from a `BaselineJ` of 0.000000.
+
+### 1.2 The two regimes are now measured to behave differently under the same intervention
+
+That is the wave's most important result and it is worth stating plainly. `D02` and `D03` are the case where the
+lever works: on `D02` the same edit relieves the downstream gates as well as the formation stage
+(`LowSensitivity` 5 916 → 2 925, `TooSmall` 3 235 → 1 971), and on `D03` `TooSmall` falls 1 032 → 94. Lowering
+the threshold there produces *better-formed* regions, not merely more of them. On `D01` the same edit produces
+regions that fail the size gate 2.3× more often than before. **One knob, one direction, two outcomes — and the
+covariate that separates them is not `K`, because all three datasets are rendered at `K = 0.700`.**
+
+---
+
+## §2 — `RULE W28-S` = **`S-WELDED`**, 3 of 3, at zero compute
+
+> `>>> RULE W28-S = S-WELDED (3 of 3 clauses hold: ['S-a', 'S-b', 'S-c'])` — `w28s_score.txt`
+
+| artifact | sha256 |
+|---|---|
+| `StarDetection/StarDetector.cs` | `1e20277797c1be05babab7365cff6a5a1d45a0637bff3f4e893715949663cce7` |
+| `Interfaces/IStarDetector.cs` | `5304ed5f42a400593b06efcd132be45865406ae2f6ed5586089c4f28b153b910` |
+
+Both hashes still hold at `HEAD 6f2b62b` — ship (1) touched neither file — so the verdict is current, not merely
+current as of the scoring run.
+
+| clause | measured |
+|---|---|
+| `S-a` | the blur width argument at line 632 is literally **`p.StructureLayers * 2 + 1`** — raw, not `effectiveStructureLayers` |
+| `S-b` | (i) the only `StarDetectorParams` member reachable from that argument is `StructureLayers`; (ii) of the class's **55** properties, **none** matches the declared blur-width name pattern `(?i)(blur\|gauss\|convolve\|smooth\|kernel)` |
+| `S-c` | `EffectiveStructureLayers(p)` binds at 611 and is used at 611/619/622, reaching the **residual** at 619 and 622 and appearing **0 times** inside the blur call's argument list; 0 unaccounted use sites |
+
+Verdict tree: **27 regions enumerated, 0 uncovered.**
+
+**What it means, and it is the finding the design promised at zero compute:** at the shipped
+`StructureLayers = 4` the post-wavelet kernel is 9×9 and σ ≈ 1.44 px, so a 1-px delta loses roughly
+`1/(2πσ²) ≈ ×0.077` of its peak before it is compared against the binarization threshold — and the width of that
+blur is set by the knob that controls the *upper* scale cutoff. **One knob sets two opposing cutoffs.** The
+defocus/donut boost already widens the residual and deliberately leaves the blur alone
+(`StarDetector.cs:1567-1578`), so the codebase decouples them in one direction and has never decoupled them in
+the other.
+
+**Per design §4 and §9 this is a FINDING, not a ship gate**, and it is reported as one. It re-opens
+[F43](followups.md): see §9's amendment, which is applied in place.
+
+Worth recording for the next reader: **`D03`'s landed settings run `StructureLayers = 3`**, so its blur is 7×7
+at σ ≈ 1.12 px while `D01` and `D02` run 9×9 at σ ≈ 1.44 px. The optimizer has already moved this knob on one of
+the three floored datasets, and it moved both cutoffs when it did.
+
+---
+
+## §3 — `RULE W28-B` = **`B-SPLIT`**, and the unifying hypothesis is REFUTED below the band
+
+> `>>> RULE W28-B = B-SPLIT   (k = 14 of 14 predicted; MID excluded by name: ['D05_tec140_1000mm', 'D06_sparse_1000mm', 'D19_cygnus_deep_shed'])`
+> — `w28b_score.txt`
+
+Populations were computed, not typed: 20 bank datasets − 3 `EXCLUDED` = **17**, less 3 MID = **14 predicted**,
+`k = 14 of 14` with **0 datasets leaving the denominator**. The blindness guard held: the reader returns the
+`PER-FRAME` slice alone and the log text never leaves it, demonstrated on a real published log that carries both
+attribution blocks.
+
+### 3.1 The clauses, every ordinal computed
+
+| clause | measured | bar | result |
+|---|---|---|---|
+| `B-1` sign agreement | **11 of 14** | 13 of 14 | **FALSE** |
+| `B-2` prediction correct | **9 of 14**, per class `HIGH 9` / **`LOW 0`** | 12 of 14, ≥ 1 per class | **FALSE** |
+| `B-3` all 4 LOW have `Δacc < 0` | **0 of 4** | 4 of 4 | **FALSE** |
+
+`B-1` fails, so the pre-registered verdict is **`B-SPLIT`**, and design §5.3's consequence applies: on a split
+**neither route is quoted** as the verdict-bearing statistic. Verdict tree: 432 regions enumerated, 0 uncovered.
+
+### 3.2 The refutation, stated without softening
+
+**`Δacc` — the detector-only route, no golden involved — is POSITIVE on all 17 datasets in the population,
+including all four LOW datasets.** The predicted sign flip at the band's lower edge **does not occur**:
+
+| class | prediction | outcome |
+|---|---|---|
+| **HIGH** (`K ≥ 2.5`, 10 datasets) | `Δ > 0`, focus is the best frame | **9 of 10 correct**; only `D15_cdk20_3454mm_e47` fails, and it fails on route 1 alone (`Δrecall −0.0280`, `Δacc +9.0000`) |
+| **LOW** (`K < 1.5`, 4 datasets) | `Δ < 0`, focus is the worst frame | **0 of 4.** `D04 +4.6120`, `D16 +0.5682`, `D18 +9.3125`, `D20 +0.1660` on `Δacc` — every one detects **more** stars at focus than in its wings |
+
+`B-3` reads `Δacc` alone, so its failure does not depend on which route a reader trusts. **The "two edges of one
+band" framing survives above the band and dies below it.** Design §5.3 named this exact failure in advance —
+*"if the lower edge is sharper than 1.5 px, `B-3` fails and the wave says the band is narrower than claimed"* —
+and it is the wave's job to say so rather than to re-draw the boundary.
+
+### 3.3 The route disagreement is unidirectional, and that is a finding in itself
+
+The two routes disagree on **5 of 17** datasets — `D05`, `D15`, `D16`, `D18`, `D19` — and **all five disagree in
+the same direction: `Δrecall < 0 < Δacc`. Not one goes the other way.**
+
+That is exactly the confound design §5.2 created route 2 to escape. [F31](followups.md) established that the
+reference tiers by **peak-pixel** SNR, so the golden evaporates toward the sweep wings; the per-frame denominator
+is therefore largest at focus, and route 1 is biased against the focus frame on every dataset where the effect is
+large enough to flip a sign. **The disagreement is not noise, it is attributable, and route 1 is the route it
+impeaches.** The design pre-registered *"a disagreement is a finding, not something to average"*; the finding is
+that the disagreements have one sign and one named cause.
+
+### 3.4 What the three read datasets do on the same statistics — diagnostic, and explicitly NOT part of the rule
+
+`D01`/`D02`/`D03` are excluded from the population because the prediction was built on them. Computing the
+pre-registered statistics on them anyway, from the arm's landed cells (which reproduce `table18` exactly, §4.3):
+
+| dataset | `K` px | `Δrecall` | `Δacc` |
+|---|---|---|---|
+| `D01_ultrawide_40mm` | 0.700 | −0.202 | **−0.969** |
+| `D02_rich_135mm` | 0.700 | −0.222 | **−0.973** |
+| `D03_redcat_250mm` | 0.700 | −0.089 | **+0.253** |
+
+**On the detector-only route the below-band dip exists on exactly two datasets in the whole bank, and a third
+dataset at the same `K = 0.700` does not show it.** `D03`'s recall dips at focus while its accepted-star count
+rises — the §3.3 confound again, on a read dataset this time.
+
+**So `K` does not separate the dip from the non-dip even at the floored value.** That is the same refutation
+shape the design itself applied to the controller's ordering by arcsec/px (§1.3), turned on the design's own
+covariate. It is recorded as diagnostic. **It is NOT a repaired class boundary and nothing is re-scored on it** —
+choosing a new boundary with these columns in hand is precisely what the [F14](followups.md) / `RULE D20` fence
+forbids. Wave 29 may pre-register a sharper stratification; §12 prices it.
+
+### 3.5 A limitation of the pre-registered statistic, named because `D03` is where it bites
+
+`Δ` compares the focus frame against **the two extreme wing frames only**. The accepted-star profiles of the
+floored datasets are humped, peaking at ±2 steps: `D01` reads `738, 1772, 3539, 953, 23, 944, 3572, 1798, 738`
+and `D03` reads `104, 182, 269, 223, 136, 228, 263, 188, 113`. On `D03` the focus frame is far below its
+neighbours (136 against 223/228) and above its extremes (104/113), so the pre-registered statistic returns
+`+0.253` where a neighbour-based one would return a negative number. **The statistic is applied as written and
+its coarseness is reported, not corrected.**
+
+### 3.6 What `B-SPLIT` does and does not establish
+
+**Does:** the sign flip is not a property of in-focus PSF size at the 1.5 px boundary the design drew;
+above the band the prediction holds on 9 of 10 blind datasets; route 1 carries a measurable, unidirectional
+reference confound.
+
+**Does not:** anything about *why* the two `K = 0.700` datasets that dip do dip and the third does not; anything
+about real frames; and — per design §9 — it does not license ship (2), which therefore did not ship.
+
+---
+
+## §4 — `RULE W28-N` = **`N-RECOVERS`**, `k = 3 of 3`
+
+> `>>> RULE W28-N = N-RECOVERS   (N-1 True, N-2 True, N-3 True; k = 3 of 3)` — `w28n_score.txt`
+
+No build. The arm copied the seedA0 optimized-settings tree per cell and edited **one field**; the arm's own
+self-test proves the edit is surgical (`exactly 1 file changed, and it is the settings file`; an unedited tree
+fingerprints identically twice). Binary: `/mnt/d/hf_w25/exe/TestApp.exe`, `TestApp.dll` sha256
+`2fb0c8fd…` — the same B15 binary that produced `table18`.
+
+| clause | measured | bar |
+|---|---|---|
+| `N-1` the edit took effect | **9 of 9** arm cells echo their intended `NoiseClip=` on the `key detector knobs:` line | all |
+| `N-2` the mechanism | high-tier `NO CANDIDATE` falls **79.2 % / 71.3 % / 96.4 %** at `NC = 1.0` | ≥ 25 % on 3 of 3 |
+| `N-3` the cost | `precision` = **1.000 / 1.000 / 1.000** from `OVERALL` at `NC = 1.0` | ≥ 0.90 on 3 of 3 |
+
+**`N-1`'s control ran on a real cell and can fail.** An unedited copy of `D03`'s tree echoes `3.625` against a
+landed `3.625`; the same reader returns `1` on `D03`'s `NC = 1.0` cell; and the scorer prints the counterfactual
+— *"had this control been asked for 1.0 it would report MISMATCH"* — so the predicate is shown to track the file
+rather than agreeing by construction. The control sits **outside** every arm denominator and is named as such.
+
+**Which copy.** The `NO CANDIDATE (structure gap)` line appears twice in every report; the scorer anchors on the
+`FALSE-NEGATIVE ATTRIBUTION, HIGH TIER ONLY` header and asserts it consumed exactly one. Self-test [3]
+demonstrates the difference is real and would have changed the number: on `D01` landed the aggregate copy reads
+**48 811** and the high-tier copy reads **42 991**, and the aggregate copy appears **first** in the file, so a
+first-match reader would have taken the wrong one.
+
+### 4.1 `N-3` is satisfied and is a weak instrument on this population — say so
+
+`precision = 1.000` with `FP = 0` on **every** cell including all three landed baselines. It was 1.000 before the
+intervention and 1.000 after; the clause cannot distinguish "cost none" from "cannot see cost". The per-frame
+rows also show `acc` exceeding `TP` throughout — `D01` landed frame 5964 reads `acc 738, TP 709, FP 0` — so 29
+accepted detections were neither confirmed nor charged. **`N-3` passes as written; a reader should treat it as
+"no precision cost was detected by an instrument that reported no precision cost at baseline either", not as a
+measured price of zero.** Wave 27's `scoredFraction` finding (§3 of that document) is the general form of this
+and applies here unchanged.
+
+### 4.2 `N-RECOVERS` is NOT a ship, and nothing in wave 28 says otherwise
+
+**No wave-28 rule pre-registered a ship on the `NoiseClippingMultiplier` axis.** Design §9's ship table lists
+four items and `NC` is not among them; §9(3) fences the sensitivity axis and §9(4) defers the blur decoupling by
+price. More importantly: **the optimizer CHOSE the landed values** — 3.8125, 3.9375, 3.625 — under the objective
+`J`, and [F83](followups.md) establishes that `J` charges nothing for a missed detection beyond `sStars` at
+weight 0.20. A default or bound change on this axis therefore owes its own wave: a pre-registered ship rule, a
+fresh `optimize` baseline (the landings themselves move), and a re-derivation. §12 prices it.
+
+### 4.3 An unpre-registered control that came free, and it is worth keeping
+
+**The three landed cells reproduce the published `table18` rows exactly** — `TP`/`FP`/`FN`, `recall@high`,
+`recall@high+med` and `recall@all` all identical on `D01`, `D02` and `D03`, against a tree copied from seedA0 and
+re-run through a pinned `--profile-id`. Design §2.3's `51 011` high-tier FN on `D01` and its 84.3 % `NO
+CANDIDATE` share reproduce on the nose. **That makes every `NC` delta in §1 attributable to the one edited
+field**, and it is a stronger control for this arm than the `--profile-id` inertness probe (`n = 1 dataset`,
+carried forward from wave 27 and stated with its `n` as the charter requires). Reported as opportunistic, not as
+a pre-registered gate.
+
+---
+
+## §5 — What shipped
+
+### 5.1 ship (1) — the false in-band statement, **UNCONDITIONAL**, shipped
+
+`6f2b62b`, `DetectionBinningResolver.cs` +64 −12, `DetectionBinningResolverTests.cs` +88.
+
+The defect, provable by arithmetic on shipped source and needing no wave-28 statistic: `RecommendFromHfr(0.7)`
+clamps to 1, `DiffersFromRecommendation` is therefore false, `ShouldShowRecommendation` returns **false**, and if
+the user finds the tooltip anyway it tells them *"0.7 px is already in that range"* about a 2–4 px band. The
+clamp is one-sided, so **every** under-sampled rig took that branch.
+
+| changed | to |
+|---|---|
+| `MinCalibratedHfrPixels` | **new**, `= TargetHfrPixels - 1.0` — an expression, not a literal, so the edge cannot drift from the centre |
+| `IsBelowCalibratedBand` | **new**, the ONE helper behind all three call sites |
+| `DescribeRecommendationDetail` | a third arm: below the band, say so, say binning only **divides**, and point at `MinHFR` ([F35](followups.md), [F43](followups.md)) |
+| `DescribeRecommendation` | a third arm on the **visible row** — see the scope extension in §13 |
+| `ShouldShowRecommendation` | **true** below the band, so the row is shown to exactly the users it was hidden from |
+
+**`RecommendFromHfr` is unchanged** and is pinned by a 16-HFR test spanning below/in/above band plus
+`NaN`/0/negative. No recommended binning value moves for any input; this changes what the user is **told**.
+
+**Suite: `Passed: 3997, Failed: 0, Total: 3997`, `SUITE_EXIT=0`, 3 m 33 s** — read by COUNT out of
+`suite_AFTER_ship1.log` ([F37](followups.md)), never by the tick. **The baseline was 3992, not the design's
+3973** (§7.5); the delta is **+5** and the commit names 5 new tests.
+
+### 5.2 ship (2) — did not ship, and that is the rule working
+
+Design §9(2) gated surfacing the below-band condition outside the wizard on `W28-B = B-BANDPASS`. The verdict is
+`B-SPLIT`. **It does not ship and is recorded as a costed recommendation** (§11, §12). The rule was not
+renegotiated after the number was seen; plan step 7 says so and it was followed.
+
+---
+
+## §6 — The controls
+
+### 6.1 `RULE V28` — self-test PASS, both FAIL fixtures evidenced, and a verdict of `V-UNEVALUATED`
+
+`vdrift_selftest_w28.txt` ends `>>> SELF-TEST PASS` with all six clause groups, including `[6]` in both
+directions — *"the block is exempt (line 3) and the file after it is NOT (line 7)"* and *"the DEFINITION of
+`HISTORICAL_BLOCKS` opens nothing — it is not an instance of itself"*, which is [F87](followups.md)'s repair
+carried forward and proved not to have regressed. The three affix shapes are demonstrated in both directions, and
+the wave's own affixed names are shown **not** to be reported, so the check discriminates.
+
+**Both pinned FAIL fixtures refuse, with their counts printed:**
+
+| fixture | clause | findings |
+|---|---|---|
+| `/mnt/d/hf_w27` | `V28-B` | **262** unlicensed previous-wave tokens (267 total findings: 4 × `V28-A`, 262 × `V28-B`, 1 × `V28-C`), first `d27_arm_w27.sh:51` |
+| `/mnt/d/hf_w24` | `V28-C` | **2** typed ordinals in printed output — `gate_w24.sh:221` (`'thirteenth'`), `prov_w24.py:179` (`'11/12/13'`) |
+| `/mnt/d/hf_w26` | `V28-B` | **0** — the expiry is demonstrated, which is why the `-B` fixture had to move |
+
+The `-B` fixture moving to `/mnt/d/hf_w27` is a deviation from design §12's pair and is assessed in §13.
+
+**And the run over the wave's own root certifies almost nothing** — §7.3.
+
+### 6.2 `W28-FP` = **`PRESERVED`**, recomputed here because the verdict line was never captured
+
+`fp_w28.sh` builds both sweeps from **one** `sweep()` function called twice ([F91](followups.md)), asserts
+`POPULATION` inside each file, and refuses to compare when the two disagree. Both files are on disk and are
+**byte-identical to each other**; each asserts `ROOTPOPULATION /mnt/d/hf_w25/table18 440`,
+`ROOTPOPULATION /mnt/d/SyntheticAutofocusBank 640`, `POPULATION 1080`, and each carries 1 080 hash lines.
+
+Re-running the script's own `compare` logic over the two artifacts:
+
+```
+BEFORE asserted 1080 hashed 1080 ; AFTER asserted 1080 hashed 1080
+missing 0 extra 0 MOVED 0
+>>> W28-FP = PRESERVED (1080 of 1080 byte-identical, 0 moved)
+```
+
+The read-only roots were read and not written. **The verdict line itself has no artifact** — the driver prints it
+on `after` and nothing redirected it — so it is reproduced above from the two sweeps rather than quoted (§7.7).
+
+---
+
+## §7 — FINDINGS: each is a defect in a rule or an instrument. Reported, not repaired
+
+### SEVERITY 1
+
+#### 7.1 `W28-B` refutes the design's own unifying hypothesis on the under-sampled half
+
+Stated in full in §3.2 and not softened here. `Δacc > 0` on **all 17** datasets; `B-3` is **0 of 4**; `B-2`'s LOW
+class is **0 of 14 correct out of 4 members**. The design's framing — item 8 and `RULE D27` are *"two edges of
+one band"* — **survives above the band (9 of 10) and dies below it.** The `LOW` class at `K ≈ 1.04–1.08` behaves
+like the `HIGH` class, and the only datasets that behave as predicted are two of the three the prediction was
+built on.
+
+**The verdict is robust to the one place `B-2` was under-specified.** Counting a dataset "correct" on route 1
+alone would give `LOW 2 of 4` (`D16`, `D18`) and `HIGH 9 of 10`, i.e. **11 of 14 — still below the 12 bar**, and
+`B-1` does not depend on that reading at all. **Neither reading rescues the hypothesis.**
+
+#### 7.2 `W28-N`'s verdict tree never gates on `N-1` — and this is the SECOND consecutive wave with a verdict-tree gap
+
+> `the DESIGN's tree, enumerated over 135 regions, leaves 4 uncovered -- every one of them is a`
+> `  region where N-1 is FALSE, which the design's tree never gates on. That is a finding about`
+> `  the pre-registration, recorded here and NOT repaired mid-wave.`
+> `the design's literal tree would return: N-RECOVERS`
+> — `w28n_score.txt`
+
+Design §8 defines `N-RECOVERS` as `N-1 ∧ N-2 ∧ N-3` in prose and then writes a tree — `N-REFUTED` if `N-2`
+fails, `N-COSTED` if `N-2` holds and `N-3` fails, `N-UNDERPOWERED` if `k < 3` — in which **`N-1` appears
+nowhere**. A run where the edit silently did not take effect would have been scored `N-RECOVERS` by the tree as
+written. The scorer returns `N-TREE-GAP` in those four regions, enumerates them, and prints what the design's
+literal tree would have said, so a reader can see both. **It did not fire this wave** (`N-1` is 9 of 9), and
+self-test [5] demonstrates it firing on a fixture where a cell echoes the landed value while intending 1.0.
+
+**This is a class, not an incident.** Wave 27 §8.1 carried the same defect on `RULE T27` (`SAT = 3, CHANCE = 3`
+matched no clause), and wave 27's §12 item 6 asked for it to be fixed *in the next wave's pre-registration*.
+Wave 28's design §12 duly made total coverage a standing rule — *"every verdict tree in this wave is checked for
+total coverage of its outcome space at pre-registration"* — **and then shipped a tree with four uncovered
+regions.** The standing rule was written and not executed. `W28-S` (27 regions) and `W28-B` (432 regions) both
+enumerate clean; only the rule with a validity clause outside its own tree does not. Registered as
+[F94](#f94-ready-to-paste).
+
+#### 7.3 The blocking pre-flight certified a root containing **one file** — itself
+
+`vdrift_w28.txt` reads `files checked: 1` and `>>> V-UNEVALUATED: no sibling target was referenced by any driver
+in this root`. It ran at **11:06:36**, when `/mnt/d/hf_w28/` held only `verify_derivation_w28.py`. **Every
+instrument the wave then wrote — `fp_w28.sh`, `score_w28s.py`, `score_w28b.py`, `score_w28n.py`,
+`w28b_manifest.sh`, `w28n_arm_w28.sh` — was created after that run and was never checked by it**, and the file
+was never re-run.
+
+Two consequences, both stated as they are:
+
+1. **The plan's gate is not met by the artifact.** Plan step 1 requires *"`vdrift_w28.txt` verdict is `V-CLEAN`
+   **and** its banner reads `RULE V28`"* before anything downstream runs. The banner does read `RULE V28` — the
+   [F87](followups.md) half of the gate holds and matters. The verdict reads `V-UNEVALUATED`, which the design
+   itself says is never a pass. The wave proceeded.
+2. **What it would have caught is unknown, and one candidate is visible.** `V28-C` looks for typed ordinals in
+   printed output; the drivers written afterwards are full of printed counts, all of which appear to be computed,
+   and `w28b_manifest.log`'s `predicted=14 (LOW=7 HIGH=10)` mixes two populations in one printed line (§7.10).
+   Whether the checker would have flagged that is not knowable without running it, and **this document does not
+   run it** — a pre-flight run at the end of the wave is a different instrument from a pre-flight.
+
+**This is [F80](followups.md)'s family in a new direction: not a pattern too narrow and not a population
+containing the instrument, but a population that was EMPTY at the only moment the check was taken.** A blocking
+gate that runs before the things it blocks exist blocks nothing. Registered as [F95](#f95-ready-to-paste).
+
+### SEVERITY 2
+
+#### 7.4 The design's Step 4 count assertion was **wrong as written** and would have made `W28-S` permanently `S-UNEVALUATED`
+
+Design §4 and plan step 4 both assert *"there is one `ConvolveGaussian` call in `BuildDetectionContextInternal`;
+the scorer asserts the count of matching call sites is exactly 1 and refuses on any other count."* The body spans
+lines 433–756 and contains **three**:
+
+```
+ConvolveGaussian call sites in that body, ALL: 3 at lines [535, 556, 632]
+  of which post-wavelet STRUCTURE-MAP blurs, ConvolveGaussian(structureMap, structureMap, ...): 1 at lines [632]
+```
+— `w28s_score.txt`
+
+The other two are the noise-reduction blurs keyed to `p.NoiseReductionRadius` — **a different knob at a different
+stage**. Taken literally the pre-registered assertion fails at HEAD, and its declared consequence is refusal:
+`S-UNEVALUATED`, forever, on correct source. The scorer scoped the count to the structure-map pair, which is
+exactly 1, **printed both numbers**, and named the design's phrasing as loose. Self-test [1] proves the two
+noise-reduction blurs are *seen and excluded* rather than invisible, and self-test [5] proves both ends of the
+count assertion: two structure-blur sites refuse (naming the count they saw), zero sites refuse as well.
+
+#### 7.5 Step 4 named ONE source artifact; `S-b` needs TWO
+
+Design §4's POPULATION is *"the single artifact `StarDetector.cs`"*. `S-b`(ii) asks whether any
+`StarDetectorParams` member controls the blur width independently — and `StarDetectorParams` is declared in
+`Interfaces/IStarDetector.cs`. The scorer records **both** sha256s (§2) and self-test [6] makes the point
+explicitly: *"an absent `StarDetectorParams` class REFUSES — `S-b`'s population is the SECOND artifact, and the
+design naming only the first is under-specified."*
+
+#### 7.6 `B-1`'s bar is **unsatisfiable at `k = 12`** taken verbatim, and `B-2`'s "correct" was undefined under a split
+
+Two under-specifications in design §5.3, both resolved in the open in the scorer's header rather than guessed
+silently:
+
+1. **The bars at a reduced denominator.** The design fixes 13 of 14 and 12 of 14 and then permits a verdict down
+   to `k = 10` without saying what the bar is below 14. **Taken verbatim, `B-1` is unsatisfiable at `k = 12`** —
+   13 agreements out of 12 datasets — for a reason that has nothing to do with the routes agreeing. The scorer
+   applies the pre-registered **rates**, ceilinged: `bar(k) = ceil(num·k/den)`; self-test [7] asserts that at
+   `k = 14` this reproduces **13** and **12** exactly, so the scaling can only engage on a population the wave
+   already lost rows from. It never engaged: `k = 14 of 14`.
+2. **What "prediction correct" means when the routes disagree.** The design says a disagreement is *"not
+   something to average"* and that on a split *"neither is quoted"*, so the scorer counts a dataset correct only
+   when **both** route signs equal the prediction. §7.1 shows the verdict is the same under the alternative
+   reading.
+
+#### 7.7 Two captures that exist only for the session that ran them
+
+**ship (1)'s six mutants (`M1`–`M6`) have no artifact.** The commit message states each of the 5 new tests was
+shown RED against a named mutant, with byte backups, `touch` after restore ([F89](followups.md)) and sha256-verified
+restores. **Nothing under `/mnt/d/hf_w28/` records a red run.** This is wave 27 §7.4 recurring one wave later:
+green tests are not a mutant kill, and F89's own entry says untested testimony from a mutation harness is exactly
+the class of claim that needs a file. Price to close: **~10 m**.
+
+**`fp_w28.sh --self-test` has no artifact either.** The script has a four-clause self-test including F91's own
+shape (*"differing MEMBERSHIP is UNEVALUATED, never a false VIOLATED"*), and `TIMING.tsv` records *"self-test 4
+of 4"*, but no file in the root contains `SELFTEST W28FP`. Same for the `W28-FP` verdict line (§6.2). Price:
+**~2 m** for both.
+
+#### 7.8 The design's suite baseline was stale by 19 tests
+
+Design §9 fixes *"Baseline **3973**"* and a gate of ≥ 3973 + 3. The real baseline entering wave 28 was **3992**
+(wave 27 added 19 with `TruthDisclosureTests.cs`), and the suite closed at **3997**. The gate as written is
+satisfied either way, so nothing turns on it — but a baseline quoted from two waves back would have hidden a
+19-test regression, and the pre-registration is where that number is supposed to be current.
+
+### SEVERITY 3 — traps the disciplines caught themselves
+
+#### 7.9 A real bug the smoke run caught: locating a method by its first name occurrence starts at a **call site**
+
+`score_w28s.py` originally located `BuildDetectionContextInternal` by the first textual occurrence of the name.
+In the real source that occurrence is a **call**, not the declaration, so the "body" began at the call site and
+contained **zero** blur calls — which, under the count assertion, would have refused with a confident and wrong
+`S-UNEVALUATED`. Declarations are now discriminated from calls, and **an overloaded declaration refuses rather
+than picking a body** (*"an ambiguous population is a could-not-look, not a coin toss"*). Self-test [10] asserts
+both, and asserts that the first textual occurrence is genuinely earlier than the located declaration — so the
+discrimination is doing work rather than agreeing by luck. The same group proves a `ConvolveGaussian` decoy
+inside a string literal is blanked (length-preserving, so offsets stay aligned) and cannot inflate the count.
+
+#### 7.10 Live traps: CRLF, and a fingerprint written inside the tree it sweeps
+
+* **Every `table18` log carries CRLF.** `score_w28b.py` strips `\r` before any comparison and self-test [10]
+  asserts the guard on a **real published log**, not a fixture: *"the real log carries CRLF and both attribution
+  blocks"*. A parser that had compared the header line raw would have refused all 20 datasets on column identity.
+* **F91's population assertion fires when a fingerprint is written inside the tree it fingerprints.**
+  `w28n_arm_w28.sh:65-67` records it in place: *"Writing `fp_before.txt` inside the directory being swept makes
+  the AFTER population one larger than the BEFORE one and reports three changed files where one changed — caught
+  by the population assertion at this file's own self-test, which is what it is for (F91)."* The remedy is
+  structural — the per-cell fingerprints live in `nc/fp/`, outside every tree they sweep.
+* **A denominator defect caught before it could print.** `score_w28b.py` self-test [6]: *"a could-not-look on a
+  MID dataset does NOT move the predicted denominator — it was never in it, and counting it there would print
+  `k of 15` on a population of 14."* MID is excluded from every denominator by name, and a MID dataset that goes
+  missing is still named rather than disappearing.
+
+#### 7.11 `w28b_manifest.log` prints two populations in one line
+
+`rows=20  excluded=3  population=17  MID=3  predicted=14  (LOW=7 HIGH=10)`. The `LOW=7 HIGH=10` is over all 20
+rows (LOW includes the three excluded datasets); `predicted=14` is not `7 + 10`. Within the predicted population
+LOW is **4** and HIGH is **10**, as `w28b_score.txt` prints unambiguously. Cosmetic, in a driver log, and named
+so a reader does not try to reconcile 14 with 17.
+
+---
+
+## §8 — What the design left unsatisfiable, under-specified or gap-ridden
+
+**Each is reported, not repaired. None was re-decided to make a verdict land.** The remedy in every case has the
+same order: **fix the rule first, in a pre-registration, and re-score afterwards — on a population measured after
+the fix** ([F14](followups.md) / `RULE D20`).
+
+| # | defect | fired? | verdict-determining? |
+|---|---|---|---|
+| §7.2 | **`W28-N`'s tree never gates on `N-1`** — 4 of 135 regions uncovered | no (`N-1` 9 of 9) | would be, if it fired |
+| §7.4 | **Step 4's `ConvolveGaussian` count assertion is wrong at HEAD** (3, not 1) | **yes** | **YES** — literally applied it forces `S-UNEVALUATED` on correct source |
+| §7.5 | Step 4 names one source artifact; `S-b` needs two | yes | no — refusal, not a wrong pass |
+| §7.6 | `B-1`/`B-2` bars undefined below `k = 14`; **`B-1` unsatisfiable at `k = 12`** | no (`k = 14`) | would be, on any could-not-look |
+| §7.6 | "prediction correct" undefined when the routes disagree | **yes — on 5 of 17** | **no** — §7.1 shows both readings fail `B-2` |
+| §3.5 | `Δ` reads only the two extreme wing frames, and the profiles are humped | yes (`D03`) | not in the population; diagnostic only |
+| §4.1 | `N-3` is a bar on a statistic that is 1.000 at baseline | yes | no — it passes, weakly |
+| §7.3 | the blocking pre-flight's population was empty when it ran | **yes** | no rule's numbers depend on it |
+| §7.8 | the suite baseline was stale by 19 | yes | no |
+
+**One rule shape is worth crediting rather than filing:** design §4 declared `W28-S` *"NOT a ship gate"* on the
+ground that a conjunct known-true at pre-registration is a one-clause rule wearing two clauses. It held, as
+predicted, and it is reported as a finding. That is the discipline working, in the same place wave 27 §8.7
+recorded it working.
+
+---
+
+## §9 — Register entries, ready to paste into `docs/followups.md`
+
+Continuing from [F91](followups.md). **`F43` is amended in place in the register itself** (its amendment is stated inside [F92](followups.md),
+under "Consequence for the register"), because it
+is an existing entry whose stated result is now known to be confounded.
+
+### F92 — The post-wavelet blur is WELDED to `StructureLayers`, so one knob sets two opposing scale cutoffs {#f92-ready-to-paste}
+
+**Status:** **Open — source-derived, zero compute, and it re-opens [F43](#f43)** (2026-08-13, wave 28,
+`RULE W28-S` = `S-WELDED`, 3 of 3)
+
+`StarDetector.cs:631-632` blurs the structure map immediately after the à trous residual is subtracted:
+
+```csharp
+// Step 5: Excluding large structures can cut off the outsides of large stars, or leave holes when far out
+//         of focus. Blurring smooths this out well for structure detection
+CvImageUtility.ConvolveGaussian(structureMap, structureMap, p.StructureLayers * 2 + 1);
+```
+
+with `sigma = 0.159758 * kernelSize` when unset (`CvImageUtility.cs:80-82`). At the shipped
+`StructureLayers = 4` the kernel is 9×9 and **σ ≈ 1.44 px**, so a 1-px source loses roughly `1/(2πσ²) ≈ ×0.077`
+of its peak amplitude **before** it is compared against
+`binarizeThreshold = median + NoiseClippingMultiplier · sigma` (`:653`).
+
+**The blur's stated purpose is to help LARGE and defocused stars, and its entire cost falls on small ones.**
+Its width is keyed to `StructureLayers`, which is the knob for the *upper* scale cutoff — the shipped tooltip
+says so: *"At the default of 4 (2⁴=16), structures larger than 16 pixels in size are excluded"*
+(`OptionsDataTemplates.xaml:444`). **Lowering `StructureLayers` therefore narrows the blur (helps a 1-px star)
+and makes the residual less smoothed (hurts it), in one move.**
+
+**Measured as a rule, both hashes recorded** (`/mnt/d/hf_w28/w28s_score.txt`, `StarDetector.cs`
+`1e202777…`, `IStarDetector.cs` `5304ed5f…`): the width argument is literally `p.StructureLayers * 2 + 1`
+(raw, **not** `EffectiveStructureLayers`); **no** member of `StarDetectorParams` — 55 properties — controls the
+blur width independently; and `EffectiveStructureLayers(p)` reaches the residual at `:619`/`:622` and appears
+**0 times** in the blur's argument list. The defocus/donut boost (`:1567-1578`) already decouples them in one
+direction, so **there is precedent for decoupling the other.**
+
+**Consequence for the register:** [F43](#f43)'s *"`StructureLayers` 4 → 2 makes it strictly worse"* moved both
+cutoffs at once and is **confounded in source**. The experiment that separates them has never been run.
+
+**Price to run it:** ~45 m code (a dedicated blur-width field defaulting to today's expression, so the default
+is bit-identical) + ~10 m arm; **plus a fresh 42 m `optimize` baseline and a re-derivation if it is ever to
+ship**, because the change reaches the detector. Design §11 defers it; `RULE W28-N` (see [F93](#f93-ready-to-paste))
+is the evidence that the amplitude account it rests on is correct.
+
+### F93 — `NoiseClippingMultiplier` is the binding gate below the calibrated band on the bank too — with one dataset where it is not enough {#f93-ready-to-paste}
+
+**Status:** **Open — measured, and explicitly NOT a licence to change a default** (2026-08-13, wave 28,
+`RULE W28-N` = `N-RECOVERS`, 3 of 3) · corroborates [F43](#f43) on synthetic frames · bounded by [F22](#f22)
+
+[F43](#f43) found that on a reporter's **real** 61 MP 19.4″/px rig the binding gate was `NoiseClippingMultiplier`,
+not `Sensitivity`. Wave 28 ran it on the bank: 3 floored datasets × `NC ∈ {landed, 2.0, 1.0}`, no build, one
+edited field per cell, 432 s.
+
+| dataset | `NC` landed | high-tier `NO CANDIDATE` landed → `NC 1.0` | `recall@high` landed → `NC 1.0` | `recall@all` | precision at 1.0 |
+|---|---|---|---|---|---|
+| `D01_ultrawide_40mm` | 3.8125 | 42 991 → **8 931** (−79.2 %) | 0.183 → **0.195** | 0.123 → 0.183 | 1.000 |
+| `D02_rich_135mm` | 3.9375 | 3 732 → **1 071** (−71.3 %) | 0.446 → **0.687** | 0.377 → 0.598 | 1.000 |
+| `D03_redcat_250mm` | 3.625 | 197 → **7** (−96.4 %) | 0.365 → **0.549** | 0.238 → 0.364 | 1.000 |
+
+**The mechanism is confirmed and the payoff is not uniform.** `D02` and `D03` gain +0.241 and +0.184 of
+`recall@high`. **`D01` does not:** 34 060 high-tier candidates now form, **97.8 % of them are re-rejected by a
+later gate** (`TooDistorted` +13 866, `LowSensitivity` +12 826, `TooSmall` +6 515), and `recall@high` moves
++0.012. Its attribution profile inverts — `NO CANDIDATE` 84.3 % → 17.8 %, those three gates 13.0 % → 79.3 % — so
+**at `NC = 1.0` `D01` looks like `D02`/`D03` did at their landed settings.** The gates fire in sequence
+(`TooSmall` → `OnBorder` → `TooDistorted` → `Degenerate` → `LowSensitivity`), so those counts are
+first-rejection-wins and **which gate binds on `D01` is NOT established.**
+
+**Three things this entry does not say.** (1) It is **not a ship**: no wave-28 rule pre-registered a change on
+this axis, and the optimizer *chose* the landed values under an objective that charges nothing for a missed
+detection ([F83](#f83)). A default or search-bound change owes its own wave with a fresh baseline. (2) The
+`precision = 1.000` is **1.000 at baseline too**, so `N-3` shows no detected cost rather than a measured cost of
+zero. (3) [F22](#f22) still binds: below ~1.1 px measured HFR over-reads by up to +234 %, so **stars recovered
+below the band carry an HFR that cannot resolve the vertex** — and `D01` already reaches `BestJ` 0.994825.
+
+**Artifacts:** `/mnt/d/hf_w28/nc/<dataset>_nc<v>/attempt01/golden_eval.txt`, `w28n_score.txt`,
+`w28n_manifest.tsv`. The three landed cells reproduce the published `table18` rows exactly, so every delta is
+attributable to the one edited field.
+
+### F94 — Verdict trees keep shipping with uncovered regions, and the standing rule against it did not stop the second one {#f94-ready-to-paste}
+
+**Status:** **Open — a class, now on its second consecutive wave** (2026-08-13, wave 28) · generalises wave 27
+§8.1 · belongs beside [F68](#f68) part 5
+
+Wave 27's `RULE T27` tree left `3 ≤ union ≤ 9` with neither set at 5 uncovered, and the scorer printed
+`T-TREE-GAP` rather than papering over it. Wave 28's design §12 turned that into a standing rule — *"every
+verdict tree in this wave is checked for total coverage of its outcome space at pre-registration"* — and then
+**`RULE W28-N`'s tree shipped with 4 of 135 regions uncovered, every one of them a region where `N-1` is
+false.** `N-1` is the clause that checks the edit took effect; a run where it silently did not would have scored
+`N-RECOVERS` on the tree as written.
+
+**The pattern is specific and predictable: the uncovered region is always the VALIDITY clause.** `N-2` and `N-3`
+are substantive and appear in every branch; `N-1` is the gate that says the measurement happened at all, it is
+expected to hold, and it fell out of the tree. `W28-S` (27 regions) and `W28-B` (432 regions) both enumerate
+clean — and neither has a validity clause outside its own conjunction.
+
+**Remedy, and it is mechanical rather than a reminder:** a design must **enumerate its own outcome space at
+pre-registration** — the scorers already do this in code, and printing `regions enumerated: N   uncovered: 0`
+costs nothing — and **every clause, including the ones expected to hold, must appear in the tree.** A scorer
+that finds a gap prints `<RULE>-TREE-GAP`, enumerates the uncovered regions, prints what the design's literal
+tree would have said, and **does not repair and re-score** (`/mnt/d/hf_w28/w28n_score.txt`, self-test [5]).
+
+### F95 — A blocking pre-flight that runs before the instruments exist certifies an empty population {#f95-ready-to-paste}
+
+**Status:** **Open — remedy known, not applied this wave** (2026-08-13, wave 28) · [F80](#f80)/[F87](#f87)'s
+family, third distinct shape
+
+`verify_derivation_w28.py` ran at `11:06:36` over `/mnt/d/hf_w28/`, which then contained exactly one file —
+itself. `vdrift_w28.txt` reads `files checked: 1` and `>>> V-UNEVALUATED: no sibling target was referenced by
+any driver in this root`. The wave's six instruments (`fp_w28.sh`, `score_w28s.py`, `score_w28b.py`,
+`score_w28n.py`, `w28b_manifest.sh`, `w28n_arm_w28.sh`) were all written afterwards and **were never checked**.
+The plan's gate required `V-CLEAN`; the design says `UNEVALUATED` is never a pass; the wave proceeded.
+
+**The self-test and both pinned FAIL fixtures are healthy** — `SELF-TEST PASS`, 262 `V28-B` findings on
+`/mnt/d/hf_w27`, 2 `V28-C` findings on `/mnt/d/hf_w24`, and `/mnt/d/hf_w26` demonstrating expiry with 0. **The
+instrument works; it was pointed at nothing.**
+
+**The class, stated so it survives this wave:** F80's first three gaps were a *pattern* too narrow; F87's was a
+*population containing the instrument*; this is a *population that was empty at the only moment the check was
+taken*. **A blocking pre-flight must be re-run at the wave's close over the finished root, and the closing run
+is the one whose verdict is quoted.** The pre-flight run proves the checker works; the closing run proves the
+wave is clean. They are two runs and this series has been conflating them. Price: **~2 m per wave.**
+
+### 9.5 Amendments owed to existing entries
+
+* **[F43](#f43) — AMEND IN PLACE, and it is the amendment this wave owes most.** The entry's *"`StructureLayers`
+  4 → 2 makes it strictly worse (0 at both central positions)"* is **confounded in source**, proved by
+  `RULE W28-S` = `S-WELDED` at zero compute. Lowering `StructureLayers` moves **two** cutoffs in opposite
+  directions: it narrows the post-wavelet Gaussian at `StarDetector.cs:632` (whose width is literally
+  `p.StructureLayers * 2 + 1`, so 4 → 2 takes the kernel 9×9 → 5×5 and σ 1.44 → 0.80 px, which **helps** a 1-px
+  star clear the binarization threshold) **and** shrinks the à trous residual's low-pass from ≈2⁴ to ≈2² px, so
+  `src − residual` retains less of the star (which **hurts** it, and by more). The measurement stands; the
+  **inference that the axis is useless does not**, because the two effects were never separated and no member of
+  `StarDetectorParams` can separate them. **F43's "`MinHFR` is the ONLY axis that rescues it" must now be read as
+  "the only axis that rescues it among those tested, on an axis set that contained a confounded knob."** See
+  [F92](#f92-ready-to-paste); and note [F93](#f93-ready-to-paste) finds a **second** axis that rescues `D01`'s
+  candidate formation (`NoiseClippingMultiplier` 3.8125 → 1.0 cuts its structure gap 79.2 %) — though not its
+  `recall@high`.
+* **[F62](#f62)** — append that wave 28 tested the "one band-pass phenomenon" claim out of sample and **it did
+  not survive below the band**. `RULE D27`'s upper-edge result is untouched and the prediction holds on **9 of 10**
+  blind datasets above the band; the lower-edge prediction fails on **0 of 4** LOW datasets, with `Δacc > 0` on
+  all 17. `RULE D27` and item 8 may still be two views of one mechanism, but the *evidence* for the unification is
+  one-sided and must be quoted that way.
+* **[F31](#f31)** — append a second, independent demonstration of the reference's wing evaporation: on wave 28's
+  blind population the golden-denominated and detector-only routes disagree on **5 of 17** datasets and **all
+  five disagree in the same direction** (`Δrecall < 0 < Δacc`). A per-frame recall statistic is biased against
+  the focus frame wherever the golden's denominator peaks there.
+* **[F21](#f21)** — extend the measured `golden eval` rate. Wave 27 recorded 6–46 s per 9-frame cell (full
+  20-dataset arm 349 s). **Wave 28's `D01` at `NC = 1.0` took 179 s** — 3.9× the previous maximum — because
+  lowering the threshold multiplies the candidate count. **Price a cell from the RANGE and from the knob
+  setting, not from the dataset alone.** Wave 28's 10 cells totalled 381 s of `TestApp` time inside a 432 s wall.
+* **[F35](#f35)** — its finding that *"the W class's recall is lost in candidate FORMATION — the structure map
+  never proposes 49 % of them"* now has a lever: `NoiseClippingMultiplier` converts most of that loss into
+  formed candidates ([F93](#f93-ready-to-paste)). On `D02`/`D03` they become detections; on `D01` 97.8 % of them
+  are re-rejected downstream, which is also where F35's *"`MinimumStarBoundingBoxSize` rejects another 17 % as
+  `TooSmall`"* now points.
+* **[F84](#f84)** — unchanged and re-affirmed: **wave 28 proposed and measured nothing on the `Sensitivity`
+  axis.** `D01`'s `LowSensitivity` count rising from 786 to 13 612 at `NC = 1.0` is a **downstream consequence**
+  of more candidates existing, not evidence for or against a sensitivity floor.
+* **`docs/synthetic-af-bank-results-table.md`** — add the **in-focus kernel HFR `K` (px)** column from
+  `truthModel` (`max(hfrMin, hfrMinEffective)`), and the note that `D01`/`D02`/`D03` are the **only three floored
+  by the generator** (`hfrMin < hfrMinEffective`), all at `K = 0.700` despite 19.4 / 5.7 / 3.1 ″/px. It reorders
+  the recall column into a monotone story and costs nothing. **Do not annotate it with a 2–4 px band claim
+  below the band** — `W28-B` is `B-SPLIT` and the lower edge is not established.
+
+---
+
+## §10 — Estimate vs actual ([F21](followups.md))
+
+From `/mnt/d/hf_w28/TIMING.tsv`:
+
+| step | est (m) | actual (m) | note |
+|---|---|---|---|
+| 0 vessel | 5 | **2** | continued on the w27 branch/PR #196 — §13 |
+| 1 pre-flight `V28` | 30 | **14** | `SELF-TEST PASS`; caught a controller `sed` (`V27_OK`, `_` is not a word boundary) |
+| 2 fingerprint BEFORE | 10 | **8** | 1 080 files (440 + 640), ONE sweep expression |
+| 3 ship (1) | 60 | **38** | 5 tests, 6 mutants, scope extended to the visible row; suite 3997 |
+| 4 `RULE W28-S` | 30 | **9** | `S-WELDED` 3 of 3; the count assertion caught the design's looseness |
+| 5 `RULE W28-B` | 75 | **14** | `B-SPLIT`; band-pass refuted below the band |
+| 6 `RULE W28-N` | 60 | **22** | `N-RECOVERS` 3 of 3; arm **432 s** against a 300–480 s estimate |
+| 8 fingerprint AFTER | 10 | **7** | `PRESERVED` 1 080 of 1 080 |
+| **rows with both figures** | **280** | **114** | **~59 % under** |
+
+**This is the third consecutive wave in which the analysis halves are over-priced.** Wave 27 was ~36 % under and
+named *"a pure-Python arm over artifacts already on disk is consistently over-priced by this series by a factor
+of 3–4."* Wave 28 is worse: `W28-B` was priced at 75 m and delivered in 14, and it is the rule that carried the
+verdict. **The one thing priced correctly was the only thing that ran a binary** — the `NC` arm, estimated
+300–480 s, actual **432 s**, inside its own band. The lesson is now specific enough to act on: **price
+compute from the measured rate and price analysis at a third of instinct.**
+
+**Rates measured this wave, to carry into the charter's §5 budget table:**
+
+| instrument | rate | how measured |
+|---|---|---|
+| `golden eval`, 9-frame cell, floored dataset at **landed** `NC` | **7 s** (`D03`) – **43 s** (`D01`) | `w28n_manifest.tsv` |
+| `golden eval`, 9-frame cell, **`NC = 1.0`** | **12 s** (`D03`) – **179 s** (`D01`) | `w28n_manifest.tsv` — the knob, not the dataset, sets the top of the range |
+| whole 10-cell `NC` arm incl. copies + fingerprints | **432 s** wall / 381 s in `TestApp` | `w28n_arm.log` |
+
+---
+
+## §11 — What was NOT run, and what it costs
+
+| not run | price | status |
+|---|---|---|
+| **ship (2)** — surfacing the below-band condition outside the wizard | **~45 m + suite** | **GATED AND THE GATE DID NOT HOLD.** `W28-B` = `B-SPLIT`, so per design §9(2) it does not ship and is a costed recommendation. The machinery exists and is wizard-only: `HasUndersampledStars` (`StarDetectionOptimizerWizardVM.cs:237-238`), `MinHfrSeed.IsBelowGate` (`MinHfrSeed.cs:113-120`). **Note ship (1) has now put a below-band message on the options row**, which changes what this item is worth |
+| **the blur/layer decoupling build** ([F92](#f92-ready-to-paste)) | **~45 m + ~10 m arm (+42 m baseline to ship)** | Deferred by price, not by verdict. `W28-N` says the amplitude account it rests on is **right**, which raises its value |
+| any `StructureLayers` sweep without that build | ~5 m | **Refused** — `W28-S` proves in source that it re-measures [F43](followups.md)'s confound |
+| **localising `D01`'s residual loss** (§1.1) | **~60 m + ~15 m compute** | **NOT RUN, and named as the wave's biggest un-answered question.** The gates are sequential, so it needs an arm that opens them one at a time |
+| **a `NoiseClippingMultiplier` default/bound change** | **design 60 m + ~1.7 h `optimize` baseline + re-derivation** | **NOT LICENSED** by wave 28 (§4.2) |
+| [F82](followups.md) — `D01`'s stalled step recommendation | ~45 m + ~10 m | Named by design §11 for wave 29; scores goal **2** |
+| new datasets rendered between 1.4 and 19.4 ″/px | ≥ 1 h render, unpriced | The only route to a **blind** wide-field dataset (design §2.6); the bank's coverage hole is unchanged |
+| [F83](followups.md)'s `P-D08` at `n = 3` | **~2 min** | Still *"the cheapest decision-moving measurement left in the register"*, still a precision question on a fenced axis |
+| wave 27's open controls (`S27-1`, `M-S1`/`M-S2a`/`M-S2b`) | ~20 m | **STILL OPEN**, one wave later |
+| **ship (1)'s `M1`–`M6` mutant records** | **~10 m** | **TESTIMONY** (§7.7) |
+| **`W28-FP` verdict + `fp_w28.sh` self-test capture** | **~2 m** | **NO ARTIFACT** (§7.7); the verdict is recomputed in §6.2 |
+| **a closing `V28` run over the finished root** | **~2 m** | **NOT RUN** (§7.3) — the only run happened over a root of one file |
+| anything on real frames | — | The bank has no real under-sampled dataset. **Every conclusion above is synthetic-only** |
+
+---
+
+## §12 — Wave 29, priced and scored against the owner's three goals
+
+Goals (charter §8): **(1)** optimization + autofocus works across a wide range of setups, bridging detected gaps;
+**(2)** accuracy of step-size recommendations; **(3)** appropriate exposure adjustments and avoiding parameters
+pinned to extremes.
+
+| # | item | price | goals | why now |
+|---|---|---|---|---|
+| **1** | **[F82](followups.md) — `D01`'s step-size recommendation stalled at 3 against a truth of 9.** Diagnosed to a line, two candidate fixes, priced | **~45 m + ~10 m** | **2** ✓✓✓ | **The design's own recommendation, and wave 28's evidence strengthens it.** It is a product defect with a mechanism (`SearchSpan` over `bestFit.Inputs`, so a shrinking bound drags cap and floor down together), on the same rig item 8 is about, and it is the only open item scoring goal 2. Item 8's own headline dataset already reaches `BestJ` 0.994825, so its recall gap is not costing goal 1 on `D01`; its **step size** is |
+| **2** | **Localise `D01`'s residual loss** — with `NC = 1.0` held fixed, open `MinimumStarBoundingBoxSize` (landed **6**, the bank's highest, against a shipped default of 5 and a `WideField` preset that *lowers* it) and `MaxDistortion` one at a time | **design 30 m + ~60 m + ~15 m compute** | **1** ✓✓, **3** ✓ | Wave 28 converted 34 060 `NO CANDIDATE` into 33 298 gate rejections and **did not say which gate binds**. The gates are sequential, so this needs an arm, not a re-read. It also scores goal 3: `MinBox = 6` on the two rigs with the smallest stars is a parameter pinned against the physics |
+| **3** | **Pre-register the lower edge properly and re-score `W28-B`** — the `LOW` class at `K ≈ 1.04` behaves like `HIGH`, and only 2 of 20 datasets dip on the detector-only route | **~30 m, zero compute** | **1** ✓ | §3.4's bracket is **diagnostic, not authority**, and the [F14](followups.md) fence forbids re-drawing the boundary with these columns in hand. Fix the rule first, then re-score. Cheap, and it settles what `DetectionBinningResolver`'s band means below 2 px |
+| **4** | **A `NoiseClippingMultiplier` ship rule, pre-registered, with a fresh baseline** | **60 m design + ~1.7 h baseline + re-derivation** | **1** ✓✓ | [F93](#f93-ready-to-paste) is a measurement, not a licence (§4.2). The optimizer chose the landed values; changing a default or a search bound moves the landings, so the baseline is not optional. **Do not run this before item 2** — the payoff on `D01` is currently +0.012 and item 2 decides whether it can be more |
+| **5** | **Close the instrument debt, all of it in one pass** — ship (1)'s `M1`–`M6` records, `fp_w28.sh`'s self-test capture, the `W28-FP` verdict line, a closing `V28` run, and wave 27's `S27-1` + three mutants | **~35 m total** | instrument | Five items, each ≤ 10 m, and three of them are one wave old already. [F95](#f95-ready-to-paste) in particular is a two-minute habit change |
+| **6** | **Make total tree coverage a mechanical step, not a standing sentence** ([F94](#f94-ready-to-paste)) | **~10 m** | instrument | The standing rule was written in wave 28's design §12 **and then not executed on wave 28's own tree**. A sentence did not work; enumerate the outcome space in the pre-registration |
+| **7** | The blur/layer decoupling build ([F92](#f92-ready-to-paste)) | ~45 m + ~10 m (+42 m to ship) | **1** ✓✓ | Now better-motivated than at pre-registration — `W28-N` confirms the amplitude account — but it is a detector change and owes a baseline. **After items 1–3** |
+
+**The recommendation, stated as a judgement rather than a table row.** Take **item 1 (F82)** first, as the design
+asked: it scores the goal nothing else scores, it is diagnosed to a line, and wave 28's §11 argument that `D01`'s
+recall gap is *not* costing goal 1 on `D01` is now stronger, not weaker, because the recall lever exists and buys
++0.012 there. Take **item 2** second, because it is what turns wave 28's `N-RECOVERS` from an interesting number
+into a decision — without it, item 4 is a proposal to change a default on the strength of a dataset where the
+default change does almost nothing. **Do not take item 4 before item 2**, and do not take it at all without the
+baseline: `N-RECOVERS` is not a ship, nothing in wave 28 pre-registered a rule that would license changing a
+default, and the values it would replace were chosen by the optimizer rather than by a person.
+
+---
+
+## §13 — Controller deviations, all recorded
+
+| # | deviation | assessment |
+|---|---|---|
+| 1 | **ship (1)'s scope was extended to `DescribeRecommendation`** — the visible row — after the code agent flagged that it still read *"1x1 is right"* to a below-band rig. The plan scoped the step to the tooltip | **Deliberate, reasoned in the commit, and named here as a scope extension of an UNCONDITIONAL ship.** The commit records it in the body: *"the same defect on the surface the user actually reads … the ship is unconditional, so scope discipline here is about honesty, not about protecting a verdict."* It is the right call — a fix that leaves the visible row saying the opposite of the tooltip is not a fix — and it is exactly the kind of change that must be declared rather than absorbed. Both surfaces now reach the band edge through **one** helper, so they cannot drift |
+| 2 | **The wave ran on `ghilios/synthetic-af-bank-followups-wave27` (PR #196), not the fresh `…wave28` branch design §0 pre-registered** | **Declared in `TIMING.tsv` step 0 and reported here.** The note says the change was *"recorded in the design"*; the design at HEAD still reads *"Wave 28 opens a fresh branch … and PR #196 stays open on its own branch"*, so the record and the design disagree and this document says so. The substantive cost is the one design §0 named: **#196 now carries two waves and a user-visible product change under a title about wave 27's truth-protection audit** — the accretion the charter's §1a warns about, one PR later |
+| 3 | **`W28-N`'s arm took 432 s against a 300–480 s estimate** | **Inside the band, and the only estimate this wave got right.** Recorded per [F21](followups.md) with its per-cell breakdown; `D01` at `NC = 1.0` alone was 179 s, outside wave 27's published 6–46 s per-cell range, and the range is amended in [F21](followups.md) rather than in a section of this document |
+| 4 | **The `V28-B` FAIL fixture moved to `/mnt/d/hf_w27`** — design §12 pinned `/mnt/d/hf_w24` and `/mnt/d/hf_w26` and warned that neither must be *"whatever came before"* ([F80](followups.md)) | **Forced, correctly handled, and worth watching.** `/mnt/d/hf_w26` now yields **0** `V28-B` findings — the self-test demonstrates the expiry rather than asserting it — so the `-B` clause needed a fixture that still refuses, and the nearest is the immediately preceding wave. Both design-named roots are **still pinned** (`hf_w24` for `-C`, `hf_w26` for the expiry demonstration), so nothing was swapped out. **But the `-B` fixture is now exactly what F80 said it should not be**, and it will expire the same way next wave. The durable fix is a **synthetic** frozen fixture that cannot expire; ~10 m, named in §12 item 5's bucket |
+| 5 | **`W28-S` was scored while the suite ran** (score 11:35:00, suite 11:34:29 → 11:38:20), against the plan's step order | **Immaterial.** `W28-S` reads two source files by sha256 and both hashes still hold at `HEAD 6f2b62b`, which is *after* the suite and the ship commit. Recorded for completeness |
+
+---
+
+## §14 — One-paragraph summary
+
+**The wave's assigned mechanism was decidable from source, and its one measurement split the population it was
+aimed at.** `RULE W28-S` = `S-WELDED`, 3 of 3, at zero compute: the post-wavelet blur width is literally
+`p.StructureLayers * 2 + 1`, no `StarDetectorParams` member controls it independently, and
+`EffectiveStructureLayers` reaches the residual but not the blur — **one knob sets two opposing cutoffs**, which
+is the confound sitting under [F43](followups.md)'s closed axis, and F43 is amended in place. `RULE W28-N` =
+`N-RECOVERS`, 3 of 3: lowering `NoiseClippingMultiplier` to 1.0 cuts the high-tier structure gap by **79.2 % /
+71.3 % / 96.4 %** at precision 1.000, and **`D02` and `D03` convert that into +0.241 and +0.184 of `recall@high`
+while `D01` converts it into +0.012** — 97.8 % of its newly formed candidates are re-rejected by a later gate, so
+on the extreme rig the loss moved one stage downstream and **this wave did not localise it**. `RULE W28-B` =
+`B-SPLIT`, and on the half item 8 is about the band-pass hypothesis is **refuted**: `Δacc` is positive on all 17
+blind datasets, `B-3` is 0 of 4, and the predicted sign flip at the lower edge does not occur — above the band
+the prediction holds on 9 of 10, below it, not once. The read-only roots are `PRESERVED`, 1 080 of 1 080, and
+ship (1) went out unconditionally at suite **3997** by COUNT: a user below the calibrated band is no longer told
+they are inside it, and is no longer shown nothing at all.
+
+**Three findings a later reader must not lose.** The design's Step 4 count assertion was **wrong at HEAD** —
+three `ConvolveGaussian` sites, not one — and applied literally would have made `W28-S` permanently
+`S-UNEVALUATED` on correct source. `W28-N`'s verdict tree **never gates on `N-1`**, leaving 4 of 135 regions
+uncovered, which is the **second consecutive wave** to ship a tree with a gap and the first to do it under a
+standing rule written in its own design forbidding exactly that. And the blocking pre-flight ran over a root
+containing **one file — itself** — returning `V-UNEVALUATED` where the plan required `V-CLEAN`, so none of the
+six instruments the wave then wrote was ever checked for derivation drift. **`N-RECOVERS` is a measurement and
+not a licence:** nothing in wave 28 pre-registered a rule that would permit changing a default, the optimizer
+chose the values it would replace, and a default change owes its own wave with a fresh baseline.

--- a/docs/synthetic-af-bank-followups-wave28-results.md
+++ b/docs/synthetic-af-bank-followups-wave28-results.md
@@ -354,6 +354,22 @@ renegotiated after the number was seen; plan step 7 says so and it was followed.
 
 ### 6.1 `RULE V28` — self-test PASS, both FAIL fixtures evidenced, and a verdict of `V-UNEVALUATED`
 
+> ### CLOSED AFTER THIS DOCUMENT'S ROLL CALL — the pre-flight was RE-RUN over the populated root
+>
+> **`RULE V28` = `V-CLEAN`** (`vdrift_w28_FINAL.txt`, 2026-08-13T16:08Z): **7 files checked, `V28-A` 8 of 8
+> siblings resolve, `V28-B` 0 unlicensed previous-wave tokens, `V28-C` 0 typed ordinals.**
+>
+> **So the six instruments ARE drift-clean, and the finding below narrows rather than disappears.** What
+> [F95](followups.md) records is a **SEQUENCING** defect, not an unchecked population: the controller ran the
+> blocking pre-flight at the moment the plan's Step 1 says to, which was **before the instruments it guards
+> existed**. The honest reading of the original `V-UNEVALUATED` was always *"an empty population is never
+> 1.0000"* — the checker said so in those words and refused to call it a pass. The remedy is ordering: **a
+> blocking pre-flight must run BEFORE the measurement and AFTER the instruments**, which is a narrower window
+> than "before anything", and no wave's plan has ever said so.
+>
+> The original artifact `vdrift_w28.txt` is KEPT unaltered beside the new one, so both states are on the record.
+
+
 `vdrift_selftest_w28.txt` ends `>>> SELF-TEST PASS` with all six clause groups, including `[6]` in both
 directions — *"the block is exempt (line 3) and the file after it is NOT (line 7)"* and *"the DEFINITION of
 `HISTORICAL_BLOCKS` opens nothing — it is not an instance of itself"*, which is [F87](followups.md)'s repair
@@ -429,7 +445,7 @@ Wave 28's design §12 duly made total coverage a standing rule — *"every verdi
 total coverage of its outcome space at pre-registration"* — **and then shipped a tree with four uncovered
 regions.** The standing rule was written and not executed. `W28-S` (27 regions) and `W28-B` (432 regions) both
 enumerate clean; only the rule with a validity clause outside its own tree does not. Registered as
-[F94](#f94-ready-to-paste).
+**F94**.
 
 #### 7.3 The blocking pre-flight certified a root containing **one file** — itself
 
@@ -453,7 +469,7 @@ Two consequences, both stated as they are:
 
 **This is [F80](followups.md)'s family in a new direction: not a pattern too narrow and not a population
 containing the instrument, but a population that was EMPTY at the only moment the check was taken.** A blocking
-gate that runs before the things it blocks exist blocks nothing. Registered as [F95](#f95-ready-to-paste).
+gate that runs before the things it blocks exist blocks nothing. Registered as **F95**.
 
 ### SEVERITY 2
 
@@ -588,7 +604,7 @@ Continuing from [F91](followups.md). **`F43` is amended in place in the register
 under "Consequence for the register"), because it
 is an existing entry whose stated result is now known to be confounded.
 
-### F92 — The post-wavelet blur is WELDED to `StructureLayers`, so one knob sets two opposing scale cutoffs {#f92-ready-to-paste}
+### F92 — The post-wavelet blur is WELDED to `StructureLayers`, so one knob sets two opposing scale cutoffs
 
 **Status:** **Open — source-derived, zero compute, and it re-opens [F43](#f43)** (2026-08-13, wave 28,
 `RULE W28-S` = `S-WELDED`, 3 of 3)
@@ -624,10 +640,10 @@ cutoffs at once and is **confounded in source**. The experiment that separates t
 
 **Price to run it:** ~45 m code (a dedicated blur-width field defaulting to today's expression, so the default
 is bit-identical) + ~10 m arm; **plus a fresh 42 m `optimize` baseline and a re-derivation if it is ever to
-ship**, because the change reaches the detector. Design §11 defers it; `RULE W28-N` (see [F93](#f93-ready-to-paste))
+ship**, because the change reaches the detector. Design §11 defers it; `RULE W28-N` (see **F93**)
 is the evidence that the amplitude account it rests on is correct.
 
-### F93 — `NoiseClippingMultiplier` is the binding gate below the calibrated band on the bank too — with one dataset where it is not enough {#f93-ready-to-paste}
+### F93 — `NoiseClippingMultiplier` is the binding gate below the calibrated band on the bank too — with one dataset where it is not enough
 
 **Status:** **Open — measured, and explicitly NOT a licence to change a default** (2026-08-13, wave 28,
 `RULE W28-N` = `N-RECOVERS`, 3 of 3) · corroborates [F43](#f43) on synthetic frames · bounded by [F22](#f22)
@@ -661,7 +677,7 @@ below the band carry an HFR that cannot resolve the vertex** — and `D01` alrea
 `w28n_manifest.tsv`. The three landed cells reproduce the published `table18` rows exactly, so every delta is
 attributable to the one edited field.
 
-### F94 — Verdict trees keep shipping with uncovered regions, and the standing rule against it did not stop the second one {#f94-ready-to-paste}
+### F94 — Verdict trees keep shipping with uncovered regions, and the standing rule against it did not stop the second one
 
 **Status:** **Open — a class, now on its second consecutive wave** (2026-08-13, wave 28) · generalises wave 27
 §8.1 · belongs beside [F68](#f68) part 5
@@ -684,7 +700,7 @@ costs nothing — and **every clause, including the ones expected to hold, must 
 that finds a gap prints `<RULE>-TREE-GAP`, enumerates the uncovered regions, prints what the design's literal
 tree would have said, and **does not repair and re-score** (`/mnt/d/hf_w28/w28n_score.txt`, self-test [5]).
 
-### F95 — A blocking pre-flight that runs before the instruments exist certifies an empty population {#f95-ready-to-paste}
+### F95 — A blocking pre-flight that runs before the instruments exist certifies an empty population
 
 **Status:** **Open — remedy known, not applied this wave** (2026-08-13, wave 28) · [F80](#f80)/[F87](#f87)'s
 family, third distinct shape
@@ -717,7 +733,7 @@ wave is clean. They are two runs and this series has been conflating them. Price
   **inference that the axis is useless does not**, because the two effects were never separated and no member of
   `StarDetectorParams` can separate them. **F43's "`MinHFR` is the ONLY axis that rescues it" must now be read as
   "the only axis that rescues it among those tested, on an axis set that contained a confounded knob."** See
-  [F92](#f92-ready-to-paste); and note [F93](#f93-ready-to-paste) finds a **second** axis that rescues `D01`'s
+  **F92**; and note **F93** finds a **second** axis that rescues `D01`'s
   candidate formation (`NoiseClippingMultiplier` 3.8125 → 1.0 cuts its structure gap 79.2 %) — though not its
   `recall@high`.
 * **[F62](#f62)** — append that wave 28 tested the "one band-pass phenomenon" claim out of sample and **it did
@@ -735,7 +751,7 @@ wave is clean. They are two runs and this series has been conflating them. Price
   setting, not from the dataset alone.** Wave 28's 10 cells totalled 381 s of `TestApp` time inside a 432 s wall.
 * **[F35](#f35)** — its finding that *"the W class's recall is lost in candidate FORMATION — the structure map
   never proposes 49 % of them"* now has a lever: `NoiseClippingMultiplier` converts most of that loss into
-  formed candidates ([F93](#f93-ready-to-paste)). On `D02`/`D03` they become detections; on `D01` 97.8 % of them
+  formed candidates (**F93**). On `D02`/`D03` they become detections; on `D01` 97.8 % of them
   are re-rejected downstream, which is also where F35's *"`MinimumStarBoundingBoxSize` rejects another 17 % as
   `TooSmall`"* now points.
 * **[F84](#f84)** — unchanged and re-affirmed: **wave 28 proposed and measured nothing on the `Sensitivity`
@@ -787,7 +803,7 @@ compute from the measured rate and price analysis at a third of instinct.**
 | not run | price | status |
 |---|---|---|
 | **ship (2)** — surfacing the below-band condition outside the wizard | **~45 m + suite** | **GATED AND THE GATE DID NOT HOLD.** `W28-B` = `B-SPLIT`, so per design §9(2) it does not ship and is a costed recommendation. The machinery exists and is wizard-only: `HasUndersampledStars` (`StarDetectionOptimizerWizardVM.cs:237-238`), `MinHfrSeed.IsBelowGate` (`MinHfrSeed.cs:113-120`). **Note ship (1) has now put a below-band message on the options row**, which changes what this item is worth |
-| **the blur/layer decoupling build** ([F92](#f92-ready-to-paste)) | **~45 m + ~10 m arm (+42 m baseline to ship)** | Deferred by price, not by verdict. `W28-N` says the amplitude account it rests on is **right**, which raises its value |
+| **the blur/layer decoupling build** (**F92**) | **~45 m + ~10 m arm (+42 m baseline to ship)** | Deferred by price, not by verdict. `W28-N` says the amplitude account it rests on is **right**, which raises its value |
 | any `StructureLayers` sweep without that build | ~5 m | **Refused** — `W28-S` proves in source that it re-measures [F43](followups.md)'s confound |
 | **localising `D01`'s residual loss** (§1.1) | **~60 m + ~15 m compute** | **NOT RUN, and named as the wave's biggest un-answered question.** The gates are sequential, so it needs an arm that opens them one at a time |
 | **a `NoiseClippingMultiplier` default/bound change** | **design 60 m + ~1.7 h `optimize` baseline + re-derivation** | **NOT LICENSED** by wave 28 (§4.2) |
@@ -813,10 +829,10 @@ pinned to extremes.
 | **1** | **[F82](followups.md) — `D01`'s step-size recommendation stalled at 3 against a truth of 9.** Diagnosed to a line, two candidate fixes, priced | **~45 m + ~10 m** | **2** ✓✓✓ | **The design's own recommendation, and wave 28's evidence strengthens it.** It is a product defect with a mechanism (`SearchSpan` over `bestFit.Inputs`, so a shrinking bound drags cap and floor down together), on the same rig item 8 is about, and it is the only open item scoring goal 2. Item 8's own headline dataset already reaches `BestJ` 0.994825, so its recall gap is not costing goal 1 on `D01`; its **step size** is |
 | **2** | **Localise `D01`'s residual loss** — with `NC = 1.0` held fixed, open `MinimumStarBoundingBoxSize` (landed **6**, the bank's highest, against a shipped default of 5 and a `WideField` preset that *lowers* it) and `MaxDistortion` one at a time | **design 30 m + ~60 m + ~15 m compute** | **1** ✓✓, **3** ✓ | Wave 28 converted 34 060 `NO CANDIDATE` into 33 298 gate rejections and **did not say which gate binds**. The gates are sequential, so this needs an arm, not a re-read. It also scores goal 3: `MinBox = 6` on the two rigs with the smallest stars is a parameter pinned against the physics |
 | **3** | **Pre-register the lower edge properly and re-score `W28-B`** — the `LOW` class at `K ≈ 1.04` behaves like `HIGH`, and only 2 of 20 datasets dip on the detector-only route | **~30 m, zero compute** | **1** ✓ | §3.4's bracket is **diagnostic, not authority**, and the [F14](followups.md) fence forbids re-drawing the boundary with these columns in hand. Fix the rule first, then re-score. Cheap, and it settles what `DetectionBinningResolver`'s band means below 2 px |
-| **4** | **A `NoiseClippingMultiplier` ship rule, pre-registered, with a fresh baseline** | **60 m design + ~1.7 h baseline + re-derivation** | **1** ✓✓ | [F93](#f93-ready-to-paste) is a measurement, not a licence (§4.2). The optimizer chose the landed values; changing a default or a search bound moves the landings, so the baseline is not optional. **Do not run this before item 2** — the payoff on `D01` is currently +0.012 and item 2 decides whether it can be more |
-| **5** | **Close the instrument debt, all of it in one pass** — ship (1)'s `M1`–`M6` records, `fp_w28.sh`'s self-test capture, the `W28-FP` verdict line, a closing `V28` run, and wave 27's `S27-1` + three mutants | **~35 m total** | instrument | Five items, each ≤ 10 m, and three of them are one wave old already. [F95](#f95-ready-to-paste) in particular is a two-minute habit change |
-| **6** | **Make total tree coverage a mechanical step, not a standing sentence** ([F94](#f94-ready-to-paste)) | **~10 m** | instrument | The standing rule was written in wave 28's design §12 **and then not executed on wave 28's own tree**. A sentence did not work; enumerate the outcome space in the pre-registration |
-| **7** | The blur/layer decoupling build ([F92](#f92-ready-to-paste)) | ~45 m + ~10 m (+42 m to ship) | **1** ✓✓ | Now better-motivated than at pre-registration — `W28-N` confirms the amplitude account — but it is a detector change and owes a baseline. **After items 1–3** |
+| **4** | **A `NoiseClippingMultiplier` ship rule, pre-registered, with a fresh baseline** | **60 m design + ~1.7 h baseline + re-derivation** | **1** ✓✓ | **F93** is a measurement, not a licence (§4.2). The optimizer chose the landed values; changing a default or a search bound moves the landings, so the baseline is not optional. **Do not run this before item 2** — the payoff on `D01` is currently +0.012 and item 2 decides whether it can be more |
+| **5** | **Close the instrument debt, all of it in one pass** — ship (1)'s `M1`–`M6` records, `fp_w28.sh`'s self-test capture, the `W28-FP` verdict line, a closing `V28` run, and wave 27's `S27-1` + three mutants | **~35 m total** | instrument | Five items, each ≤ 10 m, and three of them are one wave old already. **F95** in particular is a two-minute habit change |
+| **6** | **Make total tree coverage a mechanical step, not a standing sentence** (**F94**) | **~10 m** | instrument | The standing rule was written in wave 28's design §12 **and then not executed on wave 28's own tree**. A sentence did not work; enumerate the outcome space in the pre-registration |
+| **7** | The blur/layer decoupling build (**F92**) | ~45 m + ~10 m (+42 m to ship) | **1** ✓✓ | Now better-motivated than at pre-registration — `W28-N` confirms the amplitude account — but it is a detector change and owes a baseline. **After items 1–3** |
 
 **The recommendation, stated as a judgement rather than a table row.** Take **item 1 (F82)** first, as the design
 asked: it scores the goal nothing else scores, it is diagnosed to a line, and wave 28's §11 argument that `D01`'s
@@ -863,7 +879,9 @@ three `ConvolveGaussian` sites, not one — and applied literally would have mad
 `S-UNEVALUATED` on correct source. `W28-N`'s verdict tree **never gates on `N-1`**, leaving 4 of 135 regions
 uncovered, which is the **second consecutive wave** to ship a tree with a gap and the first to do it under a
 standing rule written in its own design forbidding exactly that. And the blocking pre-flight ran over a root
-containing **one file — itself** — returning `V-UNEVALUATED` where the plan required `V-CLEAN`, so none of the
+containing **one file — itself** — returning `V-UNEVALUATED` where the plan required `V-CLEAN`. **Re-run
+after the roll call over the populated root it returns `V-CLEAN`, 7 files, 8 of 8 siblings (§6.1), so the defect
+is one of SEQUENCING and the instruments are clean.** At the time it ran, none of the
 six instruments the wave then wrote was ever checked for derivation drift. **`N-RECOVERS` is a measurement and
 not a licence:** nothing in wave 28 pre-registered a rule that would permit changing a default, the optimizer
 chose the values it would replace, and a default change owes its own wave with a fresh baseline.

--- a/docs/synthetic-af-bank-followups-wave29-design.md
+++ b/docs/synthetic-af-bank-followups-wave29-design.md
@@ -1,0 +1,645 @@
+# Wave 29 — backlog item 1 ([F82](followups.md)): the step-size floor, and what source says about its fix
+
+**Pre-registration. Written before any wave-29 statistic is computed.** §2 records where the controller's
+framing is wrong; there are six such places and **three of them change what the wave does**. One of them
+removes the wave's ship.
+
+---
+
+## 0. THE VESSEL — decided in writing, before any measurement
+
+**Wave 29 opens a fresh branch off `ghilios/synthetic-af-bank-followups-wave27`, named
+`ghilios/synthetic-af-bank-followups-wave29`, and opens its own PR. PR #196 is left to be reviewed and merged
+as what it is.**
+
+- PR #195 (`…wave23`, waves 23–26) is **MERGED**.
+- PR #196 (`…wave27`) is **OPEN / MERGEABLE** at `6ffa498`, and already carries **two** waves (27 and 28) plus a
+  user-visible product change, under a title naming only wave 27's truth-protection audit.
+
+**Reason.** Wave 28's design §0 pre-registered exactly this and the wave did the opposite; wave 28 §13 recorded
+it as a deviation and named the cost — *"#196 now carries two waves and a user-visible product change under a
+title about wave 27's truth-protection audit."* Repeating it would make #196 carry three. The charter's §1a
+warning against silent accretion has now been ignored once with the cost measured; **a third section is the
+accretion, not a step toward it.**
+
+**Wave 29 changes no C# and builds no binary** (§9), so nothing about this choice is load-bearing for a
+verdict. It is load-bearing for whether the previous wave's declared deviation gets repeated.
+
+---
+
+## 1. THE HEADLINE: the pre-registered fix has no carrier in the product, and the "truth" it is scored against is produced by the code under test
+
+Two facts, both decidable from source at zero compute, both verified in this document against shipping files:
+
+**(a) `terminal.stepBehavioral` — the number [F82](followups.md) calls "a truth of 9" — is
+`StepSizeRecommender.Recommend` iterated to a fixed point.** `SynthValidateRunner.ComputeStepBehavioral`
+(`:1213-1270`) builds an analytic curve, fits it, and calls `StepSizeRecommender.Recommend` at **`:1262`**,
+looping until `rec.StepSize == step`. Its own XML doc says so in the file: *"the fixed point A3 compares
+against is produced by the same rule as the landing it scores."* **The harness scores the recommender against
+a fixed point of the recommender.** That is why F82 observed `stepBehavioral` moving 8.0 → 9.0 across wave
+25's two arms while it was identical on the other 17 cells: wave 25 changed `Recommend`, so it changed the
+bar as well as the measurement. F82 recorded the symptom and called it *"an assumption this series can no
+longer make for free"*; **the cause is one line and nobody has looked at it.**
+
+**(b) No caller in the product has anywhere to put a previous round's floored half-width.** The pre-registered
+fix (wave 26 design §14) is *(1) the monotone floor — carry the previous round's floored half-width forward as
+a lower bound on the next round's `maxHalfWidth`*, chosen partly because it is *"confined to the caller's round
+state, which is where a cross-round property belongs."* The callers, enumerated:
+
+| caller | file:line | has cross-round sweep state? |
+|---|---|---|
+| `StarDetectionOptimizerWizardVM.BuildSummaryAsync` | `:4117` | **No.** `Continue` (`:4850`) and `Re-optimize` (`:4740`) both call `LoadRunStampedAsync(folder, …)` and re-optimize **the frames already captured**. No new sweep is taken between wizard rounds, so `SearchSpan` cannot change between them and the defect cannot occur there at all |
+| `OptimizationDiagnosticRunner` (`optimize`) ×4 | `:1102`, `:1134`, `:1262`, `:1702` | **No.** Single-pass, all four strictly after `OptimizeAsync` returns at `:916` |
+| `TiltCalibrationRunner` | `:479` | **No.** Single-pass |
+| `SynthValidateRunner.RunRoundAsync` | `:792` | **YES** — `ScenarioRunState` (`:360-371`), and it is a **test harness** |
+| `SynthValidateRunner.ComputeStepBehavioral` | `:1262` | the truth model, per (a) |
+
+And nothing persists a half-width across sessions: `OptimizedStarDetectionSettings` carries
+`RecommendedStepSize` (`:69`) and no half-width; `OptimizationSummary` carries `RecommendedStepSize`,
+`StepSizeWasCapped`, `StepSizeWasBandFloored`, `StepSizeSampledHfrRange`, `StepSizeCappedGrowthRatio`,
+`StepSizeDegenerateReason` — **and no `HalfWidth` at all.**
+
+**So the real product's "next round" is the next SESSION**, and the only carrier for a monotone floor across
+sessions would be new persisted state. **Fix (1), implemented as pre-registered, is a change to
+`SynthValidateRunner.ScenarioRunState` and reaches no user.**
+
+**What this does and does not do to wave 26's pre-registered choice.** It impeaches reason (iii) —
+*"confined to the caller's round state"* — because the caller with round state is the harness. It leaves
+reason (i) — blast radius — standing and **quantified for the first time**: §5.1 measures that **37 of 37
+rounds across 18 paired cells are capped-or-floored**, so fix (2) moves every round of every cell in the
+population, not merely "every capped round". And fact (a) supplies a **fourth reason wave 26 never had**:
+fix (2) changes `SearchSpan`, which `ComputeStepBehavioral` also consumes, so **fix (2) moves the truth model
+as well as the landing**, while fix (1) — a new parameter defaulting to `NaN` — does not.
+
+**Two of wave 26's three reasons for (1) are impeached; the third is confirmed and a fourth is added. That is
+not a licence to flip, and wave 29 does not flip it.** What it is, is a demonstration that the choice was made
+without knowing where the state would live — and that is a finding, registered rather than repaired.
+
+### 1.1 The sentence this wave is not allowed to write
+
+**Wave 29 does not ship a fix to F82 and does not decide between (1) and (2) on new grounds.** It executes
+what wave 26 already pre-registered and nobody has run — the **reversal condition** (§5) — publishes the
+source rule above as a rule (§4), and hands the item forward re-priced with a third candidate registered but
+**not chosen** (§4.4). Choosing a fix in the same wave that discovers a new reason to prefer it is the
+[F14](followups.md) / `RULE D20` fence in a new costume.
+
+---
+
+## 2. WHERE THE CONTROLLER'S FRAMING IS WRONG
+
+### 2.1 "F82 … scores goal 2 ✓✓✓" — **not as pre-registered, it scores goal 2 ZERO**
+
+Goal 2 is *accuracy of step-size recommendations* — the recommendation a **user** receives. Fix (1) lands in
+`SynthValidateRunner`, which no user runs. Worse: shipping it there alone would make the harness model a
+product that does not have the fix, so `synth-validate` would stop reproducing the product's own stall.
+**A harness that diverges from the product in the direction of the product being better is not an
+improvement, it is a broken instrument.** Wave 28 §12 scored this item `2 ✓✓✓`; on the code as it stands the
+honest score is **0 until a product carrier is chosen and priced**, and choosing one is a design question, not
+an execution question.
+
+### 2.2 "Priced in the handoff at ~45 m code + tests, ~10 m 3-cell re-run" — **the price is for the wrong thing**
+
+45 m is the price of the harness change. The product change is a new persisted value on the optimizer's
+recommendation, surviving between wizard sessions, with the `Continue`/`Re-optimize` paths (where it is inert)
+explicitly excluded, plus the migration and — per `CLAUDE.md` — the question of whether it is an *option* and
+therefore owes a control in `Resources/OptionsDataTemplates.xaml`. **That is not 45 m and nobody has
+priced it.** §11 prices it as a band and says it is a band.
+
+### 2.3 "F82's fix touches `StepSizeRecommender`, which IS plugin code, so the intersection is probably non-empty and the gate probably IS owed" — **not "probably". CERTAINLY, and it is already on disk by name**
+
+`Q27-V1`'s FAIL end was not a hypothetical. It was **run**, against the B14 tree, and
+`/mnt/d/hf_w27/q27_v1.txt` records the two files that made the intersection non-empty:
+
+```
+intersection is NON-EMPTY (2 files), e.g.:
+Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/StarDetectionOptimizerWizardVM.cs
+Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/StepSizeRecommender.cs
+>>> FAIL END DEMONSTRATED: the same predicate REFUSES on a diff that reaches the gate.
+```
+
+**Wave 27 used F82's own two files as its canonical example of a diff that reaches the gate.** The reachable
+set is the literal ERE `^Joko\.NINA\.Plugins/Joko\.NINA\.Plugins\.HocusFocus/|^Joko\.NINA\.Plugins/TestApp/(OptimizationDiagnosticRunner|HarnessSettingsStore|OptimizationRunDiscovery|ParamsDump|StubBehaviorSelectors|DiagnosticUtil|Program)\.cs$`
+— a **directory prefix over the whole plugin assembly**, not a call graph. `StepSizeRecommender.cs` sits under
+it. **Any wave that ships F82 in the product owes the full 42 m gate, and there is no argument left to have.**
+
+**And the argument a later wave will be tempted to make must be refused in advance.** `StepSizeRecommender` is
+genuinely *not* reachable from `optimize`'s objective — the evaluator handed to `OptimizeAsync` is built by
+`RunEvaluationData.CreateEvaluator` (`:929-953`), whose body is `results.Add(await run.EvaluateAsync(p,
+token))`, and every one of the seven `Recommend` call sites is strictly downstream of `OptimizeAsync`
+returning. Wave 25 *measured* this: it shipped a change to `StepSizeRecommender.cs` and the gate returned
+`FinalJ` bit-identical to K8, **8 of 8 at sixteen digits**. **None of that licenses narrowing a pre-registered
+reachable set after seeing which files your own change touches.** It licenses one thing only: the gate becomes
+**a rule with a predicted answer** — predict `G-PASS`, 8 of 8 bit-identical, on wave 25's measurement — which
+the charter calls a virtue (`RULE R24`) because it is the only kind of rule that can be wrong.
+
+### 2.4 "Item 2 … needs no product change and reuses wave 28's arm shape … say whether it can reach a verdict at all, or whether it can only rank" — **it can reach a verdict, if it runs one more cell than the controller specified**
+
+Opening one gate at a time and differencing gives, per gate, the number of stars that gate **exclusively**
+blocked — the ones that pass every other gate. It does not decompose the multiply-blocked set, so a
+one-at-a-time design **ranks and lower-bounds, and cannot attribute.** Adding a single cell with **all three
+gates opened together** measures the total recoverable set, and then
+
+> joint (multiply-blocked) share = total − Σ(exclusive shares)
+
+**exactly.** Four intervention cells plus a baseline turn a ranking into a decomposition. §6 pre-registers it
+that way, with the prediction that the singles will sum to well under the joint total — because a 0.7 px blob
+on a 19.4″/px rig is simultaneously too small, too distorted and low-signal, and the gates are not
+independent.
+
+### 2.5 "[F22](followups.md) bounds the payoff … weigh whether recall is even the right objective there" — **agreed, and it is why item 2 is re-framed rather than dropped**
+
+The controller is right and the consequence is larger than the controller drew. `D01` reaches `BestJ`
+0.994825 from a `BaselineJ` of 0.000000; below ~1.1 px the measured HFR over-reads by up to **+234 %**; its
+0.231 px optical vertex measures 0.77 px. **Recovering `D01`'s recall cannot be justified as a focus
+improvement and wave 29 does not justify it that way.** What survives F22 untouched is the **goal-3** question:
+`MinimumStarBoundingBoxSize` landed at **6** on the rigs with the smallest stars, against a shipped default of
+**5** (`IStarDetector.cs:435`) and a `WideField` preset that *lowers* it. That is a parameter pinned against
+the physics, and *"avoiding parameters pinned to extreme values"* is goal 3 verbatim. **Item 2 runs as an
+attribution of which gate binds — a goal-3 question — and its results section is forbidden from quoting a
+recall gain as a benefit.**
+
+### 2.6 "Two waves running, the verdict tree shipped with uncovered regions ([F94](followups.md))" — **agreed, and a sentence is again not the remedy**
+
+Wave 28's design §12 wrote the standing rule and wave 28 shipped a tree with 4 of 135 regions uncovered.
+Writing the sentence a third time will not work either. §10 of this document **enumerates every region of
+every tree in a table, in this document**, and every scorer re-derives that enumeration in code and prints
+`regions enumerated: N  uncovered: 0`. **Where a region is logically unreachable, it is named, asserted empty,
+and given a refusal verdict** — the failure mode F94 describes is a region silently absent, and a region that
+is present-and-impossible is a different, checkable thing.
+
+---
+
+## 3. THE ITEM, AND WHY THE OTHERS LOSE
+
+**Chosen: item 1 ([F82](followups.md)), re-scoped from "ship the fix" to "execute the pre-registration nobody
+ran, and publish what source says about the choice" — plus item 2 as a co-equal second half.**
+
+| candidate | verdict | why |
+|---|---|---|
+| **1 — F82** | **TAKEN, re-scoped** | Its pre-registered **reversal condition has never been evaluated** and can be evaluated at zero compute on 15 blind cells. Writing the code before checking the escape clause is executing a pre-registration with its own reversal ignored. And §1 says the fix as written does not reach a user, which the wave must publish before anyone spends 45 m on it |
+| **2 — localise `D01`'s residual loss** | **TAKEN**, re-framed to goal 3 | Cheap (no build, one binary already on disk, ~25 m), finishes wave 28's named biggest open question, and with a fifth cell it **attributes** rather than ranks. Re-framed per §2.5: the deliverable is which gate binds, not a recall gain |
+| **3 — re-register the band's lower edge** | **REJECTED** | It produces a *rule*, not a *finding*. `B-SPLIT` already delivered the substantive answer — the lower edge is not where the design drew it, `Δacc > 0` on all 17. Re-scoring buys a boundary number on a synthetic-only population with **no real under-sampled dataset** ([F35](followups.md), [F43](followups.md)). It is worth ~10 m as a note on `docs/synthetic-af-bank-results-table.md`, and that note is owed anyway (wave 28 §9.5). It is not worth a rule |
+| **4 — a `NoiseClippingMultiplier` default change** | **REJECTED for wave 29** | [F93](followups.md) says plainly it is not licensed by `N-RECOVERS`; it is explicitly behind item 2; it owes a fresh **~1.7 h** `optimize` baseline because the optimizer *chose* the landed values; and its measured payoff on `D01` is **+0.012**, which is exactly the number item 2 exists to explain. Running it before item 2 is proposing a default change on the strength of a dataset where the change does almost nothing |
+
+**Is there nothing here worth a wave?** That answer was seriously considered and is rejected, but narrowly.
+The wave produces: a source rule that changes what F82 is (§4), the execution of a two-wave-old
+pre-registration on a blind population of 15 (§5), and a decomposition that closes wave 28's largest open
+question (§6). **Three register entries, no product risk, ~25 minutes of compute.** What it does *not*
+produce is a ship, and the honest reading of §1 is that **a wave that shipped fix (1) this afternoon would
+have shipped it into a test harness and scored it against a bar computed by the code it changed.**
+
+---
+
+## 4. `RULE W29-S` — the carrier and the truth model, decided from source. Zero compute
+
+**Population:** four source files at `HEAD`, each recorded by **sha256** in the scorer's output:
+`TestApp/SynthValidateRunner.cs`, `HocusFocus/StarDetection/Optimization/StepSizeRecommender.cs`,
+`HocusFocus/StarDetection/Optimization/StarDetectionOptimizerWizardVM.cs`,
+`HocusFocus/StarDetection/Optimization/OptimizedStarDetectionSettings.cs`.
+**Wave 28 §7.5's lesson applied in advance:** design §4 of that wave named one artifact where its clause
+needed two, and the scorer had to say so. Here the population is named as four and the scorer **refuses** if
+any is absent.
+
+| clause | statement | refusal condition |
+|---|---|---|
+| **`S-a`** *(validity, and it is IN the tree)* | `ComputeStepBehavioral`'s body contains **exactly one** `StepSizeRecommender.Recommend(` call site, **and** `ComputeStepBehavioral` is the **only** writer of the value serialized as `terminal.stepBehavioral` | any count ≠ 1; more than one writer; the method cannot be located by **declaration** (not first textual occurrence — wave 28 §7.9) |
+| **`S-b`** | Over every `Recommend(` call site under `Joko.NINA.Plugins.HocusFocus/`: **none** sits in a method whose enclosing round loop captures a new sweep, **and** neither `OptimizedStarDetectionSettings` nor `OptimizationSummary` declares a member matching `(?i)halfwidth` | a product caller with a re-capturing round loop; any `halfwidth` member on either type |
+| **`S-c`** | `SweepDetectability` declares a member carrying the **requested** focuser positions, and it is reachable inside `Recommend` | no such member |
+
+**Verdicts.** `S-a` false ⇒ `S-UNEVALUATED` (the coupling could not be established; nothing downstream in this
+rule is quoted). `S-a` ∧ ¬`S-b` ⇒ `S-CARRIER-EXISTS` — a product carrier was found, wave 26 reason (iii)
+stands, and §1's headline is **withdrawn in the results document, in place.** `S-a` ∧ `S-b` ∧ `S-c` ⇒
+`S-NO-CARRIER`. `S-a` ∧ `S-b` ∧ ¬`S-c` ⇒ `S-NO-CARRIER-NO-ALT`.
+
+**Both branches of every clause are reachable and the FAIL ends are demonstrated on real files**, not
+fixtures: `S-a`'s zero-site end on `StepSizeRecommender.cs` itself (which contains no such call), its
+multi-site end on `SynthValidateRunner.cs` scoped to the whole file (**two** sites, `:792` and `:1262`);
+`S-b`'s carrier end on `StepSizeRecommendation`, which **does** declare `HalfWidth`; `S-c`'s absent end on
+`StepSizeRecommendation`, which declares no focuser positions.
+
+### 4.4 The third candidate — REGISTERED, PRICED, AND NOT CHOSEN
+
+If `S-c` holds, a fix exists that wave 26 never considered, because it needs no cross-round state at all:
+**bound `maxHalfWidth` below by the span the sweep actually REQUESTED, and only on a round where
+`BandDemonstrablyUnsampled(sampledHfrRange)` is already true.** The requested positions are in
+`SweepDetectability.FrameFocuserPositions`; the guard is the same predicate F81 already ships; and it is inert
+on every round that reached the band, which is where the cap is *the* convergence mechanism.
+
+**It is proposed from source and it is NOT chosen in this wave.** Wave 26 pre-registered a binary choice
+before anyone looked; introducing a third option after reading the diagnosis and then selecting it in the same
+breath is exactly the shape the `RULE D20` fence forbids. It is registered with its price (§11) and the
+**next** wave pre-registers the choice among three.
+
+---
+
+## 5. `RULE W29-R` — wave 26's reversal condition, executed. Blind on 15 cells, zero compute
+
+Wave 26 design §14, quoted, and this is the whole of what the rule tests:
+
+> **And the condition that would reverse it**, stated now: if a later wave measures that `SearchSpan` over
+> `bestFit.Inputs` **shrinks on more than a single cell** while the requested sweep widens, then the defect is
+> in the quantity and not in its persistence, and (2) becomes correct.
+
+**Nobody has run it.** Three waves have quoted the pre-registered choice and none has evaluated its escape
+clause. It costs nothing.
+
+### 5.1 The instrument — exact, on data already on disk, needing no field that is not serialized
+
+`maxHalfWidth = MaxHalfWidthSampledHalfSpanMultiple × 0.5 × SearchSpan` (`StepSizeRecommender.cs:320`), and
+`maxHalfWidth` is **not** serialized. It does not need to be. On any round where the cap bound
+(`:347-349`, `halfWidth = maxHalfWidth`) **or** the floor engaged (`:332`, `:364-365`, `halfWidth =
+maxHalfWidth`), the serialized `stepRecommendation.halfWidth` **is** `maxHalfWidth` exactly, so
+
+```
+implied SearchSpan(round)  =  halfWidth / (MaxHalfWidthSampledHalfSpanMultiple × 0.5)   =  halfWidth / 0.75
+requested span(round)      =  2 × bootstrap.offsetSteps × bootstrap.stepSize
+```
+
+Validated against the one burned cell before the instrument was written: `D01` r0 floored `halfWidth` 12.0 ⇒
+implied 16, requested 2×4×2 = 16; r1 capped `halfWidth` 9.0 ⇒ implied 12, requested 2×4×3 = 24. **F82's
+published table reads *"requested 16 → 24, fitted 16 → 12"*. The identity reproduces on the nose.**
+
+**The trap that must not be silent, and it is checked before any statistic:** there is a **third** bound.
+`WasDetectBounded` / `MaxUsefulHalfSpan` (`:368-379`) can also set `halfWidth`, in which case
+`halfWidth ≠ maxHalfWidth` and the inversion is wrong. **A round with `wasDetectBounded == true` is a
+could-not-look**, named and counted, never silently included. A round that is neither capped nor floored is
+likewise a could-not-look. Measured at pre-registration over the 18 addressable cells: **37 rounds, 37
+capped-or-floored, 0 detect-bounded.** The instrument is applicable everywhere.
+
+**And `MaxHalfWidthSampledHalfSpanMultiple = 1.5` is asserted from source at BOTH trees** — wave 25's B15 tree
+(`29665a62…`, read out of `/mnt/d/hf_w25/binary_provenance_w25.txt`, never assumed) and `HEAD` — because the
+inversion is only valid if the constant that produced the artifacts is the constant the scorer divides by.
+A mismatch is `R-UNSATISFIABLE`, not a silently rescaled number.
+
+### 5.2 Population, and what is already known about three of its members
+
+**Population: the 18 addressable paired S1 cells under `/mnt/d/hf_w25/after/`.** 20 datasets less
+`D05_tec140_1000mm` and `D19_cygnus_deep_shed`, which time out at `timeout 600` on **every** S1 arm — four in
+a row, structural, not flaky. **The count is asserted and the gap is asserted to be exactly those two names**
+([F74](followups.md); wave 24's `40` vs `38`). Every cell has ≥ 2 rounds; `D08` has 3.
+
+`D01`, `D02` and `D03` are **burned** — their rounds are published in F82's own table — and they are **kept in
+the denominator and computed anyway**, because dropping a member because you know its answer is how a
+denominator becomes a choice. Their contribution is therefore **predicted here, before the scorer runs**:
+
+| burned cell | published `halfWidth` r0 → r1 | implied `SearchSpan` | qualifies? |
+|---|---|---|---|
+| `D01_ultrawide_40mm` | 12.0 → 9.0 | 16 → 12, **shrank** | **YES** (it is the cell the condition was written from) |
+| `D02_rich_135mm` | 12.0 → 18.0 | 16 → 24, grew | no |
+| `D03_redcat_250mm` | 24.0 → 42.0 | 32 → 56, grew | no |
+
+**So `c ≥ 2` holds if and only if at least one of the 15 BLIND cells qualifies**, and the rule is a clean
+binary question on a population nobody has computed this statistic over. The scorer **prints both** `c` (over
+18, as the condition is written) and `c_blind` (over 15), so no reader has to do that arithmetic — and the
+verdict is taken on `c ≥ 2` **as pre-registered by wave 26**, not on a rate this wave invented.
+
+### 5.3 The clauses
+
+| clause | statement | bar |
+|---|---|---|
+| **`R-0`** *(validity, IN the tree)* | addressable cells `k`, each with ≥ 2 rounds and every read round capped-or-floored and not detect-bounded; **and** `MaxHalfWidthSampledHalfSpanMultiple == 1.5` at both trees | `k ≥ 2` |
+| **`R-1`** | `c` = distinct cells with ≥ 1 round transition `r → r+1` where `requested(r+1) > requested(r)` **and** `impliedSearchSpan(r+1) < impliedSearchSpan(r)` | `c ≥ 2` |
+
+**`R-0` false ⇒ `R-UNSATISFIABLE`, and that is a FINDING, not something to repair and re-score.** The
+pre-registered default then stands: fix (1) remains the choice, because wave 26 named `n = 1` as insufficient
+and an unevaluable condition does not become an evaluated one.
+
+**Aggregation, stated because [F68](followups.md) has five parts.** Population = the report file
+`synth_validate_report.json` per cell; field = `datasets[0].scenarios[0].rounds[i].stepRecommendation.halfWidth`
+and `.bootstrap.{offsetSteps,stepSize}` — **the per-round copies, never the `terminal` block**, and the scorer
+asserts it consumed exactly one `stepRecommendation` per round index. Statistic = per transition. Aggregation
+= **any transition qualifies the cell; cells are counted, not transitions**, because wave 26 wrote "cells".
+Empty-set answer = `R-UNSATISFIABLE` per `R-0`.
+
+### 5.4 What each verdict costs, fixed before the data
+
+- **`R-STANDS`** — fix (1) remains correct **on wave 26's grounds**, and §1's finding stands beside it
+  unchanged: it still has no product carrier. F82 is re-priced and handed forward with three candidates.
+- **`R-REVERSE`** — fix (2) becomes correct by wave 26's own pre-registration, **and wave 29 does not ship it.**
+  It moves `maxHalfWidth` on **37 of 37 rounds**, and — per §1(a) — it also moves `ComputeStepBehavioral`, so
+  it moves assertion `A3`'s bar as well as `A3`'s measurement. Its price is a full paired 18-cell arm
+  (~2 h 40 m), the **42 m gate** (§8), and an `A3` re-derivation. **That is not a wave-29 ship and saying so is
+  the rule working**, in the same way wave 28's ship (2) did not ship.
+
+---
+
+## 6. `RULE W29-L` — which of `D01`'s three downstream gates actually binds. One arm, no build
+
+Wave 28 converted 34 060 `NO CANDIDATE` into 33 298 gate rejections at `NC = 1.0` and **said, correctly, that
+it had not localised them**: the gates fire in sequence — `TooSmall` (`StarDetector.cs:1757`) → `OnBorder`
+(`:1766`) → `TooDistorted` (`:1807`) → `Degenerate` (`:1823`) → `LowSensitivity` (`:1854`) — so the published
+counts are **first-rejection-wins** and are an ordering, not shares.
+
+**Design: five cells on `D01` alone, `NoiseClippingMultiplier` held at 1.0 throughout, one knob relaxed per
+cell plus one cell with all three relaxed.** No build. Binary: `/mnt/d/hf_w25/exe`, `TestApp.dll` sha256
+`2fb0c8fd…` — the same B15 that produced `table18` and wave 28's arm. Settings tree copied per cell from the
+same source wave 28's arm used, one field edited, `cp` **without** `-p` and `touch` after every copy
+([F89](followups.md)).
+
+| cell | edit, against the landed tree with `NoiseClippingMultiplier = 1.0` |
+|---|---|
+| `L0` **baseline** | `NC = 1.0` only — **must reproduce wave 28's published `D01` high-tier block exactly** |
+| `L1` | + `MinimumStarBoundingBoxSize` 6 → **3** |
+| `L2` | + `MaxDistortion` 0.5 → **0.9** |
+| `L3` | + `Sensitivity` relaxed one notch — **diagnostic only, see below** |
+| `L4` | + all three of `L1`/`L2`/`L3` together |
+
+**`L3` is diagnostic and proposes nothing on the Sensitivity axis.** [F84](followups.md) is re-affirmed, not
+touched: *"a floor on the Sensitivity axis alone is dead"*, `RULE S16` is a permanent fence, and wave 28
+already recorded that `D01`'s `LowSensitivity` rise is a **downstream consequence** of more candidates
+existing. You cannot attribute three sequential gates by opening two, so the third cell is necessary and its
+role is bounded here, in writing: **no verdict branch reads `L3` alone, and no register entry produced by this
+wave may cite it as evidence for or against a sensitivity bound.**
+
+### 6.1 The statistic and the decomposition
+
+Read **only** the `FALSE-NEGATIVE ATTRIBUTION, HIGH TIER ONLY` block, anchored on that header
+([F68](followups.md) part 5 — the same line appears twice per report and wave 28's self-test [3] proved a
+first-match reader takes the wrong one). For each cell, `FN_total` = the block's total high-tier false
+negatives.
+
+```
+exclusive(g)  =  FN_total(L0) − FN_total(L_g)                for g in {MinBox, MaxDistortion, Sensitivity}
+joint         =  FN_total(L0) − FN_total(L4)
+```
+
+`exclusive(g)` is the count of stars that gate `g` blocked **and no other opened gate did**; `joint` is the
+total recoverable across all three. `joint − Σ exclusive(g)` is the multiply-blocked residual, **exactly**.
+
+| clause | statement | bar |
+|---|---|---|
+| **`L-0`** *(validity, IN the tree)* | all 5 cells `exit=0`; each echoes its intended knob values on the `key detector knobs:` line; **and `L0` reproduces wave 28's published `D01` `NC = 1.0` high-tier attribution block field-for-field** | all |
+| **`L-1`** | `Σ exclusive(g) < 0.60 × joint` | — |
+| **`L-2`** | `Σ exclusive(g) ≥ 0.90 × joint` | — |
+
+`L-1` and `L-2` are mutually exclusive by construction and the scorer **asserts** it.
+
+**Verdicts.** ¬`L-0` ⇒ `L-UNEVALUATED`. `L-0` ∧ `L-1` ⇒ **`L-JOINTLY-BOUND`** — no single gate binds; `D01`'s
+residual loss is multiply-gated and **no single-knob change can recover it**. `L-0` ∧ `L-2` ⇒ `L-SEPARABLE` —
+the gates are near-independent and the largest `exclusive(g)` names the binding one. Otherwise ⇒ `L-PARTIAL`,
+with the shares published and no gate named.
+
+**The prediction, stated before the data so the rule can be wrong: `L-JOINTLY-BOUND`.** A 0.7 px kernel on a
+19.4″/px rig produces a candidate that is simultaneously below the bounding-box floor, noisy enough in its
+second moments to read as distorted, and marginal in signal. If instead `L-SEPARABLE` comes back naming
+`MinimumStarBoundingBoxSize`, that is a **goal-3 product finding** — a knob landed at 6 against a shipped
+default of 5 on the rig with the smallest stars, with a `WideField` preset that lowers it — and it is worth
+its own wave.
+
+**`L0` is a control that can fail, and its failure end is real:** it re-runs a cell whose numbers are
+published to the digit. Wave 28's §4.3 found the equivalent control *"a stronger control for this arm than
+the `--profile-id` inertness probe"*, and unlike that probe it is pre-registered here rather than
+opportunistic.
+
+---
+
+## 7. BLINDNESS LEDGER — stated once, exactly, before any wave-29 statistic
+
+**READ, and by whom:**
+
+| what | by whom | scope of the burn |
+|---|---|---|
+| `D01`/`D02`/`D03` per-round `halfWidth`, `stepSize`, `wasCapped`, `wasBandFloored` | [F82](followups.md)'s published table, and §5.2 above | those 3 cells, `W29-R`'s statistic |
+| `roundIndex`, round count, `wasCapped`, `wasBandFloored`, `wasDetectBounded` — **all 18 cells** | **this document**, §5.1's applicability count | **none of `W29-R`'s statistic** — see below |
+| `D01`'s full `golden eval` block at `NC` landed and `NC = 1.0`, incl. the high-tier attribution | wave 28 §1.1, and §6 above | `W29-L`'s **baseline half** |
+| the `synth_validate_report.json` **schema** (key names only, `D01`) | this document | none |
+
+**Why reading the three flags on all 18 costs no blindness.** `wasCapped` / `wasBandFloored` were already
+published as aggregates by wave 25 (`RULE N25` `A4` **18 of 18**; `RULE W25` `W-UNEXERCISED`, no blind cell
+floored), so they were burned two waves ago. They are `W29-R`'s **applicability filter**, not its statistic:
+they decide *whether a round can be read*, and `halfWidth` / `bootstrap` decide *what it says*. **Reading which
+rounds are addressable is how a population is asserted; reading the values is how a rule is pre-empted.** This
+table exists so a later reader can check that the wave did not blur them. **`halfWidth`,
+`bootstrap.offsetSteps` and `bootstrap.stepSize` have been read on `D01` only** (published), and the
+requested-vs-implied comparison has **never** been computed on any other cell.
+
+**BLIND, and carrying `W29-R`'s verdict: the 15 paired S1 cells other than `D01`/`D02`/`D03`.**
+
+**`W29-L` has no blind population and this is said plainly.** Its baseline is published to the digit and its
+verdict is a **difference** against it; the four intervention cells do not exist yet. The honesty mechanism is
+therefore not blindness but **prediction**: §6 fixes `L-JOINTLY-BOUND` as the expected answer, with its
+mechanism, before the arm runs. **Wave 28 had to relocate its verdict to the frame level because the bank
+could not supply a blind wide-field dataset; wave 29 cannot relocate `W29-L` anywhere, so it says so instead
+of claiming a blindness it does not have.**
+
+---
+
+## 8. THE GATE — answered in both directions, and it is NOT owed this wave
+
+**Wave 29 changes no C# and builds no binary.** Wave 26's four conditions for an honest skip therefore all
+hold: nothing is compiled; `G25` already answered what a re-gate asks; a re-gate does not reach this wave's
+risk (which is a source reading and two artifact re-reads); and **no clause in any verdict tree in this
+document reads a gate landing.** *A control that no clause consumes is a ritual.*
+
+**The three conditions that reverse it are checked at Step 8 and any one of them stops the wave:** a single
+line of C# changing for any reason; a hash or `BuildId` mismatch on the binary the `W29-L` arm uses; or that
+arm's own instrument proving non-deterministic. The replacement control is `Q26-V0`'s shape — dll sha256
+identity of `/mnt/d/hf_w25/exe` against `/mnt/d/hf_w25/binary_provenance_w25.txt`, with `L0`'s exact
+reproduction of a published population as the arm-level control that *can* fail.
+
+**And the answer the controller asked for, for the record and for the next wave: if wave 29 had shipped
+F82's fix, the gate would be owed, certainly and not probably.** §2.3 has the artifact. The intersection is
+non-empty by a directory prefix over the whole plugin assembly, `Q27-V1`'s own FAIL end names
+`StepSizeRecommender.cs` by path, and **`Q27-V1` does not discharge it.** Price when it comes due: **42 m**
+measured (wave 25: 42 m 43 s, ~5.2 m/run, seven consecutive waves), predicted verdict `G-PASS` 8 of 8
+bit-identical to K8.
+
+---
+
+## 9. WHAT SHIPS — nothing, fixed here, before the data
+
+**No product code changes in wave 29.** This is not a gated ship that failed its gate; it is a scope decision
+made in the pre-registration on the strength of §1, and it is recorded so that no later reader mistakes it for
+a verdict.
+
+| candidate ship | status |
+|---|---|
+| F82 fix (1), harness | **DOES NOT SHIP.** §1: it reaches no user, and shipping it would make `synth-validate` stop reproducing the product's own stall |
+| F82 fix (1), product | **DOES NOT SHIP.** Needs new persisted state; unpriced by anyone; §11 gives a band |
+| F82 fix (2) | **DOES NOT SHIP**, on either verdict of `RULE W29-R`. §5.4 |
+| F82 fix (3), the scoped requested-span bound | **DOES NOT SHIP.** Proposed from source in §4.4, deliberately not chosen in the wave that proposed it |
+| anything on the `NoiseClippingMultiplier` or `Sensitivity` axes | **DOES NOT SHIP.** §3, §6 |
+
+**Consequence:** no C# changes, so **the unit suite is not run**, and that is stated rather than skipped
+silently. `CLAUDE.md`'s *"run the suite after every code change"* is satisfied vacuously and the condition that
+reverses it is written into the plan: **if a single line of C# changes for any reason, the suite runs by COUNT
+([F37](followups.md)) and the gate becomes owed (§8).** The baseline to compare against is **3997** — wave 28's
+measured close — **not the charter's stale 3973** (wave 28 §7.8: the design quoted a figure two waves old and
+would have hidden a 19-test regression).
+
+---
+
+## 10. VERDICT TREES, ENUMERATED — [F94](followups.md)'s remedy, executed rather than restated
+
+Every clause appears in its own tree, **including every validity clause**. Every scorer re-derives these
+enumerations in code and prints `regions enumerated: N   uncovered: 0`; a gap prints `<RULE>-TREE-GAP`,
+enumerates the uncovered regions, prints what this document's tree would have said, and **does not repair and
+re-score**.
+
+**`RULE W29-S` — 3 clauses, 8 regions, 0 uncovered**
+
+| `S-a` | `S-b` | `S-c` | verdict |
+|---|---|---|---|
+| F | * | * | `S-UNEVALUATED` (4 regions) |
+| T | F | * | `S-CARRIER-EXISTS` (2 regions) |
+| T | T | T | `S-NO-CARRIER` (1) |
+| T | T | F | `S-NO-CARRIER-NO-ALT` (1) |
+
+**`RULE W29-R` — 2 clauses, 4 regions, 0 uncovered**
+
+| `R-0` | `R-1` | verdict |
+|---|---|---|
+| F | F | `R-UNSATISFIABLE` — a FINDING; wave 26's choice stands by default |
+| F | T | **logically unreachable** (`c ≥ 2` ⇒ `k ≥ 2`). Present, asserted empty, and entering it is `R-INCOHERENT` — a refusal |
+| T | F | `R-STANDS` |
+| T | T | `R-REVERSE` |
+
+**`RULE W29-L` — 3 clauses, 8 regions, 0 uncovered**
+
+| `L-0` | `L-1` | `L-2` | verdict |
+|---|---|---|---|
+| F | * | * | `L-UNEVALUATED` (4 regions) |
+| T | T | T | **unreachable by construction** — asserted empty; entering it is `L-INCOHERENT` (1) |
+| T | T | F | `L-JOINTLY-BOUND` — **the prediction** (1) |
+| T | F | T | `L-SEPARABLE` (1) |
+| T | F | F | `L-PARTIAL` (1) |
+
+**`RULE V29` (pre-flight) and `W29-FP` (fingerprint)** inherit wave 28's trees unchanged:
+`V-CLEAN` / `V-DRIFT` / `V-UNEVALUATED`, and `PRESERVED` / `VIOLATED` / `UNEVALUATED` on differing membership.
+
+**Why the pattern F94 identified does not recur here.** F94's diagnosis was specific: *"the uncovered region
+is always the VALIDITY clause"* — `N-1` was expected to hold, so it fell out of the tree. `S-a`, `R-0` and
+`L-0` are all validity clauses and **all three are the first column of their own table.**
+
+---
+
+## 11. PRICE, per half, scored against the owner's three goals, and what is cut first
+
+Goals (charter §8): **(1)** optimization + autofocus across a wide range of setups; **(2)** accuracy of
+step-size recommendations; **(3)** appropriate exposure adjustments, no parameters pinned to extremes.
+
+| step | est | compute | goals |
+|---|---|---|---|
+| 0 vessel + pre-registration commit | 10 m | — | — |
+| 1 write **all** instruments (5 files) before any of them runs | 60 m | — | — |
+| 2 `RULE V29` pre-flight, **over the populated root** ([F95](followups.md)) | 20 m | — | instrument |
+| 3 `W29-FP` fingerprint BEFORE | 8 m | — | instrument |
+| 4 `RULE W29-S` | 25 m | — | **2** ✓✓ (it decides what F82 *is*) |
+| 5 `RULE W29-R` | 25 m | — | **2** ✓✓ |
+| 6 `RULE W29-L` arm + scoring | 55 m | **~25 m** | **3** ✓✓, **1** ✓ |
+| 7 [F83](followups.md)'s `P-D08` at `n = 3` | 2 m | ~2 m | **3** ✓ |
+| 8 fingerprint AFTER + **closing** `V29` | 12 m | — | instrument |
+| 9 results, register, handoff | 75 m | — | — |
+| **total** | **~5 h** | **~27 m** | |
+
+Comfortably inside both the ~8 h wall clock and the ~6 h compute ceiling. **Slack is deliberate**, because
+this is the fourth consecutive wave in which the analysis halves are over-priced — wave 28 came in **~59 %
+under**, wave 27 ~36 % under, and the lesson is now specific: *price compute from the measured rate and price
+analysis at a third of instinct.* The one figure here priced from a measured rate is step 6: wave 28 measured
+`D01` at `NC = 1.0` at **179 s per 9-frame cell**, the top of the bank's range, and 5 cells is ~15 m plus
+copies and fingerprints — reserved at 25 m.
+
+**What is cut first, in order:**
+
+1. **`L3` and `L4`** — the Sensitivity cell and the joint cell. The arm degrades from a decomposition to a
+   ranking with lower bounds, saving ~10 m of compute. **This is the cut, and it is the one that costs the
+   most per minute saved**, so it is named first to be honest, not because it is cheap.
+2. **The whole of `RULE W29-L`.** Wave 29 still delivers `W29-S` and `W29-R`, which are the two halves that
+   decide F82's fate. `W29-L` finishes someone else's question.
+3. **Step 7** — no. **An item under two minutes is never dropped** (charter §4); wave 19 finished at 1 h 35 m
+   of a 6 h ceiling with a one-minute item undone and it cost `RULE C19` its verdict.
+4. **Step 9's handoff document**, folded into the results file's §12 rather than written separately.
+
+**What is NOT cut, at any budget:** the closing `V29` run (step 8). It is two minutes and it is
+[F95](followups.md)'s entire remedy.
+
+**Prices this wave hands forward rather than paying:**
+
+| item | price |
+|---|---|
+| F82 fix (1) **in the harness** | ~45 m + tests. **Not recommended** — §1, §9 |
+| F82 fix (1) **in the product** | **a BAND, and it is one**: ~2–4 h. New persisted half-width surviving between wizard sessions; the `Continue`/`Re-optimize` paths excluded where it is inert; migration; a `CLAUDE.md` decision on whether it is an *option* and therefore owes a control in the options templates; **+ 42 m gate** (§8) |
+| F82 fix (2) | ~45 m code **+ a full paired 18-cell arm ~2 h 40 m + 42 m gate + an `A3` re-derivation**, because it moves `ComputeStepBehavioral` |
+| F82 fix (3), the scoped requested-span bound (§4.4) | ~45 m code + a 3-cell re-run + **42 m gate**. Needs no new state and no `A3` re-derivation if the guard holds — **cheapest of the three, and precisely why it must not be chosen by the wave that thought of it** |
+| the `A4` truth-model gap (backlog item 4, "~20 m") | **the 20 m is the code. It rebuilds `TestApp`, which trips §8's first reversal condition and adds 42 m of gate.** Naming that is itself a finding: the cheapest item on the backlog is not cheap |
+
+---
+
+## 12. INSTRUMENTS AND CONSTRAINTS
+
+All under `/mnt/d/hf_w29/`, **LF**, derived from `/mnt/d/hf_w28/`.
+
+- `verify_derivation_w29.py` — derived from `verify_derivation_w28.py`, **not** any `.bak`. **Carry forward,
+  and demonstrate, all three of wave 28's repairs:** [F87](followups.md)'s `historical_ranges` fix (the
+  definition line of `HISTORICAL_BLOCKS` opens nothing — bracket-depth, top-down, `is_definition` excluded);
+  self-test clause **`[6]`** in both directions; and wave 28's **per-clause fixture pinning** `[5b]`.
+- **Per-clause fixtures: MEASURE which roots still refuse; do not inherit wave 28's choices.** Wave 28
+  established that a root pinned for its `-B` findings **goes silent exactly one wave later**, because `PREV`
+  moves: `/mnt/d/hf_w26` yielded 0 `-B` at wave 28. `/mnt/d/hf_w27` was wave 28's live `-B` fixture and
+  **`PREV` is now 28**, so it is a candidate to have expired in exactly the same way. **The plan measures
+  `-A`/`-B`/`-C` finding counts across `/mnt/d/hf_w{24,26,27,28}` and pins from the measurement**, keeps the
+  expired root asserted-silent so the expiry is demonstrated rather than described, and treats **a clause with
+  no live fixture as a FAIL**. Wave 28 assumed and got lucky; wave 29 measures.
+- **`--out` mandatory and REFUSING without it** on every scorer.
+- **`--rule` asserted against the file's own declared rule name** ([F90](followups.md)) — a hard refusal.
+  Wave 28's scorers made this a refusal and it caught the controller within a minute.
+- Populations **asserted**; ordinals and counts **computed, never typed** (`V29-C`); paths handed to scorers
+  through a **manifest**, never rebuilt from a template ([F74](followups.md)); one shared layout function.
+- `find … -print0 | sort -z | xargs -0` — `/mnt/d/Autofocus Bank` contains a space.
+- **BEFORE/AFTER built from ONE expression called twice** ([F91](followups.md)), population size asserted
+  **equal** before any hash is compared, and the fingerprint written **outside** every tree it sweeps
+  (wave 28 §7.10).
+- `touch` after every mutant or settings restore ([F89](followups.md)); `cp` **without** `-p`.
+- Provenance: `git diff --name-only <tree> -- '*.cs'` **unioned with** `git ls-files --others
+  --exclude-standard -- '*.cs'` ([F88](followups.md)), and the BEFORE tree hash read out of
+  `/mnt/d/hf_w25/binary_provenance_w25.txt`, **never assumed from a previous HEAD**.
+- **Pass scorers WSL paths.** A Windows path yields `UNEVALUATED` and looks like a failed arm.
+- `TestApp.exe` gets `< /dev/null`; `--settings` **and** `--profile-id` pinned on the arm; one `TestApp.exe`
+  at a time; **no directory rebuilt mid-wave** — every instrument is written at Step 1.
+- **Read-only for the whole wave:** `/mnt/d/hf_w25/{after,before,table18,exe}`, `/mnt/d/hf_w28/nc`,
+  `/mnt/d/SyntheticAutofocusBank`.
+
+**Every conclusion in this wave is synthetic-only.** The bank has no real under-sampled dataset
+([F35](followups.md), [F43](followups.md)) and `W29-L` is one dataset, `D01`, named as one dataset everywhere
+it is quoted.
+
+---
+
+## 13. WHAT WAVE 29 WILL NOT RUN, AND WHAT IT COSTS
+
+| not run | price | why |
+|---|---|---|
+| any F82 fix | see §11 | §1, §9 — none of the three reaches a user at wave-29 cost |
+| the 42 m `optimize` gate | 42 m | **Not owed** — no C# changes (§8). Owed, certainly, by the wave that ships F82 |
+| the unit suite | ~4 m | No C# changes (§9). Reverses on one line of C# |
+| a full paired 18-cell S1 arm | ~2 h 40 m | `W-UNEXERCISED`: 13 blind cells moved by exactly zero across a real product change. A second full arm buys a second `SAME 13` |
+| wave 28's `M1`–`M6` mutant records | ~10 m | **Not applicable** — wave 29 ships nothing and writes no test. Wave 28's debt stays wave 28's, named in its §11 |
+| `S27-1` and wave 27's three mutants | ~20 m | **STILL OPEN, two waves running.** Cut for budget; named so it is not lost a third time |
+| new datasets between 1.4 and 19.4 ″/px | ≥ 1 h render | The only route to a **blind** wide-field dataset. The bank's coverage hole is unchanged |
+| the blur/layer decoupling build ([F92](followups.md)) | ~45 m + 10 m (+42 m to ship) | Better-motivated than at its pre-registration, and it is a detector change owing a baseline |
+| the `A4` truth-model gap | 20 m code **+ 42 m gate** | §11's last row |
+| anything on real frames | — | The bank has no real under-sampled dataset |
+
+---
+
+## 14. REGISTER ENTRIES OWED, whatever the verdicts
+
+- **F96** — the harness's `stepBehavioral` is `StepSizeRecommender.Recommend` iterated to a fixed point, so a
+  change to the recommender moves the bar that scores it; and no product caller carries cross-round sweep
+  state, so F82's pre-registered fix has no product carrier. Owed on `S-NO-CARRIER` **or**
+  `S-NO-CARRIER-NO-ALT`; **withdrawn in place** on `S-CARRIER-EXISTS`.
+- **F97** — `RULE W29-R`'s verdict, whichever it is, with `c`, `c_blind`, `k` and the named qualifying cells.
+- **F98** — `RULE W29-L`'s decomposition, with the exclusive and joint shares, framed per §2.5 as goal 3.
+- **[F82](followups.md) — AMEND IN PLACE.** Its *"truth of 9"* must be labelled as a **product-derived fixed
+  point**, not a spec-derived truth; its *"confined to the recommender's caller state"* must name **which**
+  caller; and the third candidate (§4.4) must be added beside the two.
+- **[F81](followups.md)** — append that the floor it shipped is reached in the product only at round 0 of a
+  session, because the wizard's rounds do not re-sweep.
+- **[F94](followups.md)** — append §10's enumeration as the first design to publish its own outcome space,
+  and whether the scorers' re-derivations agreed with it.
+- **[F95](followups.md)** — append whether the ordering in the plan (instruments **then** pre-flight **then**
+  measurement, plus a closing run) produced a non-empty population at the first run. **This is the wave that
+  tests the remedy.**
+- **[F21](followups.md)** — estimate vs actual for every step, per §11.
+- **`docs/synthetic-af-bank-results-table.md`** — wave 28's owed `K` column, and **no 2–4 px band claim below
+  the band** (`B-SPLIT`).

--- a/docs/synthetic-af-bank-followups-wave29-design.md
+++ b/docs/synthetic-af-bank-followups-wave29-design.md
@@ -27,6 +27,36 @@ verdict. It is load-bearing for whether the previous wave's declared deviation g
 
 ---
 
+> ## CORRECTION, added after the measurement — §1(b) IS FALSE AT HEAD, and `RULE W29-S` says so
+>
+> **This design's headline is half wrong, the wave's own rule refuted it, and the pre-registration text below
+> is left EXACTLY as written so the error is visible rather than tidied away.**
+>
+> **`RULE W29-S` = `S-CARRIER-EXISTS`** (`/mnt/d/hf_w29/w29s_score.txt`): `S-a` **HOLDS**, `S-c` **HOLDS**,
+> **`S-b` is FALSE**. A product carrier *does* exist.
+>
+> §1(b)'s caller table names **two** of `BuildSummaryAsync`'s **five** callers. The full set, discovered by the
+> instrument rather than typed: `StartAsync`, `ReOptimizeWithLabelsAsync`, `ContinueOptimizationAsync`,
+> `OptimizeAgainAtRecommendedBinningAsync`, and — the one that matters —
+> **`CaptureNewSweepAsync`** (`StarDetectionOptimizerWizardVM.cs:5012`), which takes a **fresh sweep**
+> (`RunLiveAttemptAsync` per run), calls `BuildSummaryAsync` at `:5098`, and **carries the previous round's
+> recommended geometry into the next sweep** through the instance field `recaptureStepSize`.
+>
+> So the sentence *"No new sweep is taken between wizard rounds, so `SearchSpan` cannot change between them and
+> the defect cannot occur there at all"* is **false**, and with it the claims that fix (1) *"reaches no user"*
+> and that F82 *"scores goal 2 zero"*. **F82 is a real product defect on a real product path.**
+>
+> **The controller repeated the false claim in the wave-29 pre-registration commit message** (`544f2b2`), which
+> cannot be edited; it is corrected here, in the PR, and in the results document.
+>
+> **What survives, and it is the larger half:** §1(a) — the truth-model coupling — is `S-a`, and it **HOLDS**.
+> The harness still scores the recommender against a fixed point of the recommender. And the wave's refusal to
+> flip wave 26's choice still stands, now for a better reason than it was written for: `RULE W29-R` =
+> **`R-STANDS`**, so the reversal condition is not met on evidence, not merely unexamined.
+>
+> **The instrument was written to the pre-registration and NOT tuned to this result.** `S-b` was implemented
+> exactly as §4 fixes it; it returned FALSE on its own terms. That is a pre-registration working.
+
 ## 1. THE HEADLINE: the pre-registered fix has no carrier in the product, and the "truth" it is scored against is produced by the code under test
 
 Two facts, both decidable from source at zero compute, both verified in this document against shipping files:

--- a/docs/synthetic-af-bank-followups-wave29-results.md
+++ b/docs/synthetic-af-bank-followups-wave29-results.md
@@ -1,0 +1,941 @@
+# Wave 29 — results
+
+## THE TIMESTAMP — the roll call, taken at an instant
+
+```
+$ date -u '+%Y-%m-%dT%H:%M:%SZ'; ls -la --time-style=full-iso /mnt/d/hf_w29/
+2026-08-13T18:03:36Z
+drwxrwxrwx  ...  2026-08-13 13:52:45.735921200 -0400 .
+```
+
+**One row was OPEN at that instant and is marked open in place.** `fp_AFTER.txt` had mtime
+`13:52:45 → 14:03:36.461` (`= 18:03:36Z`) — **the same second as the timestamp**. Three `stat` calls two
+seconds apart returned `373637 → 377044 → 380971` bytes: it was **mid-write**, the 42 GB sweep still running.
+It closed at `14:04:27.954 -0400` (`= 18:04:27Z`), **51 seconds after the roll call**, at 398 023 bytes and
+`POPULATION 2452`. It is reported below as a completed artifact **and** as having been open at the timestamp,
+because wave 19's document was falsified by an artifact written 33 seconds before its own commit and the fix
+for that is to say both things.
+
+| row | state at **18:03:36Z** | artifact |
+|---|---|---|
+| `RULE W29-S` | **CLOSED** 17:36:08Z | `w29s_score.txt` |
+| `RULE W29-R` | **CLOSED** 17:36:19Z | `w29r_score.txt` |
+| `RULE W29-L` arm | **CLOSED** — `W29L_ARM_END 17:51:23Z`, 5 of 5 cells `exit=0`, interlock written by the driver | `w29l_arm.txt`, `w29l_manifest.tsv`, `W29L_MANIFEST_READY`, `l/out/L{0..4}.log` |
+| `RULE W29-L` scoring | **CLOSED** 17:52:13Z | `w29l_score.txt` |
+| `RULE V29` (pre-flight) | **CLOSED** 17:35:55Z, over a root of **7 files**; self-test 17:35:39Z `27 of 27`; four fixture probes 17:20:58–17:21:32Z | `vdrift_w29.txt`, `vdrift_selftest_w29.txt`, `vdrift_probe_hf_w2{4,6,7,8}.txt`, `vdrift_instrumentcheck_w29.txt` |
+| `W29-FP` AFTER sweep | **OPEN AT THE TIMESTAMP** — mid-write, closed 18:04:27Z (11 m 42 s, 2 452 files) | `fp_AFTER.txt`, `fp_after_run.txt` |
+| cross-wave integrity check | **NOT YET WRITTEN** at the timestamp — appeared 18:05:04Z | `fp_crosswave_check.txt` |
+| `W29-FP` **BEFORE** sweep | **NEVER RUN** — controller deviation (i), §8 | — |
+| the **closing** `V29` (`vdrift_w29_FINAL.txt`) | **NOT RUN** — design §11 called it the one thing not cut at any budget | — |
+| Step 7, [F83](followups.md)'s `P-D08` at `n = 3` | **NOT RUN** — no artifact under the root | — |
+| the three scorers' `--self-test` captures | **NO ARTIFACT** — `w29s_selftest.txt` / `w29r_selftest.txt` / `w29l_selftest.txt` are absent; the two drivers' self-tests **are** on disk (`27 of 27`, `33 of 33`) | — |
+| `fp_w29.sh --self-test` capture, `T0.txt` | **NO ARTIFACT** — both named by the plan, neither on disk | — |
+
+**Vessel.** Wave 29 ran on its own branch `ghilios/synthetic-af-bank-followups-wave29`, with commits `544f2b2`
+(pre-registration) and `80e42c5` (the CORRECTION), on **PR #197**, verified `OPEN`, stacked on #196. **Design
+§0 was executed rather than reversed** — wave 28's declared deviation was not repeated, and #196 does not carry
+a third section.
+
+**But the PR's own title still carries the withdrawn claim** — *"Wave 29: F82's fix has no product carrier, and
+the step-size truth is produced by the code under test"*. The second half is `S-a` and holds. **The first half
+is `S-b` and is FALSE** (§1). The title is editable where the pre-registration commit message is not, and
+correcting it is owed before merge.
+
+---
+
+## §0 — What this document is allowed to say
+
+Every number below is quoted from an artifact under `/mnt/d/hf_w29/`, from `/mnt/d/hf_w28/`, from
+`/mnt/d/hf_w25/`, or from a file in the repository at `HEAD`, and each is cited. The pre-registered rules in
+`docs/synthetic-af-bank-followups-wave29-design.md` are **applied as written**. Where a rule turned out to be
+unsatisfiable, under-specified or directionally wrong, that is reported as a **finding** (§6, §7, §8, §9) — it
+is not repaired, and no repaired version is scored.
+
+**Everything below is synthetic-only.** The bank has no real under-sampled dataset
+([F35](followups.md), [F43](followups.md)), and `RULE W29-L` is **one dataset, `D01_ultrawide_40mm`**, named as
+one dataset everywhere it is quoted.
+
+**Verdicts, in one table.**
+
+| rule | verdict | population | artifact |
+|---|---|---|---|
+| **`RULE W29-S`** | **`S-CARRIER-EXISTS`** — `S-a` HOLDS, `S-c` HOLDS, **`S-b` FALSE** | 4 source files at `HEAD`, by sha256 | `w29s_score.txt` |
+| **`RULE W29-R`** | **`R-STANDS`** — `k = 18`, **`c = 1`**, **`c_blind = 0`** | 18 addressable paired S1 cells under `/mnt/d/hf_w25/after` | `w29r_score.txt` |
+| **`RULE W29-L`** | **`L-UNEVALUATED`** — `joint = −12162`, not positive; shares undefined | 5 cells × 9 frames on `D01` | `w29l_score.txt` |
+| **`RULE V29`** | **`V-CLEAN`** over **7** instrument files; self-test **27 of 27**; tree **12 regions / 0 uncovered** | 7 files | `vdrift_w29.txt` |
+| **`W29-FP`** | **NO WAVE-29 BEFORE.** Cross-wave overlap `PRESERVED`, 1 080 of 1 080, 0 moved; **four roots have no baseline in this run and are NOT claimed preserved** | 2 452 files AFTER | `fp_AFTER.txt`, `fp_crosswave_check.txt` |
+
+---
+
+## §1 — THE HEADLINE: the design's own headline was HALF WRONG, and the wave's own rule refuted it
+
+**`S-b` is FALSE. A product carrier exists.**
+
+Design §1(b)'s caller table named **two** of `BuildSummaryAsync`'s **five** callers. The scorer discovered the
+full set rather than being handed it — `StartAsync` (`:3022`), `ReOptimizeWithLabelsAsync` (`:4741`),
+`ContinueOptimizationAsync` (`:4853`), `OptimizeAgainAtRecommendedBinningAsync` (`:4946`), and the one that
+matters, **`CaptureNewSweepAsync` (`StarDetectionOptimizerWizardVM.cs:5012`)**, which calls `BuildSummaryAsync`
+at **`:5098`**. `w29s_score.txt` prints the discrimination directly:
+
+```
+      driver                                                         reloads  captures               prior-round state (REPORTED)
+      StarDetectionOptimizerWizardVM.cs:CaptureNewSweepAsync         yes      RunLiveAttemptAsync    RecommendedStepSize,SelectedSummary
+      StarDetectionOptimizerWizardVM.cs:ContinueOptimizationAsync    yes      NO                     -
+      StarDetectionOptimizerWizardVM.cs:OptimizeAgainAtRecommendedBinningAsync yes      NO                     SelectedSummary
+      StarDetectionOptimizerWizardVM.cs:ReOptimizeWithLabelsAsync    yes      NO                     -
+      StarDetectionOptimizerWizardVM.cs:StartAsync                   NO       AcquireAsync           -
+    S-b(i) -> FALSE
+```
+
+And the cross-round carrier is on the instance, verified at `HEAD`: `recaptureStepSize` is declared at
+`:2608`, **assigned from the previous round's recommendation** at `:5037`
+(`recaptureStepSize = geometry != null && geometry.RecommendedStepSize != …`), the fresh sweep is taken at
+`:5071` (`RunLiveAttemptAsync`), and that sweep consumes it at `:3236`
+(`ApplyRecaptureGeometry(options, recaptureStepSize)`).
+
+**So design §1(b)'s sentence — *"No new sweep is taken between wizard rounds, so `SearchSpan` cannot change
+between them and the defect cannot occur there at all"* — is FALSE**, and with it the two claims that hang off
+it: that fix (1) *"reaches no user"*, and that F82 *"scores goal 2 zero"*. **F82 is a real product defect on a
+real product path.** The controller repeated the false claim in the pre-registration commit message
+(`544f2b2`), which cannot be edited; it is corrected in the design's CORRECTION block, in commit `80e42c5`, in
+PR #197, and here.
+
+**The instrument was written to the pre-registration and was NOT tuned.** `S-b` was implemented exactly as
+design §4 fixes it — enumerate every `Recommend(` site under the plugin assembly, resolve each site's enclosing
+recommendation builder, resolve each builder's own callers, and ask of each whether it re-captures. It returned
+**FALSE on its own terms**, against the document that commissioned it. **That is a pre-registration working**,
+and it is the only mechanism in this series that can produce this outcome: a rule written to confirm a claim
+and allowed to refute it instead.
+
+**What survives, and it is the larger half.** `S-a` **HOLDS**, and it is the finding this wave was worth
+running for:
+
+```
+ComputeStepBehavioral is DECLARED once, at source lines 1213 to 1270
+StepSizeRecommender.Recommend( call sites INSIDE that body : 1 at lines [1262]
+StepSizeRecommender.Recommend( call sites in the WHOLE file: 2 at lines [792, 1262]
+writers of the value serialized as terminal.stepBehavioral, over 70 harness file(s): 1
+S-a -> HOLDS
+```
+
+At `HEAD`, `SynthValidateRunner.ComputeStepBehavioral` is a `for (var iter = 0; iter < MaxIterations; iter++)`
+loop that calls `StepSizeRecommender.Recommend` at `:1262` and returns when `rec.StepSize == step`. **The
+harness scores the recommender against a fixed point of the recommender.** Every goal-2 conclusion in this
+series — including F82's *"a truth of 9"* — is denominated in a bar that the code under test produces. That is
+why `stepBehavioral` moved 8.0 → 9.0 across wave 25's two arms while it was identical on the other 17 cells:
+wave 25 changed `Recommend`, so it moved the bar and the measurement together. F82 recorded the symptom and
+called it *"an assumption this series can no longer make for free"*. **The cause is one line, it has been in
+the file the whole time, and nobody had looked at it.**
+
+`S-c` also **HOLDS**: `SweepDetectability` declares `FrameFocuserPositions`, reachable inside `Recommend` via
+`Recommend → MeasureMaxUsefulHalfSpan`. So the third candidate fix registered in design §4.4 remains available
+and remains **not chosen** — a wave that reads a diagnosis and picks the fix it just invented is the
+[F14](followups.md) / `RULE D20` fence in a new costume.
+
+---
+
+## §2 — `RULE W29-R` = `R-STANDS`, on evidence and not on caution
+
+Wave 26 wrote the escape clause — *"if a later wave measures that `SearchSpan` over `bestFit.Inputs`
+**shrinks on more than a single cell** while the requested sweep widens, then the defect is in the quantity and
+not in its persistence, and (2) becomes correct"* — and **three waves quoted it and none executed it.** Wave 29
+executed it, at zero compute, on artifacts already on disk.
+
+**Validity first, and it is the first column of its own tree.** The divisor was asserted at **both** trees, not
+assumed: `MaxHalfWidthSampledHalfSpanMultiple` reads `1.5` at `HEAD` **and** at the B15 tree
+`29665a62e4f8`, read out of `/mnt/d/hf_w25/binary_provenance_w25.txt` rather than typed. The population
+asserted 20 dataset directories, **18** addressable, and the gap matched **by name** — `D05_tec140_1000mm`,
+`D19_cygnus_deep_shed`. The applicability census, run before any statistic: `rounds seen 37;
+capped-or-floored and not detect-bounded 37; detect-bounded 0; neither capped nor floored 0`. The
+`wasDetectBounded` trap design §5.1 named never fired. And the reader asserted it consumed the **per-round**
+`stepRecommendation`/`bootstrap` copies and read nothing from `terminal` ([F68](followups.md) part 5), proved
+by inspecting its own source for the token.
+
+**The result.**
+
+```
+k  = 18 addressable cells (bar: k >= 2)
+c  = 1 cells with at least one qualifying transition, over the 18 addressable (bar: c >= 2)
+c_blind = 0 over the 15 cells excluding the burned ['D01_ultrawide_40mm', 'D02_rich_135mm', 'D03_redcat_250mm']
+qualifying cells, by name: ['D01_ultrawide_40mm']
+```
+
+**The one qualifying cell is `D01`, and `D01` is burned** — its rounds were published in F82's own table, and
+design §5.2 predicted its contribution before the scorer ran. Over the **15 blind cells nobody had computed
+this statistic on, `c_blind = 0`.** The identity reproduced F82's published table on the nose — `D01` r0
+`halfWidth` 12.0 ⇒ implied 16 against requested 16; r1 `halfWidth` 9.0 ⇒ implied 12 against requested 24 — and
+on all 17 other cells implied and requested moved **together, in the same direction, on every transition.**
+
+**What that does to F82's apparent generality, said plainly.** The shrink-while-widening transition that
+F82 diagnosed occurs on **exactly one cell out of 18 in the bank, and on zero of the 15 that were blind.**
+F82 is real — §1 establishes it reaches a real product path — but it is **not general**. Wave 26 named `n = 1`
+as insufficient to reverse its choice; wave 29 measured `n = 1` on a population 6× larger and blind on 15 of
+it. **The defect is not being suppressed by a lack of looking. It is rare.** Anyone pricing a fix for it should
+price it against one cell in eighteen, not against the 37-of-37 capped-or-floored population that design §1
+quantified.
+
+**Two `COULD-NOT-LOOK` cells, named, each having LEFT the denominator rather than scoring zero:**
+
+```
+  [CNL-NOREPORT] D05_tec140_1000mm      no synth_validate_report.json -- the cell produced no report
+  [CNL-NOREPORT] D19_cygnus_deep_shed   no synth_validate_report.json -- the cell produced no report
+```
+
+These are [F74](followups.md)'s two structural timeouts. They left the denominator; `k = 18`, not 20, and the
+gap was asserted by name before any statistic was taken.
+
+**On this verdict, wave 26's pre-registered choice stands: fix (1) remains correct on wave 26's grounds.** And
+§1's finding stands beside it, **changed**: it does now reach a user. Nothing ships (design §9).
+
+---
+
+## §3 — `RULE W29-L` = `L-UNEVALUATED`, and it is a control working
+
+`L-0`, the control that **can** fail, **HELD**. `L0` reproduced wave 28's published `D01` `NC = 1.0` high-tier
+attribution block **field for field, 8 fields compared, 0 disagreeing**, against
+`/mnt/d/hf_w28/nc/D01_ultrawide_40mm_nc1.0/attempt01/golden_eval.txt`. All five cells `exit=0`, all five echoed
+their intended knobs, per-cell wall times 177 / 198 / 152 / 168 / 145 s against wave 28's measured 179 s
+reference, **874 s actual against a 900–1500 s pre-registered band.**
+
+**And then opening gates made the counted misses go UP.**
+
+| cell | gate | `FN_total` (high tier) | `exclusive` | `recall@high` |
+|---|---|---|---|---|
+| `L0` | (baseline) | **50 249** | — | 0.195 (12 162 / 62 411) |
+| `L1` | `MinimumStarBoundingBoxSize` 6 → 3 | 50 246 | **3** | 0.195 (12 165 / 62 411) |
+| `L2` | `MaxDistortion` 0.5 → 0.9 | **62 411** | **−12 162** | **0.000 (0 / 62 411)** |
+| `L3` | `Sensitivity` 36.333 → 35.333 | 50 148 | **101** | 0.196 (12 263 / 62 411) |
+| `L4` | all three | **62 411** | — | **0.000 (0 / 62 411)** |
+
+```
+joint (total recoverable across all three)      : -12162
+sum of the exclusive shares                     : -12058
+COULD-NOT-LOOK: joint is -12162, which is not positive; the shares are undefined and a
+  ratio against it would be an artefact rather than a measurement.
+```
+
+**`62 411` is `D01`'s entire high-tier golden population.** `L2` and `L4` returned `TP=0 FP=0 FN=110384
+precision=NaN recall=0.000`. Every high-tier star became a false negative. The scorer refused rather than
+divide by a negative denominator, and `L-1` / `L-2` are `UNEVALUATED`.
+
+### 3.1 WHY — and it is a directional error in the pre-registration, verified from source
+
+Design §6 headed its table *"one knob relaxed per cell"* and pre-registered `L2` as `MaxDistortion` **0.5 → 0.9**.
+**That is not a relaxation. It is the strictest setting the axis can nearly express.**
+
+`StarDetector.cs:1804`:
+
+```csharp
+var effectiveMaxDistortion = ComputeEffectiveMaxDistortion(p, d);
+if (fillRatio < effectiveMaxDistortion) {   // ⇒ RecordRejection(..., RejectionGate.TooDistorted, ...)
+```
+
+`MaxDistortion` is compared as a **lower bound on the bounding-box fill ratio**. Raising it **tightens** the
+gate. `DefocusAwareGates` is `false` in `D01`'s landed tree (`optimized_settings.json`), so
+`ComputeEffectiveMaxDistortion` returns `p.MaxDistortion` verbatim and the effective threshold was exactly
+`0.9`. And the file's own comment at `:1786` gives the ceiling: *"a perfect disk fills ~PI/4 ≈ 0.79."*
+
+**`MaxDistortion = 0.9` is above the fill ratio of a perfect disk. `L2` and `L4` were guaranteed to return zero
+detections before they were run.** The corroboration is in the wall clock: `L2` (152 s) and `L4` (145 s) were
+the **two fastest** cells in the arm, because nothing survived the distortion gate to do downstream work.
+
+**This is reported, not repaired.** No clause in design §6's tree reads the *direction* of a knob edit, so the
+pre-registration could not catch it; the arm's own self-test checked that the edit was **surgical** (`33 of 33`,
+including *"exactly 1 file changed"* and *"an unnamed field is UNCHANGED"*) but surgical is not the same as
+correctly signed. The verdict stands at `L-UNEVALUATED`. The wave does not re-run `L2` at `0.1` and score that.
+
+### 3.2 What the arm DID measure, which the pre-registered statistic threw away
+
+The design's statistic is `FN_total` differences. The same artifacts carry the **per-gate** blocks, and those
+answer the question the rule was written to ask. Differencing `L0` → `L1` gate by gate:
+
+| gate | `L0` | `L1` | Δ |
+|---|---|---|---|
+| `REJECTED:TooSmall` | 11 372 | 1 835 | **−9 537** |
+| `REJECTED:TooDistorted` | 14 876 | 20 573 | **+5 697** |
+| `REJECTED:LowSensitivity` | 13 612 | 17 426 | **+3 814** |
+| `REJECTED:NotCentered` | 147 | 154 | +7 |
+| `REJECTED:OnBorder` | 77 | 87 | +10 |
+| `REJECTED:Degenerate` / `TooFlat` | — | 5 / 1 | +6 |
+| `NO CANDIDATE`, `Contaminated`, `ACCEPTED-elsewhere` | 8 931 / 533 / 701 | 8 931 / 533 / 701 | 0 |
+| **net** | | | **−3** ✓ |
+
+**Lowering the bounding-box floor from 6 to 3 released 9 537 high-tier candidates from `TooSmall`, and 99.97 %
+of them were immediately re-caught by `TooDistorted` (+5 697) and `LowSensitivity` (+3 814). Three reached
+acceptance.** That is a direct measurement of which gates bind, on real artifacts, and it is far stronger
+evidence than the subtraction the rule pre-registered — which sees only the net `−3` and cannot tell a gate
+that never fired from a gate whose entire yield was captured downstream.
+
+The `L3` difference decomposes the same way and is quoted **only** as arithmetic, per design §6's fence:
+`LowSensitivity` −122, `ACCEPTED-elsewhere` +5, `Contaminated` +4, `NotCentered` +12, net −101. **Nothing in
+this document cites `L3` as evidence for or against a bound on the sensitivity axis**
+([F84](followups.md), `RULE S16` is a permanent fence).
+
+### 3.3 What is still unknown about `D01`, said plainly
+
+**`D01` remains unlocalised.** Wave 28 converted 34 060 `NO CANDIDATE` into 33 298 gate rejections and said,
+correctly, that it had not localised them. Wave 29 has now **measured** that:
+
+- relaxing `MinimumStarBoundingBoxSize` 6 → 3 recovers **3 stars of 50 249** — **0.006 %**;
+- relaxing `Sensitivity` by one notch recovers **101 of 50 249** — **0.20 %**;
+- the third candidate gate was **never opened**, because the cell that was supposed to open it closed it
+  instead.
+
+So two of the three candidate gates move `D01` by a fifth of a percent between them, and the third is
+unmeasured. **The binding constraint on `D01` has not been found, and the two cheapest candidates for it are
+now excluded to within 0.2 %.** The gate-flow numbers in §3.2 say where to look next — `TooDistorted` and
+`LowSensitivity` jointly absorb everything the bounding-box floor releases — but that is a hypothesis this wave
+generated, not one it tested, and it is handed forward as such.
+
+---
+
+## §4 — `RULE V29` = `V-CLEAN`, and [F95](followups.md)'s remedy worked at its first half
+
+```
+=== RULE V29 -- --verify-derivation over /mnt/d/hf_w29 ===
+  files checked: 7
+  V29-A: sibling targets resolving on disk: 11 of 11 = 1.0000
+  V29-B: unlicensed previous-wave tokens: 0
+  V29-C: typed ordinals/counts in printed output: 0
+regions enumerated: 12   uncovered: 0
+>>> V-CLEAN
+```
+
+Self-test **`SELFTEST V29 27 of 27`**, clause groups `[1] [2] [3] [4] [5] [5b] [5c] [6]` all present, `[6]`
+showing both ends. **The plan's Step 1 → Step 2 ordering was executed**: the last instrument was written at
+`17:01:28Z` and the pre-flight ran at `17:35:55Z`, over a populated root of **7**. Wave 28 certified a root of
+**one file**; wave 29 did not. **That is F95's remedy and it worked.**
+
+**The remedy's second half did not run.** Design §11 named the closing `V29` as the one thing *not cut at any
+budget* — *"the first run proves the checker works, the closing run proves the wave is clean, and this series
+has been conflating them."* `vdrift_w29_FINAL.txt` is not on disk. `vdrift_instrumentcheck_w29.txt` (17:23:07Z)
+and `vdrift_w29.txt` (17:35:55Z) are byte-identical in content and **both pre-date the arm**. The remedy is
+therefore **half-executed, and the half that was cut is the half its own design said could not be cut.**
+Price to close: **~2 m.**
+
+---
+
+## §5 — `W29-FP`: what is proved, and what is NOT
+
+**There is no wave-29 BEFORE fingerprint**, because the controller ran `W29-S`, `W29-R` and the `W29-L` arm
+before Step 3 (§8, deviation (i)). What exists is an AFTER sweep of the six declared read-only roots
+(`POPULATION 2452`) and a cross-wave check against wave 28's `fp_BEFORE.txt` (mtime `2026-08-13 11:13:39 -0400`
+= `15:13:39Z`; the check's own header rounds it to `~15:36Z`).
+
+**PROVED:**
+
+```
+overlapping population, by root:
+   /mnt/d/SyntheticAutofocusBank      640
+   /mnt/d/hf_w25/table18              440
+compared 1080   MOVED 0   in BEFORE but absent from AFTER 0
+>>> CROSS-WAVE INTEGRITY = PRESERVED on the overlap (1080 files, 0 moved)
+```
+
+1 080 files across the two roots wave 28 also swept are **byte-identical from 15:13:39Z to 18:04:27Z**, i.e.
+across the whole of waves 28 and 29. That is a real and useful integrity statement.
+
+**NOT PROVED, and named as such by the artifact itself rather than left to a reader:**
+
+```
+roots in the AFTER sweep with NO baseline in this run (NOT claimed preserved):
+    /mnt/d/hf_w25/after
+    /mnt/d/hf_w25/before
+    /mnt/d/hf_w25/exe
+    /mnt/d/hf_w28/nc
+```
+
+**`/mnt/d/hf_w25/after` is the population `RULE W29-R` read, and `/mnt/d/hf_w28/nc` is the published baseline
+`L-0` scored against.** Neither has an earlier fingerprint in this run. The wave cannot claim they were
+unmodified; it can only claim that its own instruments opened them read-only, that `L-0` reproduced its
+published block field-for-field (which is itself strong indirect evidence that `/mnt/d/hf_w28/nc` is intact),
+and that the `/mnt/d/hf_w25/exe` dll sha256 matched `binary_provenance_w25.txt` before the arm's first cell.
+**`W29-FP` is not `PRESERVED`, because the rule it was written for could not be evaluated. It is recorded as
+what it is.**
+
+---
+
+## §6 — INSTRUMENT DEFECTS FOUND IN PREVIOUS WAVES' CHECKERS — report, do not repair
+
+### 6.1 `historical_ranges` was STILL broken after wave 27 fixed it and wave 28 carried it forward — the THIRD generation
+
+[F87](followups.md) is the record of this function eating its own file. Wave 27 repaired it; wave 28's design
+§12 required the repair be carried forward and demonstrated, and wave 28's self-test clause `[6]` did
+demonstrate it. **It was still broken, in a way clause `[6]` cannot see.**
+
+Wave 28's function counts brackets on the **raw** line:
+
+```python
+opens = sum(line.count(c) for c in "[{(") - sum(line.count(c) for c in "]})")
+```
+
+An unbalanced `[` or `{` **inside a string literal** therefore opens a phantom block, and the depth never
+returns to zero. Running wave 28's own function over wave 28's own file (599 lines) — measured, at analysis
+time:
+
+```
+ranges computed by WAVE 28's own function: [(93, 120), (557, 565), (579, 598)]
+  range 579 -> 598   opener line:     defonly = ['HISTORICAL_BLOCKS = ("PRIOR_BUILD_IDS", "ALLOW = [")',   # V28-OK: ...
+   *** RUNS TO EOF ***
+```
+
+The opener at line 579 is a **test fixture string** containing the literal text `"ALLOW = ["`. The raw count
+sees one unmatched `[`; the block runs to end of file. **Lines 579–598 of wave 28's own checker were exempt
+from `V28-B` and `V28-C` for the whole of wave 28**, plus 557–565 by the same mechanism — 29 of 599 lines, and
+the exempt span includes the file's tail.
+
+**Whether it hid a live drift in wave 28: it did not, and that is luck rather than design.** Wave 29's probe
+over `/mnt/d/hf_w28` reports lines 553, 558, 580 and 597, and every token in that span is **wave 28's own wave
+id**, not a foreign residue. The finding is the defect, not a concealed drift.
+
+**Wave 29's repair** blanks string literals length-preservingly before counting (`code_of`, `verify_derivation_w29.py:224`;
+`historical_ranges`, `:229–238`), keeps `is_definition`, and keeps the `opens > 0` requirement. Its self-test
+clause `[6]` now asserts all four ends, including *"a token INSIDE the declared historical literal is NOT
+reported — the exemption survives the repair, which is the half a bare 'it reports findings now' would miss."*
+
+**The register entry that matters is not the fix. It is that this function has now failed three times, each
+time with a passing self-test, because each generation's self-test tested the ends the previous generation
+broke.**
+
+### 6.2 `V28-C`'s population was effectively EMPTY on every wave-28 scorer — measured
+
+`V29-C` / `V28-C` is *"typed ordinals or counts in printed output"*. The clause finds a printing line with this
+regex. Wave 28's:
+
+```python
+PRINTS = re.compile(r"\b(print|log|echo|printf|Prog|tee)\b")
+```
+
+Wave 28's three scorers emit through `out.write(`, which matches none of those tokens. Measured over
+`score_w28b.py`, `score_w28n.py`, `score_w28s.py`:
+
+```
+out.write( lines total : 126        (36 + 52 + 38)
+matched by w28 PRINTS  : 2
+matched by w29 PRINTS  : 126
+```
+
+**124 of 126 printing lines in wave 28's three scorers were never scanned for a typed ordinal.** The two that
+did match matched incidentally — the *string being written* happened to contain one of the keywords. **Wave
+28's `V28-C: 0` was vacuous**: the clause returned zero because its population was almost empty, not because
+the scorers were clean.
+
+Wave 29's regex is widened to reach the method-call form:
+
+```python
+PRINTS = re.compile(r"\b(?:\w*[._])?(?:printf|print|echo|log|write|emit|say|tee|Prog)\b")
+```
+
+and the widening is **demonstrated**, not asserted — self-test clause `[3]` carries
+*"ok: V29-C via out.write fired on its own mutant"* and *"ok: V29-C via an underscored helper fired on its own
+mutant"*. On the wave-29 root, `V29-C: 0` over 7 files with the population now real.
+
+**This is the same shape as §6.1 and it should be read as one finding in two places: a clause can pass for
+three waves because its population is empty, and nothing in the verdict tree distinguishes "zero findings" from
+"zero candidates".**
+
+### 6.3 The per-clause fixture expiry REPEATED EXACTLY AS PREDICTED — the strongest evidence class this series has
+
+Wave 28 pinned `/mnt/d/hf_w27` as its live `-B` fixture and wrote into its own instrument's header that such a
+pin **goes silent exactly one wave later**, because `PREV` moves. Wave 29's plan §1a therefore forbade
+inheriting the choice and required measuring it. The four probes, run 17:20:58–17:21:32Z:
+
+| root | `V29-A` | `V29-B` | `V29-C` | role at wave 29 |
+|---|---|---|---|---|
+| `/mnt/d/hf_w24` | 1 of 1 | **0** | **2** | the durable **`-C`** fixture, third wave running |
+| `/mnt/d/hf_w26` | 2 of 6 | **0** | 1 | expired at wave 28, **still asserted silent** |
+| `/mnt/d/hf_w27` | 1 of 5 | **0** | 1 | **EXPIRED — wave 28's live `-B` fixture, now silent** |
+| `/mnt/d/hf_w28` | 0 of 5 | **100** | 1 | the new live **`-B`** fixture |
+
+Self-test `[5b]` records all four, including *"ok: `/mnt/d/hf_w27` yields ZERO `V29-B` findings — THE EXPIRY IS
+DEMONSTRATED, which is why the `-B` fixture is pinned separately and re-measured every wave."*
+
+**Why this is the strongest evidence class available here.** It is a **prediction written into an instrument's
+own header one wave before the measurement**, with a stated mechanism (`PREV` advances, so last wave's tokens
+stop being "previous-wave"), and it was confirmed by a measurement designed before the answer was known.
+Everything else in this series is a rule scored against artifacts that already existed. This is the one place
+where the series made a falsifiable forward claim about its own instruments and then checked it. **`hf_w27`
+went from 100-class `-B` findings to zero in exactly one wave, as written.** Wave 30 must re-measure again;
+`/mnt/d/hf_w28` will be the next to expire.
+
+---
+
+## §7 — A BLINDNESS BURN, caused by the instrument, recorded as a wave-29 deviation
+
+Design §7's ledger says, verbatim: *"`halfWidth`, `bootstrap.offsetSteps` and `bootstrap.stepSize` have been
+read on `D01` only (published), and the requested-vs-implied comparison has **never** been computed on any
+other cell."*
+
+**That claim is now false, and wave 29 made it false.** While validating `RULE W29-R`'s identity, the
+instrument agent computed the requested-vs-implied comparison on **all 18 addressable cells, including the 15
+blind ones**, and `w29r_score.txt` prints all 18 rows in full — `halfWidth`, implied span, requested span and
+the qualification for every cell from `D01` to `D20`.
+
+**The rule was NOT tuned.** `W29-R` was implemented exactly as design §5.3 writes it: `c` over 18, `c_blind`
+over 15, the verdict taken on `c ≥ 2` as wave 26 wrote it, both printed so no reader has to do the arithmetic.
+The burn is not a change to the statistic — it is that **computing the statistic and publishing the per-cell
+table are the same act**, and design §7 wrote a blindness claim that the design's own §5.3 instrument was
+guaranteed to violate.
+
+**Scope of the burn, stated for whoever inherits it.** The 15 blind cells' per-round `halfWidth`,
+`bootstrap.offsetSteps`, `bootstrap.stepSize`, implied span and requested span are **now published**. Any
+future rule over `SearchSpan` persistence on `/mnt/d/hf_w25/after` has **no blind population left in this
+bank.** `W29-R`'s own verdict is unaffected — it was taken on the first computation of the statistic, which is
+what blindness protects — but it is the **last** verdict on this population that can claim it.
+
+**The structural lesson, and it belongs in the register:** a blindness ledger that promises a quantity will
+stay unread, while the same document pre-registers an instrument that must read it to produce its verdict, is
+internally inconsistent at pre-registration time. Nothing checked the ledger against the instruments.
+
+---
+
+## §8 — CONTROLLER DEVIATIONS
+
+**(i) The BEFORE fingerprint was never taken, and three measurements ran ahead of it.** The plan's Step 3
+places `W29-FP` BEFORE ahead of Steps 4–6. The controller ran `RULE W29-S` (17:36:08Z), `RULE W29-R`
+(17:36:19Z) and the whole `W29-L` arm (17:36:49–17:51:23Z) **first**, and only then swept
+(17:52:45 → 18:04:27Z). `fp_BEFORE.txt` does not exist.
+
+**What that costs, exactly.** `fp_AFTER.txt` is an integrity check with no wave-29 BEFORE. The two roots that
+overlap wave 28's sweep — `/mnt/d/hf_w25/table18` (440) and `/mnt/d/SyntheticAutofocusBank` (640) — do have a
+usable earlier baseline in wave 28's `fp_BEFORE.txt` (15:13:39Z), and across it **1 080 of 1 080 are
+byte-identical, 0 moved**. The other four roots — `/mnt/d/hf_w25/{after,before,exe}` and `/mnt/d/hf_w28/nc` —
+**have no baseline in this run at all**, and the cross-wave artifact names them rather than reporting them
+preserved. `W29-FP` did not reach `PRESERVED` and is not claimed to have. §5 states what is and is not proved.
+
+**(ii) The `--out` and `--rule` conventions in the plan's own command lines were wrong**, and the controller
+used the instrument headers' forms instead. The instance verifiable from artifacts: `fp_w29.sh`'s own header
+documents `bash fp_w29.sh before --out <file> [--rule W29-FP]` and `bash fp_w29.sh after --out <file>
+[--rule W29-FP]`, while the plan's Steps 3 and 8 write `bash /mnt/d/hf_w29/fp_w29.sh after` with no `--out` —
+against a standing constraint (design §12) that **`--out` is mandatory and every instrument refuses without
+it**. The plan's Step 1a probe loop likewise omits `--rule`, which the three scorers require and the verifier
+does not accept. **The plan's command lines were not checked against the instruments the plan itself
+commissioned.**
+
+**(iii) Steps 7 and 8's second half did not run.** [F83](followups.md)'s `P-D08` at `n = 3` (~2 m) has no
+artifact, against design §11's explicit *"an item under two minutes is never dropped"* and its citation of
+`RULE C19`. The closing `V29` has no artifact, against design §11's *"NOT cut, at any budget."* Neither is
+laundered as done; both are priced in §11.
+
+**(iv) No scorer `--self-test` capture is on disk.** The plan's Step 4 and Step 6 gates name
+`w29s_selftest.txt` and `w29l_selftest.txt`; the arm driver's and the verifier's self-tests **are** captured
+(`SELFTEST W29L-ARM 33 of 33`, `SELFTEST V29 27 of 27`), the three scorers' are not. Wave 28's §7.7 recorded
+the identical class of omission for `fp_w28.sh`. **Named, not assumed.**
+
+---
+
+## §9 — UNDER-SPECIFIED IN THE PLAN, per the instrument agent
+
+| the plan said | what was true |
+|---|---|
+| *"Five files under `/mnt/d/hf_w29/`"* (Step 1) | **Seven.** `V29` reports `files checked: 7` — `layout_w29.sh` (the shared layout function design §12 requires) and the split of the `W29-L` driver from its scorer were never counted |
+| edit `MinimumStarBoundingBoxSize` and `Sensitivity` (design §6, `StarDetectorParams` spellings) | The file the arm edits is `optimized_settings.json`, whose keys are **`MinStarBoundingBoxSize`** and **`BrightnessSensitivity`**. The arm's self-test `[4]` asserts the landed FROM values against the tree by those names, and `[6]` proves *"editing a field the file does not declare REFUSES rather than inventing it"* — so the mismatch was caught by an instrument rather than by the plan |
+| *"`Sensitivity` relaxed one notch"* (design §6, `L3`) | **"One notch" was undefined.** Read at run time from the product's own axis declaration — `OptimizerVariable.cs:168`, `Continuous(nameof(StarDetectorParams.Sensitivity), …, 1.0, …)` — giving `36.333 → 35.333`. That is a **2.75 %** relaxation, which is why `exclusive(Sensitivity)` is only **101** and is weak evidence for anything |
+| *"pins `--settings`"* (plan Step 6) | Pinned to **the file wave 28's own log records** — `C:\Users\ghili\AppData\Local\HocusFocusHarness\harness_settings.json`, sha256 `b7e81813…` — recorded in the manifest, because the plan named no file |
+| `binary_provenance_w25.txt` line `tree:` (plan Step 5) | **The `tree:` line holds a COMMIT.** `git cat-file -t 29665a62e4f8` returns `commit` (`29665a6 W25: floor the half-width when the sweep demonstrably never reached the band`). The assertion works, and the field name is wrong wherever it is quoted |
+| the `MaxDistortion` direction (design §6) | Not specified at all, and wrong — §3.1 |
+
+---
+
+## §10 — [F21](followups.md): estimate vs actual, per step, and the budget error
+
+| step | est | actual | note |
+|---|---|---|---|
+| 0 vessel + pre-registration | 10 m | — | two commits (`544f2b2`, `80e42c5`); `T0.txt` never written, so no in-band start stamp |
+| 1 write **all** instruments | 60 m | **~37 m** | first write `16:41:51Z` (`layout_w29.sh`), last `17:18:45Z` (`verify_derivation_w29.py`) |
+| 2 `RULE V29` pre-flight | 20 m | **~15 m** | probes `17:20:58Z` → verdict `17:35:55Z` |
+| 3 `W29-FP` BEFORE | 8 m | **NOT RUN** | and mispriced — see below |
+| 4 `RULE W29-S` | 25 m | **~13 s** at run time | zero compute; the cost was paid in Step 1 |
+| 5 `RULE W29-R` | 25 m | **~11 s** at run time | zero compute; likewise |
+| 6 `RULE W29-L` arm + scoring | 55 m / ~25 m compute | **15 m 32 s**, of which **14 m 34 s** compute | `17:36:41Z → 17:52:13Z`; arm 874 s against its own 900–1500 s band |
+| 7 `P-D08` at `n = 3` | 2 m | **NOT RUN** | §8 (iii) |
+| 8 fingerprint AFTER + closing `V29` | 12 m | **12 m 19 s for the AFTER half alone**; closing `V29` NOT RUN | `17:52:45Z → 18:05:04Z` |
+| 9 results | 75 m | this document | |
+
+**The budget error, and it is the one durable number here.** The six declared read-only roots measure
+**~41.8 GB** (`hf_w25/after` 17 G, `hf_w25/before` 15 G, `SyntheticAutofocusBank` 8.7 G, `hf_w28/nc` 889 M,
+`hf_w25/exe` 196 M, `hf_w25/table18` 14 M). The AFTER sweep hashed all 2 452 files in **11 m 42 s**
+(`17:52:45Z → 18:04:27Z`) — **~61 MB/s**. The plan priced **Step 3 at 8 m** (a sweep alone is 1.5× that) and
+**Step 8 at 12 m** to cover a second sweep *plus* the reversal check *plus* the closing `V29` (the sweep alone
+consumed it, and the closing run is why Step 8 is ~2× under). **Steps 3 and 8 are both under-priced by ~1.5–2×,
+and the omission in §8 (iii) is downstream of the mispricing, not independent of it.** A wave declaring these
+six roots owes **~24 m of pure I/O** for a two-sided fingerprint and should price it from the measured
+61 MB/s, not from instinct.
+
+Design §11 predicted the analysis halves would again come in under (wave 28 ~59 % under, wave 27 ~36 %). They
+did — Steps 1, 2, 4, 5 and 6 all landed under. **The compute step priced from a measured rate (Step 6) was the
+most accurate one in the wave**, and the two steps priced from instinct (3 and 8) were the only ones that
+overran. That is the fourth consecutive confirmation of the same lesson and it is now boring: *price compute
+from the measured rate.*
+
+---
+
+## §11 — WHAT WAS NOT RUN, AND WHAT IT COSTS
+
+| not run | price | why, and is it owed |
+|---|---|---|
+| **the 42 m `optimize` gate** | **42 m** measured (wave 25: 42 m 43 s, ~5.2 m/run, seven consecutive waves); predicted verdict `G-PASS`, 8 of 8 bit-identical to K8 | **NOT OWED this wave, and it is checked rather than asserted.** `git diff --name-only 6ffa498..HEAD -- '*.cs'` is **empty** — wave 29's two commits touch `docs/…wave29-design.md` and `plans/…wave29-plan.md` and nothing else — and no binary was built: the arm ran `/mnt/d/hf_w25/exe`, dll sha256 `2fb0c8fd…` asserted against `binary_provenance_w25.txt` before its first cell. **All three of design §8's reversal conditions are negative.** **It is owed, certainly and not probably, by the wave that ships any F82 fix** — `Q27-V1`'s own FAIL end names `StepSizeRecommender.cs` by path |
+| **a wave-29 BEFORE fingerprint** | **~12 m** (measured: 11 m 42 s at 61 MB/s over 41.8 GB) | Owed by the plan and not taken (§8 (i)). Cannot be recovered retroactively — a BEFORE taken now is an AFTER. **The next wave must take it first, or declare fewer roots** |
+| **the closing `V29`** | **~2 m** | Owed by design §11's *"NOT cut, at any budget"*. F95's remedy is half-executed (§4) |
+| **`P-D08` at `n = 3`** | **~2 m** | Owed by charter §4 and design §11's cut-list, which explicitly refused to cut it |
+| **the three scorers' self-test captures** | **~5 m** | The gates the plan wrote for Steps 4/5/6 (§8 (iv)) |
+| **localising `D01`** | **~25 m** compute for a corrected 3-cell arm (`MaxDistortion` **lowered**, plus the two gates §3.2 identifies), on the binary already on disk | **The wave's largest open question and it is still open.** Two candidate gates now excluded to within 0.2 %; the third was never opened; §3.2 names `TooDistorted` + `LowSensitivity` as where the released candidates go |
+| the unit suite | ~4 m | **Vacuously satisfied** — no C# changed. Baseline for the wave that does change it is **3997** (wave 28's measured close), not the charter's stale 3973 |
+| a full paired 18-cell S1 arm | ~2 h 40 m | Unchanged: `W-UNEXERCISED` means a second arm buys a second `SAME 13` |
+| `S27-1` and wave 27's three mutants | ~20 m | **STILL OPEN, THREE waves running.** Named again so it is not lost a fourth time |
+| wave 28's `M1`–`M6` mutant records | ~10 m | Not applicable — wave 29 ships nothing and writes no test. Wave 28's debt stays wave 28's |
+| new datasets between 1.4 and 19.4 ″/px | ≥ 1 h render | The only route to a **blind** wide-field dataset; the coverage hole is unchanged, and §7 has now spent the blindness that existed |
+| the blur/layer decoupling build ([F92](followups.md)) | ~45 m + 10 m (+ 42 m to ship) | Unchanged |
+| the `A4` truth-model gap | 20 m code **+ 42 m gate** | And §1 has now made it **more** urgent, not less: `S-a` shows the harness's own bar is produced by the code under test |
+| anything on real frames | — | The bank has no real under-sampled dataset |
+
+---
+
+## §12 — REGISTER ENTRIES, READY TO PASTE
+
+The register's highest existing entry is **F95**. These continue from it.
+
+---
+
+### F96 — The harness's `stepBehavioral` "truth" is a fixed point of the recommender it scores, so every goal-2 conclusion is denominated in a bar the code under test produces
+
+**Status:** Open (diagnosed to a line; no fix priced) · found 2026-08-13, wave 29, `RULE W29-S` clause `S-a`
+= HOLDS · `/mnt/d/hf_w29/w29s_score.txt`
+
+`SynthValidateRunner.ComputeStepBehavioral` (`:1213–1270`) builds an analytic curve, fits it, calls
+`StepSizeRecommender.Recommend` at **`:1262`**, and loops until `rec.StepSize == step`. `RULE W29-S` asserts
+from source, at `HEAD`, by sha256, that the method is **declared once**, contains **exactly one** `Recommend(`
+call site inside its body (whole-file count 2, at `:792` and `:1262`, printed so the scoping is visibly doing
+work), and is the **only writer** over 70 harness files of the value serialized as `terminal.stepBehavioral`.
+
+**Consequence.** A change to `Recommend` moves the bar **and** the measurement together. This is the mechanism
+behind [F82](#f82)'s observation that `stepBehavioral` moved 8.0 → 9.0 across wave 25's two arms while it was
+identical on the other 17 cells: wave 25 changed `Recommend`. **Assertion `A3`, and every goal-2 statement in
+waves 20–29 that quotes `stepBehavioral` as truth, is a self-consistency check and not an accuracy measurement.**
+
+**What it does NOT say.** It does not say the recommender is wrong; a fixed point can be correct. It says the
+harness cannot tell. **The remedy is a spec-derived truth model** — backlog item 4's `A4` gap, priced at 20 m
+of code **+ 42 m of gate** because it rebuilds `TestApp`.
+
+**Note on scope.** Design §14 pre-registered F96 as a two-part entry — the truth-model coupling **and** "F82's
+fix has no product carrier" — to be **withdrawn in place** on `S-CARRIER-EXISTS`. The verdict was
+`S-CARRIER-EXISTS`, so **the carrier half is withdrawn and is not registered.** The coupling half is `S-a`,
+which held, and stands.
+
+---
+
+### F97 — F82's shrink-while-widening transition occurs on exactly ONE cell in the bank, and on ZERO of the fifteen that were blind
+
+**Status:** Open (measured; F82's fix choice unchanged) · found 2026-08-13, wave 29, `RULE W29-R` =
+**`R-STANDS`** · `/mnt/d/hf_w29/w29r_score.txt`
+
+Wave 26 pre-registered a reversal condition on its choice between F82's two fixes — *"if a later wave measures
+that `SearchSpan` … shrinks on more than a single cell while the requested sweep widens, then … (2) becomes
+correct."* **Three waves quoted it; none ran it.** Wave 29 ran it at zero compute over the 18 addressable
+paired S1 cells under `/mnt/d/hf_w25/after`, via the exact inversion
+`impliedSearchSpan = stepRecommendation.halfWidth / (1.5 × 0.5)`, with the multiple asserted `= 1.5` at **both**
+the B15 tree `29665a62e4f8` and `HEAD`, and with all 37 rounds confirmed capped-or-floored and none
+detect-bounded before any statistic was taken.
+
+```
+k = 18   c = 1   c_blind = 0   qualifying cells: ['D01_ultrawide_40mm']
+```
+
+**`c = 1`, and the one cell is `D01`, which was already burned.** `D05_tec140_1000mm` and
+`D19_cygnus_deep_shed` produced no report and **left the denominator** as named `CNL-NOREPORT`, never as zeros.
+
+**What this changes.** F82 is real and (per [F98's sibling finding in `RULE W29-S`](#f96)) reaches a real
+product path — but it is **rare, not general**: one cell in eighteen, zero in fifteen blind. On all 17 other
+cells the implied and requested spans move together on every transition. **Anyone pricing a fix should price it
+against 1 of 18, not against the 37-of-37 capped-or-floored population.** Wave 26's choice of fix (1) stands on
+wave 26's own grounds; the reversal condition is now **evaluated** rather than merely unexamined.
+
+**Blindness spent.** Producing this verdict required publishing the per-cell table for all 18 cells, so the 15
+formerly-blind cells' `halfWidth`/`bootstrap`/implied-span values are now read. See F100.
+
+---
+
+### F98 — `MaxDistortion` is a MINIMUM fill-ratio despite its name, and 0.9 is above the ~0.79 ceiling of a perfect disk, so a whole arm cell was dead before it ran
+
+**Status:** Open — **candidate goal-3 product finding** · found 2026-08-13, wave 29, `RULE W29-L` =
+**`L-UNEVALUATED`** · `/mnt/d/hf_w29/w29l_score.txt`, `/mnt/d/hf_w29/l/out/L{0,2,4}.log`
+
+`StarDetector.cs:1804` rejects a candidate as `TooDistorted` when `fillRatio < effectiveMaxDistortion`. The
+parameter is a **lower bound on bounding-box fill ratio**; **raising it tightens the gate.** The file's own
+comment at `:1786` states the ceiling: *"a perfect disk fills ~PI/4 ≈ 0.79."* With `DefocusAwareGates: false`
+in `D01`'s landed tree, `ComputeEffectiveMaxDistortion` returns `p.MaxDistortion` verbatim.
+
+Wave 29's design §6 pre-registered `MaxDistortion` **0.5 → 0.9** under the heading *"one knob relaxed per
+cell"*. Measured result on `D01`, 9 frames: **`TP=0 FP=0 FN=110384`, `recall@high = 0.000 (0/62 411)`** on
+both `L2` and `L4` — total detection collapse. Corroborated by wall clock: `L2` (152 s) and `L4` (145 s) were
+the two **fastest** cells in a five-cell arm, because nothing survived the gate to do downstream work.
+
+**Two findings, and they are separable.**
+
+1. **The instrument finding.** A pre-registration can specify a knob edit whose *direction* no clause reads.
+   The arm's self-test proved the edit was **surgical** (`33 of 33`, *"exactly 1 file changed"*, *"an unnamed
+   field is UNCHANGED"*) — surgical is not correctly signed. `RULE W29-L`'s verdict is
+   **`L-UNEVALUATED`** and it stands; the cell was not re-run at a corrected value and scored.
+2. **The product finding.** `OptimizerVariable.cs:176` declares the searchable axis
+   `Continuous(nameof(StarDetectorParams.MaxDistortion), 0.1, 1.0, 0.1)`. **The upper ~21 % of that axis
+   (> π/4 ≈ 0.785) is provably detection-killing for round stars** — any value above the perfect-disk fill
+   ratio rejects every candidate. A searchable range whose top fifth returns zero detections is a parameter
+   space that wastes optimizer evaluations, and the name `MaxDistortion` reads as the opposite of what it
+   gates. **Worth ~20 m to bound the axis at π/4 and rename or document the field; owes the 42 m gate because
+   it touches plugin code.**
+
+---
+
+### F99 — Relaxing the bounding-box floor on `D01` releases 9 537 candidates and three survive: the binding gates are downstream, and the pre-registered statistic could not see it
+
+**Status:** Open — the hypothesis wave 30 should pre-register · found 2026-08-13, wave 29 ·
+`/mnt/d/hf_w29/l/out/L{0,1}/attempt01/golden_eval.txt`
+
+`RULE W29-L`'s pre-registered statistic is the difference in `FN_total`. On `D01`, lowering
+`MinStarBoundingBoxSize` 6 → 3 gives `FN_total` 50 249 → 50 246, i.e. **−3**, which reads as "this gate does
+almost nothing". The per-gate blocks in the same artifact say otherwise:
+
+| gate | `L0` | `L1` (MinBox 6→3) | Δ |
+|---|---|---|---|
+| `REJECTED:TooSmall` | 11 372 | 1 835 | **−9 537** |
+| `REJECTED:TooDistorted` | 14 876 | 20 573 | **+5 697** |
+| `REJECTED:LowSensitivity` | 13 612 | 17 426 | **+3 814** |
+| others | | | +23 |
+
+**9 537 high-tier candidates were released from the bounding-box floor and 99.97 % of them were immediately
+re-caught by `TooDistorted` and `LowSensitivity`. Three reached acceptance.** The gate is not inert; its entire
+yield is absorbed one and two gates downstream.
+
+**The lesson is about the statistic, not the detector.** A first-rejection-wins attribution differenced only at
+the *total* cannot distinguish a gate that never fires from a gate whose output is fully captured downstream.
+**Wave 30's rule over sequential gates must read the per-gate flow, not the net.** And the substantive
+hypothesis this generates, stated so it can be wrong: **`D01`'s binding constraint is `TooDistorted`, jointly
+with `LowSensitivity`, and no single-knob change recovers it** — which is `L-JOINTLY-BOUND`'s claim arrived at
+by a different route than the rule that could not evaluate it.
+
+---
+
+### F100 — A blindness ledger that promises a quantity will stay unread, beside an instrument that must read it, burns the population at pre-registration time
+
+**Status:** Recorded (the burn is spent; the structural fix is cheap) · found 2026-08-13, wave 29 ·
+design §7 vs `/mnt/d/hf_w29/w29r_score.txt`
+
+Wave 29's design §7 wrote: *"the requested-vs-implied comparison has **never** been computed on any other
+cell"*, and named the 15 non-burned cells as **BLIND, and carrying `W29-R`'s verdict**. The same document's
+§5.3 pre-registered a scorer that computes exactly that comparison over all 18 addressable cells and prints
+`c` and `c_blind`. **`w29r_score.txt` publishes the full 18-row table.** The ledger's claim is now false, and
+the instrument that falsified it was commissioned by the document that made the claim.
+
+**The rule was not tuned** — `W29-R` is implemented exactly as §5.3 writes it, and its verdict was taken on the
+first computation of the statistic, which is what blindness protects. **But it is the last verdict on this
+population that can claim blindness.** Any future rule over `SearchSpan` persistence on `/mnt/d/hf_w25/after`
+has no blind cells left.
+
+**Fix, ~5 m per wave:** the design's blindness ledger must be checked against the design's own instrument
+specifications before the pre-registration commit — every quantity the ledger promises stays unread must not
+appear in any clause's per-member output. Nothing does this today.
+
+---
+
+### F101 — The derivation checker's `historical_ranges` has now failed THREE generations, each time with a passing self-test
+
+**Status:** Repaired in wave 29's checker; the pattern is the entry · found 2026-08-13, wave 29 ·
+`/mnt/d/hf_w28/verify_derivation_w28.py:579`, `/mnt/d/hf_w29/verify_derivation_w29.py:224–238`
+
+[F87](followups.md) recorded this function eating its own file; wave 27 repaired it; wave 28's design required
+the repair be carried forward and demonstrated, and wave 28's self-test clause `[6]` did demonstrate both ends
+it knew about. **It was still broken.** Wave 28 counted brackets on the **raw** line, so an unbalanced `[` or
+`{` inside a **string literal** opened a phantom block that ran to EOF. Measured on wave 28's own 599-line
+file:
+
+```
+ranges computed by WAVE 28's own function: [(93, 120), (557, 565), (579, 598)]
+  range 579 -> 598   opener: defonly = ['HISTORICAL_BLOCKS = ("PRIOR_BUILD_IDS", "ALLOW = [")',  ...
+   *** RUNS TO EOF ***
+```
+
+**29 of 599 lines of wave 28's own checker, including its tail, were exempt from `V28-B` and `V28-C` for the
+whole of wave 28.** It concealed nothing — every token in the exempt span is wave 28's own wave id — and that
+is luck, not design. Wave 29 blanks string literals length-preservingly before counting and asserts all four
+ends in clause `[6]`, including *"a token INSIDE the declared historical literal is NOT reported"*.
+
+**The durable finding is the pattern:** three generations, three passing self-tests, because each generation's
+self-test tested the ends the previous generation broke. **A self-test that only covers the last bug found is a
+regression test, not a specification.**
+
+---
+
+### F102 — `V28-C` returned zero because its population was almost empty: 124 of 126 printing lines in wave 28's scorers were never scanned
+
+**Status:** Repaired in wave 29's checker; the vacuity class is the entry · found 2026-08-13, wave 29 ·
+`/mnt/d/hf_w28/verify_derivation_w28.py:170`, `/mnt/d/hf_w29/verify_derivation_w29.py:160`
+
+`V*-C` forbids typed ordinals and counts in an instrument's printed output. Wave 28's line-selector was
+`\b(print|log|echo|printf|Prog|tee)\b`; wave 28's three scorers emit through `out.write(`, which matches none
+of it. Measured over `score_w28b.py` (36), `score_w28n.py` (52), `score_w28s.py` (38):
+
+```
+out.write( lines total : 126
+matched by w28 PRINTS  : 2      (incidentally -- the string being WRITTEN contained a keyword)
+matched by w29 PRINTS  : 126
+```
+
+**Wave 28's `V28-C: 0` was vacuous.** Wave 29 widened the selector to
+`\b(?:\w*[._])?(?:printf|print|echo|log|write|emit|say|tee|Prog)\b` and **demonstrated** the widening rather
+than asserting it — self-test `[3]` carries *"V29-C via `out.write` fired on its own mutant"* and *"V29-C via
+an underscored helper fired on its own mutant"*.
+
+**The class, which is the same as F101's and should be read with it:** a clause can pass for three waves
+because it has no candidates, and **no verdict tree in this series distinguishes "zero findings" from "zero
+candidates".** [F94](followups.md) made trees total over their *outcomes*; nothing makes a clause report its
+*population*. **~10 m to make every clause print `candidates: N   findings: M` and refuse on `N = 0` where a
+population is expected.**
+
+---
+
+### F103 — A pinned per-clause fixture goes silent exactly one wave later, as predicted in an instrument's own header and confirmed by measurement
+
+**Status:** Closed as a mechanism; standing obligation to re-measure each wave · found 2026-08-13, wave 29 ·
+`/mnt/d/hf_w29/vdrift_selftest_w29.txt` `[5b]`, `vdrift_probe_hf_w2{4,6,7,8}.txt`
+
+Wave 28 pinned `/mnt/d/hf_w27` as its live `V28-B` fixture and wrote into its own instrument's header that such
+a pin expires one wave later, because `PREV` advances and last wave's tokens stop being "previous-wave". Wave
+29 measured all four candidate roots before pinning anything:
+
+| root | `-A` resolving | `-B` findings | `-C` findings | role |
+|---|---|---|---|---|
+| `hf_w24` | 1 of 1 | 0 | **2** | durable `-C` fixture, third wave running |
+| `hf_w26` | 2 of 6 | **0** | 1 | expired at wave 28; kept and **asserted silent** |
+| `hf_w27` | 1 of 5 | **0** | 1 | **EXPIRED as predicted** — wave 28's live `-B` |
+| `hf_w28` | 0 of 5 | **100** | 1 | the new live `-B` |
+
+**This is the strongest evidence class this series has produced**, and the reason is structural: it is a
+**falsifiable forward claim about the instruments, written before the measurement, with a stated mechanism, and
+checked one wave later.** Everything else in the series is a rule scored against artifacts that already
+existed. **`hf_w28` is next to expire; wave 30 must re-measure and must treat a clause with no live fixture as
+a FAIL, not a pass.**
+
+---
+
+### AMENDMENTS TO EXISTING ENTRIES
+
+**[F82](followups.md) — AMEND IN PLACE. Its fix choice stands; its scope, its generality and its truth
+model are now measured.** Append:
+
+> **Amended 2026-08-13, wave 29.** Three things about this entry were unmeasured when it was written.
+>
+> 1. **The "truth of 9" is a PRODUCT-DERIVED FIXED POINT, not a spec-derived truth.** `terminal.stepBehavioral`
+>    is `StepSizeRecommender.Recommend` iterated to a fixed point by
+>    `SynthValidateRunner.ComputeStepBehavioral:1262` — see **F96**. `D01`'s stall is measured against a bar the
+>    recommender itself produces, and wave 25 moved both together.
+> 2. **"Confined to the recommender's caller state" names a caller, and it is
+>    `StarDetectionOptimizerWizardVM.CaptureNewSweepAsync` (`:5012`).** `RULE W29-S` clause `S-b` returned
+>    **FALSE**: of `BuildSummaryAsync`'s five callers, `CaptureNewSweepAsync` takes a **fresh sweep**
+>    (`RunLiveAttemptAsync`, `:5071`), calls `BuildSummaryAsync` at `:5098`, and carries the previous round's
+>    recommended geometry forward through the instance field `recaptureStepSize` (`:2608`, assigned `:5037`,
+>    consumed `:3236`). **F82 is a real product defect on a real product path**, and the wave-29
+>    pre-registration's claim that it "reaches no user" and "scores goal 2 zero" is **withdrawn**.
+> 3. **Its generality is one cell in eighteen.** `RULE W29-R` = `R-STANDS`: `k = 18`, `c = 1`, `c_blind = 0`.
+>    The only qualifying cell is `D01` itself. See **F97**. Wave 26's choice of fix (1) stands, on wave 26's
+>    own grounds, with the escape clause now **evaluated** rather than unexamined.
+> 4. **A third candidate fix is registered and deliberately NOT chosen** (wave 29 design §4.4): bound
+>    `maxHalfWidth` below by the span the sweep actually **requested**, guarded by
+>    `BandDemonstrablyUnsampled(sampledHfrRange)`. `RULE W29-S` clause `S-c` **HOLDS** — the requested positions
+>    are in `SweepDetectability.FrameFocuserPositions`, reachable inside `Recommend` via
+>    `MeasureMaxUsefulHalfSpan`. It needs **no cross-round state and no `A3` re-derivation**, which makes it the
+>    cheapest of the three (~45 m + a 3-cell re-run + the 42 m gate) and is precisely why the wave that thought
+>    of it did not select it. **The next wave pre-registers the choice among three.**
+
+**[F81](followups.md)** — append: the floor F81 shipped **is** reached in the product on a re-swept round, not
+only at round 0 of a session. `CaptureNewSweepAsync` (`:5012`) re-captures and carries `recaptureStepSize`
+forward, so the wizard's `Capture new sweep` path has genuine cross-round sweep state. The `Continue` and
+`Re-optimize` paths do not — they call `LoadRunStampedAsync` and re-optimize already-captured frames — so on
+those two the floor is inert after round 0, and that half of the original claim stands.
+
+**[F94](followups.md)** — append: wave 29's design §10 is the first in the series to publish its own outcome
+space as a table, and **every scorer re-derived it in code and agreed with the published counts**: `W29-S`
+**8 / 0 uncovered**, `W29-R` **4 / 0**, `W29-L` **8 / 0** — matching design §10's three tables exactly — and
+`V29`, which §10 declared as inheriting wave 28's tree without a count, re-derived **12 / 0** including the
+`A=None` empty-population region. The two logically-unreachable regions (`R-INCOHERENT`, `L-INCOHERENT`) are
+present, asserted empty, and checked against the measured numbers (`c = 1 ≤ k = 18 is True`; `L-1 ∧ L-2 =
+False`). **The remedy works for outcome coverage.** It does **not** cover two adjacent failures found this wave: a clause whose *population* is
+empty (**F102**) and a clause whose realized value is **neither `True` nor `False`** — `W29-L` ended at
+`L-0 = True, L-1 = None, L-2 = None`, a state outside the enumerated boolean cube, yet the scorer still printed
+`uncovered: 0` and appended a canned `READING:` line saying *"the control did not hold"* **when `L-0` in fact
+HELD**. The tree was total over booleans and the run was not a boolean. **Trees must enumerate `None` as a
+clause value, and a verdict's explanatory text must be derived from the clause values rather than templated per
+verdict name.**
+
+**[F95](followups.md)** — append: **the remedy's first half works and was proved this wave.** Wave 29's plan
+ordered instruments (Step 1) before the blocking pre-flight (Step 2); the last instrument was written at
+`17:01:28Z`, the pre-flight ran at `17:35:55Z` over a **populated root of 7 files**, and returned `V-CLEAN`
+with `SELFTEST V29 27 of 27`. Wave 28's equivalent certified **one file**. **The second half did not run** —
+the closing `V29` (`vdrift_w29_FINAL.txt`) has no artifact, against design §11's *"NOT cut, at any budget."*
+Both halves are needed and the series has now demonstrated one of them.
+
+**[F21](followups.md)** — append wave 29's per-step estimate vs actual (§10). Steps 1, 2, 4, 5 and 6 all landed
+**under**; the only two that overran were the two priced from instinct rather than from a measured rate
+(fingerprint sweeps, §10). Measured constant for future waves: **the six declared read-only roots are ~41.8 GB
+/ 2 452 files and hash at ~61 MB/s, i.e. ~12 m per sweep, ~24 m for a two-sided fingerprint.**
+
+**`docs/synthetic-af-bank-results-table.md`** — still owed from wave 28: the `K` column from `truthModel`
+(`max(hfrMin, hfrMinEffective)`), the note that `D01`/`D02`/`D03` are the only three floored by the generator,
+and **no 2–4 px band claim below the band** (`W28-B` = `B-SPLIT`). **Not paid this wave.** ~10 m.
+
+---
+
+## §13 — WAVE 30, priced and goal-scored
+
+| # | item | price | compute | goals | why |
+|---|---|---|---|---|---|
+| **1** | **Pay wave 29's four small debts**: the closing `V29`, `P-D08` at `n = 3`, the three scorer self-test captures, and the results-table `K` column | **~20 m** | ~2 m | instrument, **3** ✓ | All four were owed, all four are cheap, and two of them (`P-D08`, the closing `V29`) were explicitly refused-to-cut by the design that then cut them. **Starting a wave by paying the previous wave's named debts is the only thing that stops the list growing** |
+| **2** | **`D01` localised properly** — a 4-cell arm on the binary already on disk, with `MaxDistortion` **lowered** (0.5 → 0.3, 0.2), and a rule whose statistic is the **per-gate flow** (F99), not `FN_total` | **~50 m** | **~13 m** | **3** ✓✓ | The wave's largest open question, now with a corrected direction (F98) and a stated hypothesis that can be wrong (F99: `TooDistorted` + `LowSensitivity` bind jointly). `MinStarBoundingBoxSize` landed at **6** against a shipped default of **5** on the rig with the smallest stars — goal 3 verbatim |
+| **3** | **Choose among F82's three fixes, pre-registered before reading**, and price the winner | **~40 m** | — | **2** ✓✓ | `RULE W29-S` and `W29-R` have delivered everything a choice needs: the carrier exists (`S-b` FALSE), the reversal condition is evaluated (`c = 1`), and `S-c` holds so candidate (3) is live. **The `RULE D20` fence forbade choosing in the wave that proposed (3); it does not forbid the next one.** Ship price is separate: fix (3) ~45 m + 3-cell re-run + **42 m gate** |
+| **4** | **`MaxDistortion`'s axis and name** (F98 part 2) | ~20 m + **42 m gate** | — | **3** ✓✓ | The top ~21 % of a searchable axis returns zero detections for round stars. Touches plugin code, so the gate is owed — predict `G-PASS`, 8 of 8 bit-identical |
+| **5** | **Clause populations** (F102) — every clause prints `candidates: N   findings: M` and refuses on an unexpected `N = 0`; and trees enumerate `None` (F94 append) | ~25 m | — | instrument | Two waves of vacuous clauses (F101, F102) and one verdict that landed outside its own tree. **This is the cheapest structural fix on the list** |
+| **6** | `S27-1` and wave 27's three mutants | ~20 m | — | instrument | **Open three waves running.** Cut again and it should be formally withdrawn rather than re-listed a fifth time |
+
+**Recommended wave 30 = items 1, 2 and 5** — ~1 h 35 m, ~15 m compute, no C# and therefore no gate. Item 3 is
+the natural wave 31 and should be its own pre-registration; item 4 is a genuine ship and owes the 42 m gate.
+
+**Run hard stop: `2026-08-14T00:45:17Z`.**
+
+### Is the register thinning? Yes, and it should be said
+
+**Of the eight entries this wave produces, five are about the instruments and three are about the product** —
+and of those three, one (**F97**) is a *reduction* in an existing finding's scope, one (**F98** part 2) is a
+20-minute parameter-range fix, and one (**F96**) says the series' own measuring stick is self-referential.
+**Wave 29 found no new product defect.** It found that a known one is rarer than believed, that its fix does
+reach a user after all, and that three of the checkers have been passing vacuously.
+
+That is a real and useful wave, and it is also a pattern worth naming: **the marginal finding in this series is
+increasingly about the apparatus rather than about HocusFocus.** The bank's coverage hole (no real
+under-sampled dataset, [F35](followups.md)/[F43](followups.md)) is unchanged after ten waves, §7 has now spent
+the blindness that remained on `/mnt/d/hf_w25/after`, and `RULE W-UNEXERCISED` has twice shown that a full
+paired arm buys a second `SAME 13`.
+
+**The charter's stop condition is *"two consecutive waves producing no finding worth a register entry."* That
+condition is NOT met** — waves 28 and 29 both produced product findings (`B-SPLIT`/`N-RECOVERS`; F97/F98).
+**But the honest forward-looking statement is that items 2 and 4 above are the last two product questions this
+bank can answer without new data**, and once they are closed, the next wave that cannot name a product question
+should stop rather than audit its own instruments a fourth time.
+
+---
+
+## §14 — HANDOFF (design §11's cut 4: folded here rather than written separately)
+
+**Branch** `ghilios/synthetic-af-bank-followups-wave29`, **PR #197**, stacked on #196. Commits: `544f2b2`
+(pre-registration — **its message contains the false §1(b) claim and cannot be edited**), `80e42c5`
+(the CORRECTION), plus this results commit.
+
+**Read first, in this order:** the design's CORRECTION block (above its §1) · §1 and §2 of this document ·
+F96, F97, F82's amendment.
+
+**Do not repeat:** (a) taking the fingerprint after the measurements — it cost `W29-FP` its verdict on four of
+six roots; (b) pricing a sweep from instinct — the constant is ~61 MB/s, ~12 m per sweep; (c) writing a
+blindness ledger without checking it against your own instruments (F100); (d) inheriting a fixture pin
+(F103) — `hf_w28` is next to expire.
+
+**Standing:** never push `develop`; commit with `322725+ghilios@users.noreply.github.com` as author **and**
+committer; pass scorers WSL paths; `--out` mandatory; `--rule` asserted against the file's own declared name;
+one `TestApp.exe` at a time; no directory rebuilt mid-wave.

--- a/docs/synthetic-af-bank-followups-wave30-design.md
+++ b/docs/synthetic-af-bank-followups-wave30-design.md
@@ -1,0 +1,912 @@
+# Wave 30 — backlog item 2: which gate actually binds on `D01`, measured as a FLOW
+
+**Pre-registration. Written before any wave-30 statistic is computed.** §2 records where the controller's
+framing is wrong; there are seven such places and **four of them change what the wave does**. Two of them
+delete work the controller asked for, because it is already done.
+
+---
+
+## 0. THE VESSEL — decided in writing, before any measurement
+
+**Wave 30 opens a fresh branch `ghilios/synthetic-af-bank-followups-wave30` off
+`ghilios/synthetic-af-bank-followups-wave29` at `59e27ab`, and opens its own PR with
+`--base ghilios/synthetic-af-bank-followups-wave29`.**
+
+The base matters more than the branch, and this is a finding rather than a preference.
+
+**Measured at pre-registration time, `gh pr view`:**
+
+| PR | head | **base** | state |
+|---|---|---|---|
+| #196 | `ghilios/synthetic-af-bank-followups-wave27` | **`develop`** | OPEN |
+| #197 | `ghilios/synthetic-af-bank-followups-wave29` | **`develop`** | OPEN |
+
+**#197's base is `develop`, not #196's branch.** Wave 29's results §0 describes it as *"stacked on #196"*; in
+git it is not stacked at all. `gh pr view 197 --json files` returns **25 files**, and they include
+`TruthDisclosure.cs`, `GoldenEvalRunner.cs`, `DetectionBinningResolver.cs`, wave 27's design and results, wave
+28's design and results, and wave 29's — **#197's own diff carries waves 27, 28 and 29, plus wave 27's C# ship.**
+
+Wave 29's design §0 opened a fresh branch specifically so that *"#196 does not carry a third section"*, and it
+succeeded at that. **It did not stop the accretion; it moved it.** The mechanism that stops accretion is the
+PR **base**, and nobody set it. A fourth wave committed anywhere in this family with base `develop` produces a
+28-file diff spanning four waves.
+
+**So wave 30 sets `--base ghilios/synthetic-af-bank-followups-wave29`**, which makes its PR's diff **wave 30
+only**. That is the first PR in this family whose diff is one wave.
+
+**Not done, and named rather than done quietly:** re-targeting #197's base to `ghilios/…wave27` (and #196's to
+`develop`) would retroactively give both PRs one-wave diffs. It is a ~2 m `gh pr edit --base` on two PRs the
+owner may already be reading, and **wave 30 does not edit another wave's open PR.** It is recommended in §16
+and left to the owner.
+
+**PR #197's title has already been corrected** — it now reads *"Wave 29: F82 IS a product defect (its own rule
+refuted the pre-registration), and the step-size truth is a fixed point of the recommender"*. Wave 29's results
+§0 listed the correction as owed before merge; it is **paid**, verified by `gh pr view 197 --json title`, and
+wave 30 does not re-pay it.
+
+**Wave 30 changes no C# and builds no binary** (§10), so the vessel is not load-bearing for any verdict. It is
+load-bearing for whether this family's PRs can ever be reviewed one wave at a time.
+
+---
+
+## 1. THE PRODUCT QUESTION, in one sentence
+
+> **On `D01_ultrawide_40mm` — the bank's most under-sampled rig, where `MinStarBoundingBoxSize` landed at 6
+> against a shipped default of 5 — does opening the `TooDistorted` gate *in the correct direction*, alone and
+> jointly with `LowSensitivity`, deliver a material share of the 50 249 high-tier stars the detector misses, or
+> is everything those gates release re-captured downstream, so that no landed knob is pinned against the
+> physics in any recoverable way?**
+
+That is a **goal 3** question — *"appropriate exposure adjustments, no parameters pinned to extremes"* — and it
+is the question wave 29 §13 named as one of the last two this bank can answer without new data. It is not a
+recall question; §2.7 fences that.
+
+The wave has a product question. It does not recommend stopping. §17 says what would.
+
+---
+
+## 2. WHERE THE CONTROLLER'S FRAMING IS WRONG
+
+### 2.1 `P-D08` at `n = 3` is NOT owed. It was paid at 09:06Z, seven hours before wave 29 started
+
+The controller's item 1 lists *"`P-D08` at `n = 3`"* as one of wave 29's four named debts, citing wave 29's
+§8 (iii) — *"no artifact under the root"* — and §11's *"Owed by charter §4."*
+
+**It is done, it is published, and it was published before wave 29 opened its branch.**
+
+- `docs/synthetic-af-bank-followups-w26-pd08-followon.md` carries a section headed
+  **`# RESULT — P-D08 is REFUTED at n = 3`**, measured *"2026-08-13T09:06-09:08Z on B15"*, with both blind
+  sub-boundary landings (`D01_ultrawide_40mm` gate 0.2234, `D16_esprit550_ha3` gate 0.1969) at **base precision
+  1.000, `FP = 0`**, i.e. the confirming branch's requirement failed on both.
+- `git log -- docs/synthetic-af-bank-followups-w26-pd08-followon.md` dates the result commit `e42e2df` at
+  **2026-08-13 05:09:37 -0400 = 09:09:37Z**, after the pre-registration commit `c4fc0c2` at 09:06:02Z.
+- The artifacts are on disk: `/mnt/d/hf_w26/pd08/` holds `D01_ultrawide_40mm__{base,sens}` and
+  `D16_esprit550_ha3__{base,sens}`, four cells with their logs, plus `F31_truth_rescore.txt`.
+
+Wave 29's §8 (iii) is literally true — there is no `P-D08` artifact **under `/mnt/d/hf_w29/`** — and the
+inference drawn from it is false. **The debt was carried forward on a search of the wrong directory.**
+
+This is [F85](followups.md)'s class recurring — *a closed, shipped correction re-measured as an open defect* —
+and this time the gap between paying and re-listing is **under twelve hours, inside a single day's run.**
+
+**Consequence for wave 30:** re-running it would spend two minutes of `TestApp` producing a second copy of a
+published refutation. Wave 30 does not re-run it. It does something better and cheaper: §5 makes wave 29's
+whole "not run" ledger into **`RULE W30-D`**, a rule that checks every row rather than inheriting it.
+
+### 2.2 The closing `V29` is paid, and it is a genuine closing run — verified, not taken on trust
+
+The controller says so and it checks out with a stronger claim than the controller made.
+`/mnt/d/hf_w29/vdrift_w29_CLOSING.txt` has mtime **`2026-08-13 14:18:01.915 -0400 = 18:18:01Z`**, which is
+**after** `fp_AFTER.txt` closed at 18:04:27Z and after the cross-wave check at 18:05:04Z. It is 1 189 bytes,
+identical in structure to `vdrift_w29.txt`, and ends `>>> V-CLEAN`. **It is a run at the close, not a copy of
+the run at the open**, and [F95](followups.md)'s remedy is now demonstrated in both halves. Wave 30 inherits
+the obligation, not the debt.
+
+### 2.3 "`MaxDistortion` LOWERED (0.5 → 0.3, 0.2)" — the direction is right and the DESIGN is wrong
+
+The direction is correct and §4.1 verifies it in source rather than quoting [F98](followups.md).
+
+But **two doses of one knob cannot test a joint hypothesis.** [F99](followups.md)'s claim — the one this wave
+exists to test — is *"`D01`'s binding constraint is `TooDistorted`, **jointly with** `LowSensitivity`, and no
+single-knob change recovers it."* A `{0.5, 0.3, 0.2}` ladder on `MaxDistortion` measures a dose-response on one
+axis and says **nothing** about a joint. Wave 29 already made the mirror-image error: it ran three single-knob
+cells and one all-three cell and could not decompose them, and its own §2.4 had argued that a one-at-a-time
+design *"ranks and lower-bounds, and cannot attribute."*
+
+**Wave 30 runs a 2×2 factorial on the two gates F99 names**, which is the smallest design that yields an
+interaction term:
+
+| | `Sensitivity` landed | `Sensitivity` opened |
+|---|---|---|
+| `MaxDistortion` landed | **`M0`** | **`M2`** |
+| `MaxDistortion` opened | **`M1`** | **`M3`** |
+
+Four cells, exactly the budget the controller allowed. The second `MaxDistortion` dose survives as **`M4`**,
+**fenced out of every verdict branch** and first on the cut list (§13), so cutting it changes no verdict. Full
+cell table in §4.3.
+
+### 2.4 "one notch" of `Sensitivity` is too small to be in a joint test at all
+
+Wave 29 relaxed `BrightnessSensitivity` 36.333 → 35.333 — one axis step read from
+`OptimizerVariable.cs:168` — and recorded the result as **2.75 %**, *"which is why `exclusive(Sensitivity)` is
+only 101 and is weak evidence for anything."*
+
+Putting that same 2.75 % into a joint cell guarantees a null on the joint arm by construction, and a
+pre-registered null by construction is not a test. **Wave 30 opens `Sensitivity` by four axis steps**
+(36.333 → 32.333, **11.0 %**), computed at run time as `landed − 4 × step` with `step` read from the product's
+own axis declaration, **never typed**. Wave 29's one-notch cell `L3` is imported unchanged as the low dose, so
+the wave gets a two-point dose curve on that axis for free.
+
+**[F84](followups.md) / `RULE S16` is re-affirmed, not touched.** The `Sensitivity` axis here is a **diagnostic
+dial** and nothing more. §4.5 fences it in the scorer: no verdict branch may name `Sensitivity` as a knob to
+change, and no register entry this wave produces may cite `M2`, `M3` or `L3` as evidence for or against a
+sensitivity bound.
+
+### 2.5 "Item 5: clause populations and `None`" is not a fifth item. It is how this wave's own rules are built
+
+The controller lists [F102](followups.md)'s populations and [F94](followups.md)'s `None` enumeration as a
+separate deliverable worth ~25 m. **Built as a separate deliverable it is exactly the failure it is trying to
+fix** — a checker improved in a wave whose own rules do not use it, which is how `V28-C` shipped with an empty
+population for three waves.
+
+**Wave 30 does not build it beside the rules. It builds the rules out of it.** Every clause in `W30-G`, `W30-D`
+and `V30` prints `candidates: N   findings: M` and **refuses** on an unexpected `N = 0`; every tree enumerates
+over the clause's **actual** value domain including `None`; and every scorer asserts **its own realized clause
+tuple is a member of the enumerated set** and prints that tuple. §11 and §12. The marginal cost is ~20 m of
+instrument writing, not a 25 m item, and the remedy is exercised by the wave that writes it.
+
+**And `None` is not decorative here.** `RULE W29-L` died on a ratio with a negative denominator and landed at
+`(True, None, None)` while printing `uncovered: 0`. **`W30-G`'s `G-3` is a ratio with a denominator that can be
+non-positive, and §11 enumerates its `None` region and names the measured condition that reaches it.**
+
+### 2.6 The 42 GB root set is not what wave 30 reads. It is 2.4 GB, and every entry is justified
+
+The controller is right that the root list must be trimmed and each entry justified. The trim is larger than
+"trim": **wave 30 reads one dataset, and `/mnt/d/hf_w25/after` — the 17 GB root — it does not read at all.**
+
+The results-table `K` column needs `truthModel.max(hfrMin, hfrMinEffective)`. **`truthModel` is not in
+`synth_validate_report.json`.** It is in `synthetic_meta.json`, per `SynthBankSpec.cs:263` (*"the dataset's
+geometric truth model — `synthetic_meta.json`'s `truthModel` block"*), and a key-name-only probe confirms
+`truthModel` → `['hfrMin', 'hfrMinEffective', 'kappa', 'arcsecPerPixel', 'captureBinning', 'readNoiseNote',
+'perFrame']` in `/mnt/d/SyntheticAutofocusBank/<dataset>/synthetic_meta.json`, **20 of 20 present**. So the `K`
+column reads 20 small JSON files under the bank, not 17 GB of sweeps under `hf_w25/after`.
+
+Full root table with the justification per entry, and the four roots dropped with reasons, in §6. Measured
+consequence: **~2.4 GB, ~40 s per sweep at wave 29's measured 61 MB/s, priced at 3 m per side** against wave
+29's measured 11 m 42 s and its ~24 m two-sided owing.
+
+### 2.7 "[F22](followups.md) bounds the payoff" — agreed, and it is a hard constraint on what §4 may conclude
+
+`D01` reaches `BestJ` **0.994825**; below ~1.1 px measured HFR the detector's HFR over-reads by up to
+**+234 %**; its 0.231 px optical vertex measures 0.77 px. **Working autofocus and terrible recall coexist on
+this rig, and recovering `D01`'s recall cannot be justified as a focus improvement.**
+
+**Fixed here, before the data:** the results section is **forbidden** from quoting a recall gain as a product
+benefit. What survives F22 untouched is goal 3 — a knob landed at an extreme against the physics — and that is
+the only frame in which `W30-G`'s verdict may be read. The scorer prints the F22 caveat beside every recall
+number it emits, so a reader quoting the number out of context has to delete the caveat to do it.
+
+---
+
+## 3. THE ITEMS, AND WHAT LOSES
+
+**Taken: item 2 whole (`RULE W30-G`), item 5 folded into the instruments (§2.5), and item 1 re-scoped to what
+is actually owed (`RULE W30-D` + two real debts).**
+
+| candidate | verdict | why |
+|---|---|---|
+| **2 — `D01` localised** | **TAKEN, whole, and re-designed to a 2×2 factorial** | The wave's product question (§1). The direction is now verified in source (§4.1), the statistic is the per-gate flow with an exact conservation identity (§4.2), and the hypothesis under test is F99's and can be refuted (§4.6) |
+| **5 — populations + `None`** | **TAKEN, folded** | Not a separate item (§2.5). Built into `W30-G`, `W30-D` and `V30` |
+| **1 — the debts** | **TAKEN, re-scoped, and now a RULE** | Two of the five are already paid (§2.1, §2.2, §0). What remains is the three scorer self-test captures and the `K` column. The ledger itself becomes `RULE W30-D` (§5) — a rule that can be wrong, replacing a list that rotted |
+| 3 — choose among F82's three fixes | **REJECTED for wave 30** | Wave 29 §13 calls it the natural wave 31 and it deserves its own pre-registration. Mixing a fix-selection with a detector arm makes one wave carry two unrelated verdicts, which is how #197 came to carry three waves |
+| 4 — `MaxDistortion`'s axis and name | **REJECTED for wave 30** | It is plugin C#, it owes the 42 m gate, and **its evidence base is exactly what `W30-G` is about to change.** F98 part 2 claims the top ~21 % of the axis is detection-killing; wave 30 measures the *bottom* of that axis for the first time. Shipping an axis bound in the wave that first measures the axis is the [F14](followups.md) / `RULE D20` fence in a new costume |
+| 6 — `S27-1` and wave 27's three mutants | **REJECTED, and it should be formally WITHDRAWN** | Open four waves running. §16 registers the withdrawal rather than listing it a fifth time |
+
+**Is there a wave here?** Yes, and unlike wave 29 it is not narrow. `W30-G` opens a gate **nobody has ever
+opened in the correct direction**, on a hypothesis stated by the previous wave in a form that can be refuted,
+with a conservation identity that makes the whole attribution model of these reports falsifiable for the first
+time (§4.2). Three of its five cells are **genuinely blind** (§8) — wave 29's `W29-L` had none.
+
+---
+
+## 4. `RULE W30-G` — the gate-flow decomposition on `D01`. One arm, no build
+
+### 4.1 What I verified in source MYSELF, and what I verified it against
+
+[F98](followups.md) is taken as a lead, not as a fact. Every claim below was read at `HEAD` during
+pre-registration, and the instrument re-asserts each of them at run time at **both** `HEAD` **and** the B15
+tree the arm's binary was built from.
+
+**(a) `MaxDistortion` is a MINIMUM fill ratio. Lowering it relaxes the gate.**
+`StarDetector.cs:1802-1810`:
+
+```csharp
+var fillRatio = (starPoints.Count + donutHoleArea) / d / d;
+var effectiveMaxDistortion = ComputeEffectiveMaxDistortion(p, d);
+if (fillRatio < effectiveMaxDistortion) {
+    metrics.TooDistortedBounds.Add(starBounds);
+    …RecordRejection(…, RejectionGate.TooDistorted, fillRatio, effectiveMaxDistortion, …);
+    return null;
+}
+```
+
+The comparison is `fillRatio < threshold ⇒ REJECT`. **The threshold is a floor on fill ratio; raising it
+tightens, lowering it relaxes.** The file's own comment at `:1786-1787` gives the ceiling: *"a perfect disk
+fills ~PI/4 ≈ 0.79."* Wave 29 raised it to **0.9**, above that ceiling, and both cells that carried the raise
+returned `TP=0 FP=0 FN=110384`.
+
+**(b) The three defocus-aware master flags are OFF in `D01`'s landed tree, so effective == strict and the gate
+chain is the legacy chain.** Read from `/mnt/d/hf_w29/l/opt/L0/attempt01/optimized_settings.json`:
+`DefocusAwareGates: false`, `DefocusAwareDonutDetection: false`, `DefocusAwareStructure: false`,
+`DonutMaxStreakEccentricity: 1.0`. Consequences, each from source:
+
+- `ComputeEffectiveMaxDistortion` returns `p.MaxDistortion` verbatim (`:1459`), so the effective threshold is
+  the edited value exactly.
+- `donutHoleArea` is `0` (`:1799`), so `fillRatio` is the plain `points / d²`.
+- The `TooElongated` gate at `:1775` **does not exist in the chain** — it is guarded by
+  `p.DefocusAwareDonutDetection`.
+- The integrated-SNR branch inside the sensitivity gate (`:1844-1850`) does not run, so
+  `sensitivity == NormalizedBrightness / noiseSigma` exactly.
+
+**This is a precondition of the whole design and the arm asserts all four and REFUSES if any is not as
+recorded.** Wave 29 spot-checked one of them.
+
+**(c) The gate order, by first `RecordRejection` line in `StarDetector.cs`:**
+
+| # | gate | line |
+|---|---|---|
+| 1 | `TooSmall` | `:1757` |
+| 2 | `OnBorder` | `:1766` |
+| — | *(`TooElongated` `:1780` — absent, flag OFF)* | |
+| 3 | `TooDistorted` | `:1807` |
+| 4 | `Degenerate` | `:1823` |
+| 5 | `LowSensitivity` | `:1854` |
+| 6 | `NotCentered` | `:1876` |
+| 7 | `TooFlat` | `:1891` |
+
+**The instrument does not read this table.** It extracts the order from source by line number at run time,
+at `HEAD` and at the B15 tree `29665a62e4f8` (read out of `/mnt/d/hf_w25/binary_provenance_w25.txt`, never
+typed), and **refuses if the two disagree.** Wave 29 established the pattern for the `1.5` multiple; this
+extends it to an ordering. Note that `NotCentered` and `TooFlat` are **downstream of `LowSensitivity`**, which
+wave 28's and wave 29's prose ("`TooSmall` → … → `LowSensitivity`") never said and which matters to §4.2.
+
+**(d) The landed knob values**, from the same file: `MaxDistortion 0.5`, `MinStarBoundingBoxSize 6`,
+`BrightnessSensitivity 36.33333333333333`, `NoiseClippingMultiplier 1.0`.
+
+### 4.2 THE STATISTIC: a flow with an exact conservation identity, and it can FAIL
+
+Wave 29's `RULE W29-L` differenced `FN_total`. Its own results §3.2 measured why that throws the answer away:
+`MinBox 6→3` releases **9 537** candidates from `TooSmall`, **5 697** are re-caught by `TooDistorted`, **3 814**
+by `LowSensitivity`, and the net is **−3**.
+
+**The flow model, stated as a specification of the report that can be wrong.** The attribution is
+first-rejection-wins over the source order in §4.1(c). Relaxing exactly one gate `g` changes no other
+threshold, therefore:
+
+1. candidates rejected **upstream** of `g` never reach `g`, so those buckets are **invariant**;
+2. candidates rejected **at** `g` are re-tested by everything downstream;
+3. candidates that passed `g` before still pass it, so downstream buckets can only **grow**.
+
+Write `R_g = FN_g(M0) − FN_g(cell)` for the **release**, and let the terminal classes be `TP`, `Contaminated`
+and `ACCEPTED-elsewhere` (a released candidate that is accepted may be matched, matched elsewhere, or fall in a
+contaminated region). Then:
+
+> **`ΔNO-CANDIDATE = 0`, `ΔFN_h = 0` for every gate `h` strictly upstream of `g`, and**
+>
+> **`R_g  =  Σ_{h downstream of g} ΔFN_h  +  ΔContaminated  +  ΔACCEPTED-elsewhere  +  ΔTP`, EXACTLY, in integers.**
+
+**Checked against wave 29's published artifacts before pre-registration, twice, and it balances on the nose
+both times.**
+
+`L0 → L1`, `MinBox 6 → 3`, `g = TooSmall` (first gate, so no upstream terms):
+
+| term | value |
+|---|---|
+| `R_TooSmall` = 11 372 − 1 835 | **9 537** |
+| `ΔOnBorder` | +10 |
+| `ΔTooDistorted` | +5 697 |
+| `ΔDegenerate` | +5 |
+| `ΔLowSensitivity` | +3 814 |
+| `ΔNotCentered` | +7 |
+| `ΔTooFlat` | +1 |
+| `ΔContaminated`, `ΔACCEPTED-elsewhere`, `ΔNO CANDIDATE` | 0, 0, 0 |
+| `ΔTP` = 12 165 − 12 162 | +3 |
+| **Σ downstream + terminals** | **9 537** ✓ |
+
+`L0 → L3`, `Sensitivity 36.333 → 35.333`, `g = LowSensitivity` (gate 5, so gates 1–4 must be invariant — and
+wave 29's decomposition lists no change on any of them):
+
+| term | value |
+|---|---|
+| `R_LowSensitivity` | **122** |
+| `ΔNotCentered` | +12 |
+| `ΔContaminated` | +4 |
+| `ΔACCEPTED-elsewhere` | +5 |
+| `ΔTP` = 12 263 − 12 162 | +101 |
+| **Σ** | **122** ✓ |
+
+**Two exact balances on artifacts nobody built for this purpose.** That makes the identity a live specification
+rather than an assumption, and it makes wave 29's `L0/L1` and `L0/L3` pairs available as **real fixtures with
+known answers** for `score_w30g.py`'s self-test — not synthetic mutants.
+
+**And it exposes a confound the naive reading would walk into.** `π_g = ΔTP / R_g` is **not comparable across
+gates**: `MinBox` sits first and yields `3 / 9 537 = 0.0003`; `Sensitivity` sits fifth of seven and yields
+`101 / 122 = 0.83`. The last gate before acceptance always has a high pass-through *because of its position*.
+**§4.4 therefore never compares `π` across gates.** It pools.
+
+### 4.3 THE CELLS — a 2×2 factorial, one fenced dose, two imports
+
+`NoiseClippingMultiplier` held at **1.0** throughout, matching wave 28's `N-RECOVERS` cell and wave 29's whole
+arm. No build. Binary `/mnt/d/hf_w25/exe`, `TestApp.dll` sha256 asserted against
+`binary_provenance_w25.txt` **before the first cell**. Settings tree copied per cell from the same seed wave
+29's arm used, edited fields only, `cp` **without** `-p`, `touch` after every copy ([F89](followups.md)).
+
+| cell | `MaxDistortion` | `BrightnessSensitivity` | `MinStarBoundingBoxSize` | role |
+|---|---|---|---|---|
+| **`M0`** | 0.5 | 36.333 | 6 | **baseline / control** — must reproduce wave 29's `L0` high-tier attribution block field-for-field |
+| **`M1`** | **0.3** | 36.333 | 6 | the gate never opened in the correct direction |
+| **`M2`** | 0.5 | **32.333** | 6 | `Sensitivity` at four axis steps (11.0 %) — **diagnostic, fenced** |
+| **`M3`** | **0.3** | **32.333** | 6 | the **joint** cell F99's hypothesis is about |
+| **`M4`** | **0.2** | 36.333 | 6 | second `MaxDistortion` dose — **fenced out of every verdict branch, first to cut** (§13) |
+
+**Imported from wave 29, not re-run** (`/mnt/d/hf_w29/l/out/L{1,3}/attempt01/golden_eval.txt`):
+
+| import | edit | what it supplies |
+|---|---|---|
+| `L1` | `MinStarBoundingBoxSize` 6 → 3 | the third gate's flow, already measured |
+| `L3` | `BrightnessSensitivity` 36.333 → 35.333 | the low dose of `M2`'s axis |
+
+**What licenses the import, stated before the data.** Same binary, same frames, same seed tree, one field
+differing. **`M0` re-running `L0` and reproducing it field-for-field IS the licence.** If `M0 ≠ L0`, the
+pipeline is not reproducing and **the imports are void, `G-0` fails, and the verdict is `G-UNEVALUATED`** — the
+wave does not fall back to using them anyway. This is stated here so that the licence cannot be granted after
+seeing whether it was needed.
+
+**Every edited field's JSON key is RESOLVED, never typed.** Wave 29 §9 recorded that the design named
+`StarDetectorParams` spellings while the file declares `MinStarBoundingBoxSize` and `BrightnessSensitivity`.
+The arm searches the tree's own declared keys for a case-insensitive match against a candidate list, **refuses
+on zero or more than one match**, and prints the resolved key per cell. `MaxDistortion` resolves to
+`MaxDistortion`; the arm still resolves it.
+
+**One guard wave 29 did not need and wave 30 does.** The landed tree also declares
+`EffectiveSensitivityGate: 36.33333333333333`, mirroring `BrightnessSensitivity`. Wave 29's `L3` edited
+`BrightnessSensitivity` alone and the `LowSensitivity` bucket moved by 122, so the edit demonstrably takes;
+wave 30 edits the same field, leaves the mirror alone, and **asserts from each cell's own `key detector knobs:`
+echo that the intended value is the one in force.** A cell whose echo disagrees REFUSES.
+
+**Wall-clock band, priced from wave 29's measured per-cell times** (177 / 198 / 152 / 168 / 145 s; the two
+fastest were the two dead cells): predicted **~950 s** for five cells, pre-registered band **725–1 600 s**. A
+run outside the band is reported, not silently accepted.
+
+### 4.4 THE STATISTIC, fixed before the data
+
+Per cell, read **only** the `FALSE-NEGATIVE ATTRIBUTION, HIGH TIER ONLY` block, anchored on that header
+([F68](followups.md) part 5: the line appears twice per report and a first-match reader takes the wrong one).
+
+For each single-knob cell `c` opening gate `g`:
+
+```
+R_g        = FN_g(M0) − FN_g(c)                       the release
+survive_g  = ΔTP(c)                                   what reached acceptance
+capture_g  = R_g − survive_g                          what a downstream gate re-caught
+row C_{g→h} = ΔFN_h(c)  for every h downstream of g   WHERE it went
+```
+
+and the two aggregate quantities the verdict is taken on:
+
+```
+recapture  = Σ_g capture_g / Σ_g R_g                  pooled over ALL single-knob cells
+material   = 0.01 × FN_total(M0)                      the bar, COMPUTED not typed
+```
+
+`material` is one percent of the misses the wave is trying to explain. At `FN_total(M0) = 50 249` (expected,
+from `L0`) that is **≥ 503 stars**; the scorer computes it from `M0` and prints it.
+
+Pooling `recapture` across gates rather than comparing `π_g` is deliberate — §4.2's positional confound makes
+per-gate `π` incomparable, while the pooled fraction answers exactly the question F99 asks: *of everything
+these knobs release, how much survives to acceptance?*
+
+**The full capture matrix `C` is published** — every gate's release and where each unit of it went — because it
+is the wave's product, and because publishing it is what makes a later reader able to check §4.2's identity.
+
+### 4.5 THE CLAUSES, their populations, and their `None` conditions
+
+| clause | statement | population it declares | value domain |
+|---|---|---|---|
+| **`G-0`** *(validity, first column of the tree)* | seven sub-assertions: (i) all cells `exit=0`; (ii) each echoes its intended knobs; (iii) `M0` reproduces `L0` field-for-field, fields compared ≥ 8; (iv) the source gate order is identical at `HEAD` and `29665a62e4f8`; (v) the four defocus preconditions of §4.1(b) hold in the landed tree; (vi) every edited JSON key resolved uniquely; (vii) dll sha256 matches the recorded provenance | cells run, fields compared, gates ordered, keys resolved — **each printed as `candidates: N`, each refusing on `N = 0`** | `{True, False}` |
+| **`G-1`** *(the model)* | on **every** single-knob cell (`M1`, `M2`, `M4`, and imports `L1`, `L3`): `ΔNO-CANDIDATE = 0`, `ΔFN_h = 0` for all `h` upstream of `g`, `R_g ≥ 0`, and §4.2's balance holds as **integer equality with no tolerance** | single-knob cells | `{True, False}` |
+| **`G-2`** *(the flow)* | `recapture ≥ 0.90` — at least 90 % of everything the single knobs release is re-caught downstream rather than accepted | released candidates, `Σ R_g` | `{True, False, None}` — **`None` iff `Σ R_g = 0`** |
+| **`G-3`** *(the joint)* | `ΔTP(M3) ≥ material` **and** `ΔTP(M3) ≥ 2 × [ΔTP(M1) + ΔTP(M2)]` | the joint cell against the two singles | `{True, False, None}` — **`None` iff `ΔTP(M1) + ΔTP(M2) ≤ 0`**, because the ratio's denominator is then non-positive and a ratio against it is an artefact |
+
+**`G-2`'s `None` region is reachable** (no knob releases anything) and **`G-3`'s `None` region is reachable**
+(a single knob can *lose* accepted stars — `ACCEPTED-elsewhere` shows the matching is competitive, so `ΔTP < 0`
+is possible). Both are named here, before the data, with the measured condition that reaches them. **This is
+the region `RULE W29-L` fell into while its tree said `uncovered: 0`.**
+
+**The `Sensitivity` fence, enforced in the scorer.** `M2`, `M3` and the `L3` import contribute to `G-2` and
+`G-3` as *diagnostics of where flow goes*. The scorer **refuses to name `Sensitivity`** in any verdict string,
+even if it carries the largest release, and prints the fence text beside the number.
+[F84](followups.md) / `RULE S16` stands; no register entry from this wave may cite these cells as evidence for
+or against a sensitivity bound.
+
+### 4.6 THE PREDICTIONS — two of them, differing, both fixed before the data
+
+**Prediction A, inherited — [F99](followups.md)'s hypothesis: `G-JOINTLY-BOUND`.** `TooDistorted` and
+`LowSensitivity` bind jointly; no single knob recovers `D01`; opening the pair recovers materially more than
+the sum of the singles.
+
+**Prediction B, this document's own, and it differs: `G-NOT-RECOVERABLE`.** The reasoning, stated so it can be
+wrong: `D01` is a 19.4 ″/px rig whose kernel is ~0.7 px, and `LowSensitivity`'s threshold is **36.3 σ**. A
+candidate released by `TooDistorted` at 0.3 is a small, low-fill blob; a 11 % relaxation of a 36 σ bar does not
+turn a 5 σ blob into a detection. I expect a large `R_TooDistorted`, `recapture` well above 0.90, and
+`ΔTP(M3)` **below** the 503-star material bar — i.e. F99's mechanism confirmed and F99's *joint recovery* claim
+refuted.
+
+**Registering both is the point.** If `G-JOINTLY-BOUND` comes back, F99 was right and this document was wrong,
+in writing, before the data. If `G-NOT-RECOVERABLE` comes back, F99's hypothesis is **refuted** and the wave
+did not discover that after the fact. Neither outcome lets the wave claim a hit it did not call.
+
+**What `G-SINGLE-BINDS` would mean, and it is the outcome with the largest product consequence.** If
+`recapture < 0.90` — more than a tenth of what the knobs release reaches acceptance — then a single landed knob
+is holding real stars, the largest `survive_g` names it, and **that is a parameter pinned against the physics,
+goal 3 verbatim, worth its own wave.** Neither prediction expects it.
+
+---
+
+## 5. `RULE W30-D` — wave 29's "not run" ledger, CHECKED rather than inherited
+
+§2.1 found a debt that had been paid seven hours before it was listed. **The remedy is not to fix that one row.
+It is to stop inheriting the list.**
+
+`RULE W30-D` parses wave 29's results §11 table (*"WHAT WAS NOT RUN, AND WHAT IT COSTS"*) out of the committed
+document, resolves each row to a checkable predicate, and searches a declared set — `/mnt/d/hf_w2{5,6,7,8,9}`,
+`/mnt/d/hf_w30`, and the repository at `HEAD` — for an artifact that satisfies it. Zero compute.
+
+| clause | statement | population | domain |
+|---|---|---|---|
+| **`D-0`** *(validity)* | the §11 table parses; every row resolves to exactly one predicate; the search set exists | rows parsed (`candidates: N`, **refuses on `N = 0`**) | `{True, False}` |
+| **`D-1`** | **no** row claimed "not run" has a satisfying artifact | rows claimed not-run | `{True, False, None}` — `None` iff every row is a "not applicable" row |
+
+**Verdicts:** ¬`D-0` ⇒ `D-UNEVALUATED`. `D-0` ∧ `D-1` ⇒ `D-LEDGER-CLEAN`. `D-0` ∧ ¬`D-1` ⇒ **`D-STALE`**, a
+FINDING, with every already-paid row named and its artifact's path and mtime printed.
+
+**The prediction, and the honest disclosure that comes with it: `D-STALE`, with `P-D08 at n = 3` as a named
+row — because §2.1 already found it.** That row is **read and is not blind.** **The blind quantity is the
+count of *other* stale rows**, which nobody has checked, and `D-1`'s verdict is carried by the whole table, not
+by the one row. This is [F100](followups.md)'s lesson applied at pre-registration time: the ledger says exactly
+which quantity it has spent and which it has not.
+
+**A row that cannot be resolved to a predicate leaves the denominator as `CNL-UNRESOLVABLE` and is named, never
+scored as clean.** Wave 29's `CNL-NOREPORT` pattern.
+
+---
+
+## 6. `W30-FP` — the fingerprint, trimmed to what wave 30 reads, taken BEFORE anything
+
+**The BEFORE sweep is the FIRST thing any instrument does — Step 2, immediately after Step 1 writes the
+instruments, before `V30`'s fixture probes read `/mnt/d/hf_w29` and before the arm's first cell.** Wave 29 ran
+it last and it cost `W29-FP` its verdict on four of six roots; the failure is not recoverable retroactively,
+because a BEFORE taken afterwards is an AFTER.
+
+**This deliberately puts the sweep ahead of the blocking pre-flight, and [F95](followups.md) is not weakened by
+it.** F95's remedy is *instruments before the pre-flight, and the pre-flight before the measurements* — both
+still hold. The sweep is not a measurement; it is the baseline the measurements are judged against, and it must
+predate every read of a declared root, including `V30`'s own probes.
+
+**The declared population is a list of (root, predicate) pairs, defined ONCE in `layout_w30.sh` and consumed by
+both sides** ([F91](followups.md): one expression, called twice). Population size asserted **equal** before any
+hash is compared. Paths deduplicated by `realpath` so the D01 overlap between rows 1 and 2 is counted once.
+
+| # | root | predicate | why wave 30 opens it | size |
+|---|---|---|---|---|
+| 1 | `/mnt/d/SyntheticAutofocusBank/D01_ultrawide_40mm` | all files | the arm's 9 frames and golden sidecars — **the only dataset wave 30 runs** | 630 M |
+| 2 | `/mnt/d/SyntheticAutofocusBank` | `-name synthetic_meta.json` | the `K` column's `truthModel` (§2.6), 20 files | ~1 M |
+| 3 | `/mnt/d/hf_w25/exe` | all files | the B15 `TestApp` the arm runs; its dll sha256 is separately asserted | 196 M |
+| 4 | `/mnt/d/hf_w29` | all files | `L0`/`L1`/`L3` `golden_eval.txt` (the control and the two imports), the three scorers (self-test captures), `verify_derivation_w29.py` (`V30`'s parent), and the §11 table's search target | 635 M |
+| 5 | `/mnt/d/hf_w28/nc` | all files | the published `NC = 1.0` block — the second leg of the `M0 → L0 → wave 28` control chain | 889 M |
+| 6 | `/mnt/d/hf_w25/table18` | all files | provenance of the results table the `K` column edits | 14 M |
+| | **total** | | | **~2.4 G** |
+
+**Dropped, each with its reason — this is the part wave 29 could not write:**
+
+| dropped | size | why wave 30 does not read it |
+|---|---|---|
+| `/mnt/d/hf_w25/after` | **17 G** | `W29-R`'s population. Wave 30 runs no `SearchSpan` rule, and the `K` column's `truthModel` is **not** in `synth_validate_report.json` (§2.6) |
+| `/mnt/d/hf_w25/before` | **15 G** | Nothing in wave 30 reads it. It was in wave 29's list without a stated reader either |
+| `/mnt/d/SyntheticAutofocusBank/D02…D20` frames | ~8.1 G | The arm is **one dataset**. Only their `synthetic_meta.json` is read, and row 2 covers exactly that |
+| `/mnt/d/hf_w26/pd08` | small | §2.1: `RULE W30-D` **reads** it, so it would belong here — **and it is added as row 7 if `D-0` resolves any row to that path.** The root list is computed from the resolved predicates, not typed |
+
+**Price, from wave 29's measured rate.** 2.4 GB at **61 MB/s** is **~40 s per sweep**. Priced at **3 m per
+side**, ~4× the measured expectation, because the roots are on DrvFs and the small-file rows carry per-file
+overhead the rate does not capture. Wave 29 owed ~24 m for both sides and did not pay it; wave 30 owes ~6 m and
+pays it. **That is what "justify each entry" buys.**
+
+---
+
+## 7. `RULE V30` — the pre-flight, three generations carried, fixtures MEASURED
+
+Derived from `/mnt/d/hf_w29/verify_derivation_w29.py`, **not** from any `.bak`.
+
+**Carry forward and demonstrate all THREE generations of the `historical_ranges` repair**
+([F87](followups.md) → wave 27 → wave 29's string-literal blanking, [F101](followups.md)):
+
+1. bracket-depth top-down with `is_definition` excluded (wave 27's repair);
+2. the `opens > 0` requirement (wave 28's);
+3. **length-preserving blanking of string literals before counting** (wave 29's, `verify_derivation_w29.py:224`
+   `code_of`, `:229-238` `historical_ranges`) — the fix for the phantom block that made 29 of 599 lines of wave
+   28's own checker exempt.
+
+Self-test clause `[6]` asserts **all four ends**, including *"a token INSIDE the declared historical literal is
+NOT reported"*. **F101's durable point is that each generation's self-test tested the ends the previous
+generation broke**, so `[6]` keeps every end all three generations established and adds none of its own
+invention.
+
+**Per-clause fixtures are MEASURED, not inherited** ([F103](followups.md)). The probe runs over
+`/mnt/d/hf_w{24,26,27,28,29}` — five roots, one more than wave 29 — and pins from the measurement.
+
+**The forward prediction, written here one wave before the measurement, which is the strongest evidence class
+this series has:** `PREV` is now **29**, so
+
+- **`/mnt/d/hf_w28` EXPIRES** — wave 29's live `-B` fixture, which yielded **100** `-B` findings at wave 29,
+  goes to **0** at wave 30;
+- **`/mnt/d/hf_w29` becomes the new live `-B` fixture**, yielding a large non-zero `-B` count;
+- `/mnt/d/hf_w24` remains the durable `-C` fixture (2 findings, fourth wave running);
+- `/mnt/d/hf_w26` and `/mnt/d/hf_w27` remain asserted-silent at `-B = 0`.
+
+**A clause with no live fixture is a FAIL, not a pass.** The expired roots are kept and asserted silent so the
+expiry is demonstrated rather than described.
+
+**`V30` runs TWICE: at Step 3 over the populated root, and at the close** (`vdrift_w30_CLOSING.txt`). The
+closing run is **not cut at any budget** (§13). Wave 29 proved the first half of [F95](followups.md)'s remedy
+and, at 18:18:01Z, the second; wave 30 does both from the start.
+
+**Every `V30` clause prints its population and refuses on an unexpected `N = 0`** — [F102](followups.md)'s
+remedy, and the direct fix for `V28-C` returning zero over 2 of 126 printing lines.
+
+---
+
+## 8. BLINDNESS LEDGER — stated once, and CHECKED AGAINST THIS DOCUMENT'S OWN INSTRUMENTS
+
+[F100](followups.md)'s remedy, executed: **every quantity this ledger promises stays unread is checked against
+every clause's per-member output in §4 and §5 before this document is committed.** The check is recorded below,
+row by row, and it is why the `W30-D` row says what it says.
+
+**READ, and by whom:**
+
+| quantity | by whom | scope of the burn |
+|---|---|---|
+| `D01`'s `L0` high-tier attribution block, every field | wave 28 §1.1, wave 29 §3.2, and §4.2 above | `M0`'s baseline half — it is a **control**, not a statistic |
+| `L1`'s and `L3`'s full per-gate deltas | wave 29 §3.2 and [F99](followups.md), and §4.2 above | the two imported cells. Their flows are **published inputs**, not blind measurements |
+| `D01`'s landed knob values and the three defocus flags | §4.1(b), (d) — read from `L0`'s settings tree at pre-registration | none: they are the arm's inputs |
+| `StarDetector.cs`'s gate order and the `MaxDistortion` comparison | §4.1 above | none: source, not data |
+| the `synthetic_meta.json` **schema** (`truthModel`'s key names only, no values) | §2.6 | none |
+| **`P-D08` at `n = 3`'s result** | §2.1 — **read, in full, at pre-registration** | **one named row of `RULE W30-D`'s population.** Disclosed in §5 |
+
+**BLIND, and carrying `RULE W30-G`'s verdict:**
+
+> **`M1`, `M3` and `M4` — every number they produce.** `MaxDistortion` has **never** been run at a value below
+> 0.5 on this dataset by anyone. `M2` at four axis steps has never been run either. Their releases, capture
+> rows, `ΔTP` and the pooled `recapture` are unread by any human or agent at the time this document is
+> committed.
+
+**Checked against the instruments, per F100:** §4.4 and §4.5 specify that the scorer computes and prints
+exactly these quantities and nothing else about `M1`–`M4`. No clause in §4.5 requires reading any `M1`–`M4`
+value before the rule is scored, and no clause in §5 or §7 reads them at all. **The ledger and the instruments
+are consistent.** Wave 29's were not, and nothing checked.
+
+**BLIND, and carrying `RULE W30-D`'s verdict:** every row of wave 29's §11 table **except** `P-D08`.
+
+**The burn wave 30 will spend, named in advance:** publishing `W30-G`'s capture matrix reads `M1`–`M4`
+completely. **`D01`'s gate behaviour at these settings will have no blind population left.** That is the
+correct trade — the matrix is the wave's product — and it means any further arm on `D01` at these knobs must
+say plainly that it is unblinded, exactly as §7 of wave 29 had to.
+
+**`RULE V30` has no blind population and this is said plainly.** Its honesty mechanism is the §7 forward
+prediction about fixture expiry, which is falsifiable and is checked one wave after it was written.
+
+---
+
+## 9. THE GATE — not owed, and the three conditions that reverse it
+
+**Wave 30 changes no C# and builds no binary.** The arm runs `/mnt/d/hf_w25/exe`, dll sha256 asserted against
+`binary_provenance_w25.txt` before the first cell. Wave 26's four conditions for an honest skip all hold:
+nothing is compiled; `G25` already answered what a re-gate asks; a re-gate does not reach this wave's risk; and
+**no clause in any verdict tree in this document reads a gate landing.** *A control no clause consumes is a
+ritual.*
+
+**The three conditions are checked at Step 8 and any one of them stops the wave:** a single line of C# changing
+for any reason; a hash or `BuildId` mismatch on the arm's binary; or the arm's own instrument proving
+non-deterministic. The check is `git diff --name-only <base> HEAD -- '*.cs'` **unioned with**
+`git ls-files --others --exclude-standard -- '*.cs'` ([F88](followups.md)), and it is **run**, not asserted.
+
+**If wave 30 proposed C# — and it deliberately does not (§3, item 4) — the 42 m `optimize` gate would be owed,
+certainly and not probably.** `Q27-V1`'s reachable set is a directory prefix over the whole plugin assembly,
+and `StarDetector.cs` sits under it by a wide margin. Price: **42 m** measured (wave 25: 42 m 43 s, ~5.2 m/run,
+seven consecutive waves), predicted verdict `G-PASS`, 8 of 8 bit-identical to K8. The unit suite would run **by
+count** ([F37](followups.md)) against baseline **3997** — wave 28's measured close, **not** the charter's stale
+3973.
+
+---
+
+## 10. WHAT SHIPS — nothing, fixed here, before the data
+
+| candidate ship | status |
+|---|---|
+| bounding the `MaxDistortion` axis at ~π/4 (F98 part 2) | **DOES NOT SHIP.** §3: wave 30 is the first wave to measure the *bottom* of that axis; shipping a bound in the wave that first measures it is the `RULE D20` fence |
+| renaming or re-documenting `MaxDistortion` | **DOES NOT SHIP.** Same wave, same fence |
+| anything on the `Sensitivity` axis | **DOES NOT SHIP.** [F84](followups.md) / `RULE S16` is permanent; §4.5 fences the scorer |
+| anything on `MinStarBoundingBoxSize` | **DOES NOT SHIP.** Its flow is an *import*; a default change owes its own wave with a fresh baseline ([F93](followups.md)'s three refusals apply verbatim) |
+| any F82 fix | **DOES NOT SHIP.** Wave 31's item, its own pre-registration (§3) |
+
+**Consequence:** no C# changes, so the unit suite is not run, and that is stated rather than skipped silently.
+The condition that reverses it is in §9 and in the plan's Step 8.
+
+**Documentation does change:** `docs/synthetic-af-bank-results-table.md` gains the `K` column (§13, Step 7).
+That is a `.md` edit and reaches no gate.
+
+---
+
+## 11. VERDICT TREES, ENUMERATED OVER THE ACTUAL VALUE DOMAIN — `None` INCLUDED
+
+Every clause appears in its own tree, **including every validity clause**, over its **actual** domain from
+§4.5 / §5 / §7 — `{True, False}` where the clause is a conjunction of assertions, `{True, False, None}` where
+it can be undefined. Every scorer re-derives the enumeration in code, prints `regions enumerated: N
+uncovered: 0`, **prints its own realized clause tuple, and ASSERTS that tuple is a member of the enumerated
+set.** A gap prints `<RULE>-TREE-GAP`, enumerates the uncovered regions, prints what this document's tree would
+have said, and **does not repair and re-score**.
+
+**This is the [F94](followups.md) append executed.** Wave 29 proved totality over `{True, False}` and then
+landed on `(True, None, None)`. **Proving totality over the wrong domain is not proving totality.** The
+membership assertion is the half that catches it.
+
+**`RULE W30-G` — 4 clauses, 2 × 2 × 3 × 3 = 36 regions, 0 uncovered**
+
+| `G-0` | `G-1` | `G-2` | `G-3` | verdict | regions |
+|---|---|---|---|---|---|
+| `F` | `*` | `*` | `*` | `G-UNEVALUATED` | 18 |
+| `T` | `F` | `*` | `*` | **`G-MODEL-BROKEN`** — a FINDING: the report's first-rejection-wins attribution does not conserve, and **every gate-count difference in waves 28 and 29 is unsafe.** No repair, no re-score | 9 |
+| `T` | `T` | `None` | `*` | **`G-NO-RELEASE`** — a FINDING: no knob released anything; these three gates are not where `D01`'s loss is | 3 |
+| `T` | `T` | `F` | `*` | **`G-SINGLE-BINDS`** — more than a tenth of the released mass reaches acceptance; the largest `survive_g` names the knob (subject to §4.5's `Sensitivity` fence). **The goal-3 product finding** | 3 |
+| `T` | `T` | `T` | `T` | **`G-JOINTLY-BOUND`** — **prediction A** (F99) | 1 |
+| `T` | `T` | `T` | `F` | **`G-NOT-RECOVERABLE`** — **prediction B** (this document): re-capture dominates *and* the joint is immaterial | 1 |
+| `T` | `T` | `T` | `None` | **`G-SINGLES-DEAD`** — the singles delivered ≤ 0 to acceptance, the ratio is undefined, the joint is published raw and **no ratio is quoted** | 1 |
+| | | | | **total** | **36** |
+
+**`RULE W30-D` — 2 clauses, 2 × 3 = 6 regions, 0 uncovered**
+
+| `D-0` | `D-1` | verdict | regions |
+|---|---|---|---|
+| `F` | `*` | `D-UNEVALUATED` | 3 |
+| `T` | `T` | `D-LEDGER-CLEAN` | 1 |
+| `T` | `F` | **`D-STALE`** — a FINDING, rows named — **the prediction** | 1 |
+| `T` | `None` | `D-VACUOUS` — every row was "not applicable"; **a FINDING about the ledger's shape**, not a pass | 1 |
+
+**`RULE V30` — 3 clauses, `A` ∈ `{T,F,None}`, `B`,`C` ∈ `{T,F}`, 12 regions, 0 uncovered.** Inherited from
+wave 29's checker unchanged (`vdrift_w29_CLOSING.txt` prints all 12, including the `A=None` empty-population
+region), plus the per-clause population line and the `N = 0` refusal from §7.
+
+**`W30-FP` — `PRESERVED` / `VIOLATED` / `UNEVALUATED` on differing membership**, with `UNEVALUATED` reached
+when the BEFORE and AFTER populations differ in size — asserted before any hash is compared.
+
+**Why the pattern F94 names does not recur here.** F94's diagnosis was *"the uncovered region is always the
+VALIDITY clause"*. `G-0` and `D-0` are the **first column** of their own tables, and `V30`'s `A` is declared
+validity-with-a-`None`. And the new failure mode wave 29 found — a realized tuple outside the enumerated set —
+is caught by the membership assertion, not by a count.
+
+---
+
+## 12. CLAUSE POPULATIONS — [F102](followups.md)'s remedy, in every instrument this wave writes
+
+**Every clause, in every instrument, prints:**
+
+```
+  <clause>: candidates: <N>   findings: <M>       [or   value: <x>]
+```
+
+and **REFUSES** — verdict `<RULE>-POPULATION-EMPTY`, a FINDING — when `N = 0` on a clause that declares a
+non-empty population. `N` and `M` are **computed**, never typed (`V30-C`).
+
+The populations each clause declares are named in §4.5, §5 and §7. The class F102 identifies — *"no verdict
+tree in this series distinguishes zero findings from zero candidates"* — is closed by making the distinction
+**printable and refusable**, not by widening one regex. `V30`'s regex widening (wave 29's, carried forward)
+remains, and is now *checked* by the population line rather than trusted.
+
+**A clause whose population is unsatisfiable is a FINDING and is not repaired.** Standing rule, re-stated
+because wave 30 writes five new clauses and the temptation is proportional.
+
+---
+
+## 13. PRICE, scored against the owner's three goals, and what is cut first
+
+Goals (charter §8): **(1)** optimization + autofocus across a wide range of setups; **(2)** accuracy of
+step-size recommendations; **(3)** appropriate exposure adjustments, no parameters pinned to extremes.
+
+| step | est | compute | goals |
+|---|---|---|---|
+| 0 vessel + pre-registration commit + PR with the right base | 12 m | — | — |
+| 1 write **all 7 instruments** before any of them runs ([F95](followups.md)) | 60 m | — | — |
+| 2 **`W30-FP` BEFORE** — the first thing any instrument does | 5 m | — | instrument |
+| 3 `RULE V30` pre-flight over the **populated** root + 5 fixture probes | 15 m | — | instrument |
+| 4 `RULE W30-G` arm, 5 cells | 25 m | **~15 m** | **3** ✓✓ |
+| 5 `RULE W30-G` scoring | 12 m | — | **3** ✓✓ |
+| 6 `RULE W30-D` + the three retrospective scorer self-test captures | 15 m | ~2 m | instrument |
+| 7 the results-table `K` column | 12 m | — | **3** ✓ |
+| 8 `W30-FP` AFTER + **closing `V30`** + the §9 reversal checks | 8 m | — | instrument |
+| 9 results, register, handoff (folded) | 80 m | — | — |
+| **total** | **~4 h 04 m** | **~17 m** | |
+
+**Against a hard stop of `2026-08-14T00:45:17Z` and a start near `18:25Z`, that is ~6 h 20 m available and
+~2 h 15 m of margin.** The margin is deliberate: this is the fifth consecutive wave in which the analysis
+halves are over-priced (wave 29 came in under on Steps 1, 2, 4, 5 and 6; wave 28 ~59 % under; wave 27 ~36 %).
+**The two figures priced from a measured rate — Step 4 from wave 29's 145–198 s per cell, Step 3/8 from wave
+29's 61 MB/s — are the two expected to be accurate**, and wave 29 demonstrated that the steps priced from
+instinct are the only ones that overran.
+
+**What is cut first, in order:**
+
+1. **`M4`** — the second `MaxDistortion` dose. It is **fenced out of every verdict branch** by construction, so
+   cutting it changes no verdict and no register entry. −3 m compute, −3 m wall. *Named first because it is
+   genuinely free to cut, which is why it was designed to be fenced.*
+2. **Step 7, the `K` column.** −12 m. **And if it is cut, it must be WITHDRAWN or paid, not re-listed** — it
+   has now been owed by waves 28, 29 and 30, and a debt carried three waves without being paid is a debt
+   nobody intends to pay. §16 registers that either way.
+3. **The three retrospective scorer self-test captures.** −6 m. They are a *retrospective* capture of a gate
+   wave 29's plan wrote and did not take; running them now proves the scorers' self-tests pass **now**, which
+   is weaker than the gate would have been, and the results document must label them as retrospective.
+4. **Step 9's handoff document**, folded into the results file's final section rather than written separately.
+
+**What is NOT cut, at any budget:**
+
+- **the closing `V30`** (~2 m) — [F95](followups.md)'s remedy is both halves or neither;
+- **the `W30-FP` BEFORE sweep** (~3 m) — it cannot be recovered retroactively, and wave 29 paid the whole cost
+  of learning that;
+- **`RULE W30-D`** (~10 m of the 15) — it is the only thing that stops the debt list rotting further, and §2.1
+  is the measurement that says it is already rotting.
+
+**Prices this wave hands forward rather than paying:**
+
+| item | price |
+|---|---|
+| F82's three-way fix choice (wave 29 §13 item 3) | ~40 m to choose; ship price ~45 m + 3-cell re-run + **42 m gate** for candidate (3), ~2–4 h + gate for candidate (1) in the product |
+| `MaxDistortion` axis bound + rename (F98 part 2) | ~20 m code **+ 42 m gate**, and **it should now wait for `W30-G`'s capture matrix**, which is the first measurement of that axis's low end |
+| the `A4` truth-model gap | 20 m code **+ 42 m gate** — it rebuilds `TestApp` |
+| new datasets between 1.4 and 19.4 ″/px | ≥ 1 h render. The only route to a **blind** wide-field dataset; the coverage hole is unchanged after eleven waves |
+| a full paired 18-cell S1 arm | ~2 h 40 m. `W-UNEXERCISED` twice: a second arm buys a second `SAME 13` |
+
+---
+
+## 14. INSTRUMENTS AND CONSTRAINTS
+
+Seven files, all under `/mnt/d/hf_w30/`, **LF**, **ASCII**, derived from `/mnt/d/hf_w29/`, **all written at
+Step 1 before any of them runs** ([F95](followups.md)):
+
+| file | derived from | role |
+|---|---|---|
+| `layout_w30.sh` | `layout_w29.sh` | shared layout, the `(root, predicate)` array, `w30_sweep` (**one** expression, called twice), the shared self-test counter |
+| `verify_derivation_w30.py` | `verify_derivation_w29.py` | `RULE V30` — three generations of `historical_ranges` (§7), populations, `None` |
+| `fp_w30.sh` | `fp_w29.sh` | `W30-FP` |
+| `w30g_arm_w30.sh` | `w29l_arm_w29.sh` | the 5-cell arm + manifest + `READY` marker |
+| `score_w30g.py` | `score_w29l.py` | `RULE W30-G` — the flow scorer |
+| `score_w30d.py` | *(new)* | `RULE W30-D` — the ledger checker |
+| `kcol_w30.py` | *(new)* | the `K` column extractor |
+
+**Standing constraints, every one of them earned:**
+
+- **`--out` mandatory and REFUSING without it** on every instrument. The plan's command lines in
+  `plans/synthetic-af-bank-followups-wave30-plan.md` §0 are **checked against each instrument's own `usage:`
+  line at Step 1** — wave 29's plan wrote `bash fp_w29.sh after` with no `--out` against its own standing
+  constraint, and the controller had to deviate.
+- **`--rule` asserted against the file's own declared rule name** ([F90](followups.md)) — a hard refusal.
+  `verify_derivation_w29.py` accepts `--rule` (its `argparse` declares it at `:748`); `V30` keeps it and
+  asserts it.
+- **Populations asserted; ordinals and counts COMPUTED, never typed** (`V30-C`), including the **gate order**
+  (§4.1(c)), the **axis step** (§2.4) and the **material bar** (§4.4).
+- **Paths handed to scorers through a MANIFEST** ([F74](followups.md)), never rebuilt from a template.
+- **BEFORE/AFTER from ONE expression called twice** ([F91](followups.md)); population size asserted **equal**
+  before any hash is compared; the fingerprint written **outside** every tree it sweeps.
+- **`find … -print0 | sort -z | xargs -0`** — `/mnt/d/Autofocus Bank` contains a space.
+- **`cp` without `-p`; `touch` after every copy or restore** ([F89](followups.md)).
+- Provenance: `git diff --name-only <tree> -- '*.cs'` **unioned with** `git ls-files --others
+  --exclude-standard -- '*.cs'` ([F88](followups.md)); the B15 tree hash read out of
+  `/mnt/d/hf_w25/binary_provenance_w25.txt`, **never assumed from a previous HEAD**. Note wave 29 §9's
+  correction: that file's `tree:` line holds a **commit**, and the field name is wrong wherever it is quoted.
+- **Pass scorers WSL paths.** A Windows path yields `UNEVALUATED` and looks like a failed arm.
+- `TestApp.exe` gets `< /dev/null`; `--settings` **and** `--profile-id` pinned on the arm, `--settings` pinned
+  to the file wave 28's log records (`…\HocusFocusHarness\harness_settings.json`, sha256 `b7e81813…`) and
+  recorded in the manifest; **one `TestApp.exe` at a time**; **no directory rebuilt mid-wave.**
+- **Read-only for the whole wave:** every root in §6's table.
+
+**Every conclusion in this wave is synthetic-only.** The bank has no real under-sampled dataset
+([F35](followups.md), [F43](followups.md)) and `W30-G` is **one dataset, `D01_ultrawide_40mm`**, named as one
+dataset everywhere it is quoted.
+
+---
+
+## 15. WHAT WAVE 30 WILL NOT RUN, AND WHAT IT COSTS
+
+| not run | price | why, and is it owed |
+|---|---|---|
+| the 42 m `optimize` gate | 42 m | **NOT OWED** — no C# (§9), checked rather than asserted at Step 8. Owed by the wave that ships anything from §10 |
+| the unit suite | ~4 m | Vacuously satisfied. Baseline for the wave that changes C# is **3997**, not 3973 |
+| `P-D08` at `n = 3` | ~2 m | **NOT OWED — already paid**, 09:06–09:09Z, `e42e2df`, `/mnt/d/hf_w26/pd08/`. §2.1 |
+| the closing `V29` | ~2 m | **NOT OWED — already paid**, 18:18:01Z, `vdrift_w29_CLOSING.txt`. §2.2 |
+| PR #197's title correction | ~1 m | **NOT OWED — already paid.** §0 |
+| re-targeting #196/#197's PR bases | ~2 m | **Recommended to the owner, not done by wave 30** (§0). It edits open PRs the owner may be reading |
+| `S27-1` and wave 27's three mutants | ~20 m | **FOUR waves open.** §16 registers its **withdrawal** rather than listing it a fifth time |
+| a second `MaxDistortion` dose beyond `M4` | ~3 m each | The axis has 10 steps; wave 30 measures 3 of them and says so |
+| a full paired 18-cell S1 arm | ~2 h 40 m | Unchanged: a second arm buys a second `SAME 13` |
+| new datasets between 1.4 and 19.4 ″/px | ≥ 1 h render | The coverage hole, eleven waves running |
+| the blur/layer decoupling build ([F92](followups.md)) | ~45 m + 10 m (+42 m to ship) | Unchanged |
+| the `A4` truth-model gap | 20 m code **+ 42 m gate** | Made more urgent by [F96](followups.md), not less |
+| anything on real frames | — | The bank has no real under-sampled dataset |
+
+---
+
+## 16. REGISTER ENTRIES OWED, whatever the verdicts
+
+The register's highest existing entry is **F103**.
+
+- **F104** — `RULE W30-G`'s verdict, with the full capture matrix, `Σ R_g`, `recapture`, `survive_g` per gate,
+  `ΔTP(M3)` against the computed material bar, and the F22 caveat inline. Framed as **goal 3** per §2.7;
+  **forbidden** from quoting a recall gain as a product benefit.
+- **F105** — the **gate-flow conservation identity** (§4.2) as a *specification of the attribution report*,
+  with `G-1`'s verdict. If `G-1` holds, this is the first checked model of these reports in eleven waves. If it
+  fails, it is the largest instrument finding this series has produced and it invalidates every gate-count
+  difference waves 28 and 29 published.
+- **F106** — **the stale debt.** `P-D08` at `n = 3` was measured, published and committed at 09:06–09:09Z on
+  2026-08-13 and was carried on wave 29's owed list at 18:05Z the same day, because the search was for an
+  artifact *under the wave's own root* rather than for the measurement. [F85](followups.md)'s class, recurring
+  inside a single day. With `RULE W30-D`'s verdict and every other stale row it names.
+- **F107** — **the vessel.** #196 and #197 both target `develop`, so #197's own diff carries waves 27, 28 and
+  29 plus wave 27's C# ship (25 files, measured). Opening a fresh branch relocates accretion; **only the PR
+  base prevents it.** With the recommendation to re-target both.
+- **[F99](followups.md) — AMEND IN PLACE** with `W30-G`'s verdict: its hypothesis confirmed or refuted, named
+  as such, and its "the statistic must be the per-gate flow" half either vindicated by §4.2's identity or
+  superseded by it.
+- **[F98](followups.md)** — append the first measurement of the *low* end of the `MaxDistortion` axis, and
+  whether part 2's axis-bound proposal gains or loses support.
+- **[F103](followups.md)** — append wave 30's five-root fixture measurement against §7's forward prediction.
+  **This is the second consecutive test of the series' only falsifiable forward claim about its own
+  instruments.**
+- **[F94](followups.md)** — append whether the `None` enumeration plus the **realized-tuple membership
+  assertion** caught anything the count would have missed.
+- **[F102](followups.md)** — append whether any clause's `candidates: N` printed `0` and refused, i.e. whether
+  a vacuous clause existed and was caught at the moment it was written rather than three waves later.
+- **[F95](followups.md)** — append that wave 30 ran the pre-flight over a populated root **and** at the close,
+  both from the pre-registration rather than from a debt.
+- **[F21](followups.md)** — estimate vs actual per step, plus the measured constant for the **trimmed** root
+  set (~2.4 GB) against wave 29's ~41.8 GB, so a later wave can price a sweep from its own declared roots.
+- **`S27-1` and wave 27's three mutants — WITHDRAWN**, formally, after four waves on the cut list. Wave 29 §13
+  said cutting it a fifth time should mean withdrawal; wave 30 withdraws it rather than listing it again.
+- **`docs/synthetic-af-bank-results-table.md`** — the `K` column from `truthModel.max(hfrMin, hfrMinEffective)`
+  (source: `synthetic_meta.json`, §2.6), the note that `D01`/`D02`/`D03` are the only three floored by the
+  generator, and **no 2–4 px band claim below the band** (`W28-B` = `B-SPLIT`). Owed by waves 28 and 29; §13
+  says it is paid or withdrawn this wave, not re-listed.
+
+---
+
+## 17. THE STOP QUESTION, answered
+
+Wave 29 §13 wrote the honest forward-looking sentence: *"items 2 and 4 above are the last two product questions
+this bank can answer without new data, and once they are closed, the next wave that cannot name a product
+question should stop rather than audit its own instruments a fourth time."*
+
+**Wave 30 is item 2. It names its product question in §1 and it is a real one:** a knob landed at an extreme on
+the rig where the physics is hardest, and nobody has ever opened the gate that plausibly holds it. So wave 30
+runs.
+
+**What wave 30 owes the wave after it, stated now rather than discovered later.** After `W30-G` lands, the
+bank's remaining product questions are:
+
+1. **item 4** — bound the `MaxDistortion` axis and rename it (F98 part 2), which `W30-G` will have supplied the
+   evidence for;
+2. **item 3** — choose among F82's three fixes, which needs no new measurement at all;
+
+and **both are ships, not measurements.** Neither needs another arm on this bank. So the honest statement wave
+30 hands forward is: **after wave 30, this bank has no unanswered product question that another synthetic arm
+can address.** Waves 31 and 32 should be the two ships, each with its 42 m gate, and **the wave after those
+should stop** — or render the 1.4–19.4 ″/px datasets that [F35](followups.md)/[F43](followups.md) have named as
+the coverage hole for eleven waves, which is the only thing that would give this series a new blind population.
+
+**A wave that cannot name a product question should stop rather than audit its own instruments a fifth time.**
+Wave 30 can name one. It is the last time that sentence is expected to be true without new data.

--- a/docs/synthetic-af-bank-followups-wave30-results.md
+++ b/docs/synthetic-af-bank-followups-wave30-results.md
@@ -1,0 +1,1239 @@
+# Wave 30 — results
+
+## THE TIMESTAMP — the roll call, taken at an instant
+
+```
+$ date -u '+%Y-%m-%dT%H:%M:%SZ'; ls -la --time-style=full-iso /mnt/d/hf_w30/
+2026-08-13T19:56:41Z
+drwxrwxrwx  ...  2026-08-13 15:55:35.089538800 -0400 .
+```
+
+**No row was open at that instant, and that is asserted rather than assumed.** The newest artifact under the
+root is `vdrift_w30_CLOSING.txt` at `15:55:59.941 -0400` (`= 19:55:59Z`), **42 seconds before the roll call**;
+a `ps` taken in the same call returned **zero** `TestApp` and zero `python3` processes. Wave 29's document had
+to mark one row open mid-write; wave 30 has none, and the check was still made, because "nothing looked open"
+is not the same fact as "nothing was running."
+
+| row | state at **19:56:41Z** | artifact |
+|---|---|---|
+| `RULE W30-G` arm | **CLOSED** — `W30G_ARM_END 19:52:10Z`, 5 of 5 cells `exit=0`, 2 cells imported, interlock written by the driver | `w30g_arm.txt`, `w30g_manifest.tsv`, `W30G_MANIFEST_READY`, `g/out/M{0..4}.log` |
+| `RULE W30-G` scoring | **CLOSED** 19:52:25Z | `w30g_score.txt` |
+| `RULE W30-D` | **CLOSED** 19:53:49Z; manifest + interlock 19:52:56Z | `w30d_score.txt`, `w30d_manifest.tsv`, `W30D_MANIFEST_READY` |
+| `RULE V30` (pre-flight, populated root) | **CLOSED** 19:34:09Z; an earlier populated run at 19:27:34Z | `vdrift_w30.txt`, `instrumentcheck/vdrift_populated.txt` |
+| `RULE V30` (**closing**) | **CLOSED** 19:55:59Z — **byte-identical** to the opening run | `vdrift_w30_CLOSING.txt` |
+| `W30-FP` BEFORE sweep | **CLOSED** 19:24:56Z, `POPULATION 1230` | `fp_BEFORE.txt`, `fp_before_run.txt` |
+| `W30-FP` AFTER sweep + verdict | **CLOSED** 19:55:34Z | `fp_AFTER.txt`, `fp_after_run.txt` |
+| the six instrument self-tests | **ALL CAPTURED** 19:19:11–19:33:44Z | `w30g_selftest.txt` (59), `w30g_arm_selftest.txt` (58), `w30d_selftest.txt` (37), `vdrift_selftest_w30.txt` (37), `fp_selftest.txt` (27), `instrumentcheck/kcol_selftest.txt` (21) |
+| the five `V30` fixture probes | **CLOSED** 18:58:02–18:58:52Z — and see §7.4 on their ordering | `instrumentcheck/probe_hf_w2{4,6,7,8,9}.txt` |
+| **Step 7, the results-table `K` column** | **NOT RUN.** The instrument exists and self-tests `21 of 21`; no column was emitted and `docs/synthetic-af-bank-results-table.md` is unchanged | `kcol_w30.py` only |
+| `instrumentcheck/vdrift_selftest.txt` | **EMPTY ARTIFACT**, 0 bytes, 19:27:53Z. The real capture is `vdrift_selftest_w30.txt` (§7.5) | — |
+
+**Vessel, and it changed mid-wave at the owner's instruction.** Wave 30 did **not** open a fresh branch.
+Waves 27, 28, 29 and 30 all sit on the single branch `ghilios/synthetic-af-bank-followups-wave27` =
+**PR #196** (`OPEN`, base `develop`, title *"Waves 27-30: audit the truth-protection correction, the wide-field
+gap, F82's carrier, and which gate binds on D01"*). **PR #197 is `MERGED`** (into `…wave27`, i.e. re-targeted
+exactly as the design §0 recommended) and **PR #199 is `CLOSED`**. The branch was **rebased onto
+`develop @ ec06bec` and force-pushed** with `--force-with-lease`; `ec06bec` is verified an ancestor of `HEAD`
+`1e7de32`. **Design §0 argued for a fresh branch with a stacked base, and that decision was overruled by the
+owner.** §9 records it as such.
+
+---
+
+## §0 — What this document is allowed to say
+
+Every number below is quoted from an artifact under `/mnt/d/hf_w30/`, from `/mnt/d/hf_w29/`, `/mnt/d/hf_w27/`,
+`/mnt/d/hf_w26/` or `/mnt/d/hf_w25/`, or from a file in the repository at `HEAD`, and each is cited. The
+pre-registered rules in `docs/synthetic-af-bank-followups-wave30-design.md` are **applied as written**. Where a
+rule turned out to be under-specified or directionally wrong, that is reported as a **finding** (§5, §8) — it is
+not repaired, and no repaired version is scored.
+
+**Everything below is synthetic-only.** The bank has no real under-sampled dataset
+([F35](followups.md), [F43](followups.md)), and `RULE W30-G` is **one dataset, `D01_ultrawide_40mm`**, named as
+one dataset everywhere it is quoted.
+
+**The [F22](followups.md) fence, and it is enforced in the instrument, not only in this prose.**
+`score_w30g.py` prints the caveat **before its first number**, tags **every** line carrying a recall or
+true-positive count with `[F22]`, prints the caveat **again at the verdict**, and closes with:
+
+> *"FORBIDDEN, in writing, by design section 2.7: nothing this wave writes may quote a recall gain on this
+> dataset as a product benefit. The deliverable is which gate binds, a goal-3 question."*
+
+On this rig the detector's HFR over-reads by a large factor below ~1.1 px measured HFR and its autofocus
+already lands (`BestJ 0.994825`). **Recall recovered here is not a focus improvement and is not quoted as
+one.** Every count in §2–§4 carries the `[F22]` tag in its source artifact and is read in the goal-3 frame
+only: *is a landed knob sitting at an extreme against the physics?*
+
+**Verdicts, in one table.**
+
+| rule | verdict | population | artifact |
+|---|---|---|---|
+| **`W30-G`** | **`G-NOT-RECOVERABLE`** — `G-0` True, `G-1` True, `G-2` True, `G-3` False | 5 run cells + 2 imports on `D01_ultrawide_40mm`; 45 frame evaluations | `w30g_score.txt` |
+| **`W30-D`** | **`D-STALE`** — `D-0` True, `D-1` False; 6 of 10 debt-claiming rows flagged | wave 29 §11's 14-row table | `w30d_score.txt` |
+| **`W30-FP`** | **`PRESERVED`** — 1230 of 1230 byte-identical, 0 moved | 6 declared roots, 1230 files after dedup | `fp_BEFORE.txt` / `fp_AFTER.txt` |
+| **`V30`** | **`V-CLEAN`** at the open **and** at the close, the two runs byte-identical | `-A` 12, `-B` 5026, `-C` 667 | `vdrift_w30.txt`, `vdrift_w30_CLOSING.txt` |
+
+The realized clause tuple was **asserted a member of the enumerated set** in all four: `W30-G`
+`(True, True, True, False)` over **36** regions, `W30-D` `(True, False)` over **6**, `V30`
+`(True, True, True)` over **12**, `W30-FP` `(True, True, True)` over **18**. `uncovered: 0` in every case.
+
+---
+
+## §1 — THE HEADLINE: the outcome was called either way, in writing, before the data
+
+`RULE W30-G` returned **`G-NOT-RECOVERABLE`**. That is **PREDICTION B — this wave's own design §4.6 — and it
+refutes PREDICTION A, [F99](followups.md)'s joint-recovery claim.**
+
+Both predictions were written into the pre-registration, in the same section, one paragraph apart, before the
+arm ran:
+
+> **Prediction A, inherited — F99's hypothesis: `G-JOINTLY-BOUND`.** `TooDistorted` and `LowSensitivity` bind
+> jointly; no single knob recovers `D01`; opening the pair recovers materially more than the sum of the singles.
+>
+> **Prediction B, this document's own, and it differs: `G-NOT-RECOVERABLE`.** […] I expect a large
+> `R_TooDistorted`, `recapture` well above 0.90, and `ΔTP(M3)` **below** the 503-star material bar — i.e. F99's
+> mechanism confirmed and F99's *joint recovery* claim refuted.
+
+**Why this is the strongest evidential form this series has produced.** A wave that registers **one** prediction
+and then finds it has demonstrated only that its author could guess. The reader has no way to price the guess,
+because the counterfactual — what the wave would have written had the number gone the other way — was never
+committed to paper. A wave that registers **two rival predictions, attached to two distinct terminal verdicts of
+the same enumerated tree**, has no such escape: whichever region the data lands in, some named document is
+wrong, in writing, and the wave cannot claim a hit it did not call. Wave 30 landed in `G-NOT-RECOVERABLE`, so
+**F99 is refuted at the pre-registered bar and the design is vindicated at it — and had the tuple come back
+`(T,T,T,T)`, the design would have been refuted by its own rule** in exactly the way wave 29's headline claim
+was (see wave 29's CORRECTION block).
+
+Compare wave 29, which registered `L-JOINTLY-BOUND` alone and got `L-UNEVALUATED`: the rule could not evaluate
+its own prediction, and the wave learned that only after the fact. Wave 30's two-prediction form makes the
+"after the fact" impossible by construction.
+
+**And Prediction B was right for the reason it gave, not by luck.** Its stated mechanism was: *"a candidate
+released by `TooDistorted` at 0.3 is a small, low-fill blob; a 11 % relaxation of a 36 σ bar does not turn a 5 σ
+blob into a detection."* The measurement says exactly that, in numbers §4 gives: of the **12 090** candidates
+`TooDistorted` releases at 0.3, **9 676 (80.0 %)** are taken straight back by `LowSensitivity`; opening
+`LowSensitivity` by 11 % on top of that converts only **92** of those 9 676 (**0.95 %**) into acceptances. The
+interaction term is real and is negligible.
+
+---
+
+## §2 — `G-0` HOLDS, and it is load-bearing beyond this wave
+
+`G-0` is seven sub-assertions, each with its own printed population, each able to drive the rule to
+`G-UNEVALUATED` on its own. All seven held.
+
+| sub-assertion | population | result |
+|---|---|---|
+| (i) all run cells `exit=0` | 5 | 0 findings |
+| (ii) each cell echoes its intended knobs, read from the report's own `key detector knobs:` line | 7 | 0 mismatched |
+| (iii) **`M0` reproduces the published `L0` block field-for-field** | 8 fields (bar: ≥ 8) | **0 disagreeing** |
+| (iv) the source gate order is identical across the trees the arm read | 3 trees, chain length 11 | 0 findings |
+| (v) the four defocus preconditions of design §4.1(b) hold in the landed tree | 4 | 0 violating |
+| (vi) every edited JSON key resolved uniquely | 4 | `MAXDIST→MaxDistortion`, `MINBOX→MinStarBoundingBoxSize`, `NC→NoiseClippingMultiplier`, `SENS→BrightnessSensitivity` |
+| (vii) dll sha256 matches the recorded provenance | 2 | manifest, provenance and on-disk dll all agree |
+
+**The control that can fail, and did not.** `M0` re-ran wave 29's `L0` on the same binary, same frames, same
+seed tree, and reproduced it **exactly**:
+
+| field | published `L0` | `M0` |
+|---|---|---|
+| `ACCEPTED-elsewhere` | 701 | 701 |
+| `NO CANDIDATE (structure gap)` | 8 931 | 8 931 |
+| `REJECTED:Contaminated` | 533 | 533 |
+| `REJECTED:LowSensitivity` | 13 612 | 13 612 |
+| `REJECTED:NotCentered` | 147 | 147 |
+| `REJECTED:OnBorder` | 77 | 77 |
+| `REJECTED:TooDistorted` | 14 876 | 14 876 |
+| `REJECTED:TooSmall` | 11 372 | 11 372 |
+
+Those eight sum to **50 249**, which is `FN_total(M0)` on the nose. **This is what licensed the two imports**
+(`L1`, `L3`), and the licence was granted by a measurement, not by an argument, and the design fixed before the
+data that failing it would void the imports and force `G-UNEVALUATED` rather than a fallback.
+
+**Corroborating evidence that all five cells did real work.** Wave 29's two dead cells (`MaxDistortion` raised
+to 0.9, above the π/4 ceiling) were its two *fastest*, because nothing survived the gate to do downstream work.
+Wave 30's five cells ran **187 / 227 / 194 / 208 / 204 s** against wave 29's 177 s reference — every one of them
+**slower** than the reference, i.e. every one of them doing downstream work. Total **1 057 s**, inside the
+pre-registered band **725–1 600 s**, against a point prediction of ~950 s.
+
+**The `MaxDistortion` direction was verified in source by the arm itself, at run time.** The arm printed:
+
+> *"distortion gate: rejects when `'fillRatio < effectiveMaxDistortion'`, so the threshold is a MINIMUM fill
+> ratio and RELAXING IT MEANS LOWERING IT; the perfect-disk ceiling is PI/4 = 0.7853981634"*
+
+and the **11-gate order was extracted from the per-candidate routine and asserted identical at the working
+tree, at `HEAD`, and at B15's commit `29665a62e4f8`** — three trees, `GATE_ORDER_AGREES=yes` in the manifest.
+Wave 29 spot-checked one precondition and typed its gate order into a design table; wave 30 typed neither.
+
+**Why `G-0` matters past this wave.** The whole point of (iii) is that it is the same measurement waves 28 and
+29 published, taken again on a different day by a different instrument. It reproduced to the digit on eight
+independent counts. **So the bank's `golden_eval` attribution block is deterministic and reproducible across
+waves on this binary**, which is the premise every gate-count difference in waves 28 and 29 silently relied on.
+Combined with `G-1` (§3), it is now checked rather than assumed.
+
+---
+
+## §3 — `G-1` HOLDS: the conservation identity balances EXACTLY on real data, 5 of 5
+
+Design §4.2 specified the attribution model as something that could **fail**:
+
+> `R_g = Σ_{h downstream of g} ΔFN_h + ΔContaminated + ΔACCEPTED-elsewhere + ΔTP`, **exactly, in integers**,
+> with `ΔNO-CANDIDATE = 0` and `ΔFN_h = 0` for every `h` strictly upstream of `g`.
+
+**Five single-knob cells, five exact balances, no tolerance, integer equality.**
+
+| cell | knob | gate (position of 11) | `R_g` | balance |
+|---|---|---|---|---|
+| `M1` | `MaxDistortion` 0.5 → 0.3 | `TooDistorted` (4) | **12 090** | 12 090 == 12 090 ✓ |
+| `M2` | `BrightnessSensitivity` 36.333 → 32.333 | `LowSensitivity` (6) | **486** | 486 == 486 ✓ |
+| `M4` | `MaxDistortion` 0.5 → 0.2 | `TooDistorted` (4) | **14 425** | 14 425 == 14 425 ✓ |
+| `L1` *(import)* | `MinStarBoundingBoxSize` 6 → 3 | `TooSmall` (1) | **9 537** | 9 537 == 9 537 ✓ |
+| `L3` *(import)* | `BrightnessSensitivity` 36.333 → 35.333 | `LowSensitivity` (6) | **122** | 122 == 122 ✓ |
+
+Every cell's invariants — `NO-CANDIDATE`, the pre-chain stage `BloomSuppressed`, and every gate strictly
+upstream — came back **all zero**, as the model requires.
+
+**This is the first checked model of these reports in eleven waves, and it should be said plainly what it
+buys.** The design pre-computed the identity against wave 29's `L0/L1` and `L0/L3` pairs and it balanced
+twice; that was a check against **published inputs**. Wave 30 balanced it three more times against cells
+**nobody had ever run** — `M1`, `M2` and `M4` are blind by design §8 — and it held to the integer.
+
+**The consequence is the one design §11 named as the `G-MODEL-BROKEN` branch's inverse: waves 28's and 29's
+gate-count differences are safe to read.** Had `G-1` failed, the verdict would have been
+`G-MODEL-BROKEN`, *"a FINDING: the report's first-rejection-wins attribution does not conserve, and every
+gate-count difference in waves 28 and 29 is unsafe."* It did not fail. **First-rejection-wins is the correct
+model of `golden_eval`'s attribution block, and every Δ-on-a-bucket that waves 28 and 29 published can be read
+as a flow.** That is a licence granted by measurement to two earlier waves' arithmetic, and it is worth more
+than this wave's own product answer.
+
+**And the identity's fail end is exercised, not merely asserted.** `score_w30g.py`'s self-test clause `[2]`
+moves one bucket by one on a live fixture and the balance breaks; clause `[9]` drives a non-conserving cell all
+the way to `G-MODEL-BROKEN` with a non-zero exit. A balance that cannot fail is not evidence.
+
+### 3.1 A reported difference from the design, named by the instrument rather than repaired
+
+The design's §4.1(c) table listed **7** gates and asserted `TooElongated` absent. The arm's run-time extraction
+found **11**:
+
+```
+TooSmall, OnBorder, TooElongated, TooDistorted, Degenerate, LowSensitivity,
+NotCentered, TooFlat, HFRAnalysisFailed, TooLowHFR, Contaminated
+```
+
+plus a **pre-chain** stage `BloomSuppressed`, asserted invariant and never spliced into the sequence. The
+scorer printed the difference at the top of its own artifact:
+
+> *"the destinations are partitioned ONCE from the chain above. The design's formula names the contamination
+> bucket as a separate terminal while source makes it the LAST GATE of this chain; counted twice it would
+> double, so it is counted once, as a downstream gate. **This is a reported difference from the design, not a
+> repair.**"*
+
+That is the correct handling and it is worth recording as a positive: the design's hand-typed 7-gate table was
+wrong, the instrument's extraction was right, the instrument said so in its own output rather than silently
+conforming, and the double-count that the design's formula would have produced was avoided. **`G-1`'s exact
+balances are themselves the proof that the 11-gate partition is the right one** — the design's 7-gate partition
+could not have balanced, because `Contaminated` would have appeared on both sides.
+
+---
+
+## §4 — `G-2` True and `G-3` False: re-capture dominates, and the joint is material but ADDITIVE
+
+### 4.1 The capture matrix — this wave's product, published in full
+
+`C[g → h]`: where every released candidate went. A `.` is a bucket **upstream** of that cell's gate, which the
+model says cannot move, and the zero-invariants above are what assert it. **Every count below carries `[F22]`
+in the source artifact.**
+
+| cell | gate `g` | `R_g` | OnBorder | TooDistorted | Degenerate | LowSensitivity | NotCentered | TooFlat | Contaminated | ACCEPTED-elsewhere | **ΔTP** |
+|---|---|---|---|---|---|---|---|---|---|---|---|
+| `L1` | `TooSmall` | 9 537 | 10 | 5 697 | 5 | 3 814 | 7 | 1 | 0 | 0 | **3** |
+| `L3` | `LowSensitivity` | 122 | . | . | . | . | 12 | 0 | 4 | 5 | **101** |
+| `M1` | `TooDistorted` | 12 090 | . | . | 0 | **9 676** | 931 | 0 | 57 | 330 | **1 096** |
+| `M2` | `LowSensitivity` | 486 | . | . | . | . | 52 | 0 | 6 | 44 | **384** |
+| `M4` | `TooDistorted` | 14 425 | . | . | 0 | **11 652** | 1 130 | 0 | 61 | 390 | **1 192** |
+
+*(`HFRAnalysisFailed` and `TooLowHFR` are columns of the published matrix and are `0` on every row; they are
+omitted here for width and are in `w30g_score.txt` in full.)*
+
+### 4.2 `G-2` = True: **re-capture dominates — what the gates release is taken by gates downstream**
+
+```
+sum R_g over ALL single-knob cells   : 36 660
+sum capture_g over ALL single-knob cells : 33 884
+recapture = sum capture_g / sum R_g  : 0.9243   (bar 0.90)
+recapture EXCLUDING the fenced cell M4 : 0.9288
+```
+
+**92.4 % of everything these knobs release is re-caught by a gate further down the chain.** The two figures
+agree on the verdict, so the fenced cell does not carry it.
+
+The mechanism is legible in one column of the matrix. `TooDistorted` at 0.3 releases 12 090 candidates and
+**`LowSensitivity` alone absorbs 9 676 of them — 80.0 %**. At 0.2 it releases 14 425 and `LowSensitivity`
+absorbs 11 652 — 80.8 %. **This is [F99](followups.md)'s mechanism, confirmed with a number and on the gate F99
+named**, and it is the same shape F99 measured for `MinBox`: `L1` releases 9 537 from `TooSmall` and
+`TooDistorted` + `LowSensitivity` take back 9 511 of them.
+
+The design pooled `recapture` rather than comparing per-gate pass-through, and the artifact says why on the
+line itself: *"per-gate pass-through is NOT comparable, because the last gate before acceptance has a high
+pass-through by POSITION."* That fence is honoured here. **Within one gate across two doses** the comparison is
+legitimate, and it is informative:
+
+| gate | dose | `R_g` | `ΔTP` | pass-through |
+|---|---|---|---|---|
+| `TooDistorted` | 0.5 → 0.3 | 12 090 | 1 096 | 9.1 % |
+| `TooDistorted` | 0.5 → 0.2 | 14 425 | 1 192 | 8.3 % |
+| `LowSensitivity` | 36.333 → 35.333 | 122 | 101 | 82.8 % |
+| `LowSensitivity` | 36.333 → 32.333 | 486 | 384 | 79.0 % |
+
+**The second `MaxDistortion` dose buys almost nothing.** Going 0.3 → 0.2 releases **2 335 more** candidates and
+converts **96 more** of them — a **4.1 % marginal pass-through**, less than half the first dose's already-low
+9.1 %. The axis's low end is exhausted well before its floor of 0.1.
+
+### 4.3 `G-3` = False: the joint clears the material bar and misses the interaction bar
+
+```
+dTP(M3), the joint cell                    : +1 572   [F22]
+sum of dTP over the unfenced singles       : +1 480   [F22]
+FN_total(M0), the misses being explained   : 50 249   [F22]
+the material bar, COMPUTED as 0.01 x FN_total(M0) : 502.5 star(s)   [F22]
+
+dTP(joint) >= material bar (502.5)          : True    [F22]
+dTP(joint) >= 2.0 x sum(dTP singles) (2960.0) : False [F22]
+```
+
+**Both halves matter and they say different things.**
+
+- **The joint IS material.** 1 572 clears a bar of 502.5 by 3.1×. Opening these two gates together is not a
+  null result. It reaches **3.1 % of `FN_total(M0)`**, and 5.5 % of the 28 488 high-tier misses those two gates
+  jointly hold.
+- **The joint is essentially ADDITIVE, not synergistic.** `1 572` against `1 096 + 384 = 1 480` is an
+  interaction term of **+92**, i.e. **+6.2 % over pure additivity**. F99's claim was that the pair binds
+  *jointly* — that the whole exceeds the sum because each gate re-catches the other's release. The design set
+  the bar for "jointly" at **2× the sum**. The measured multiple is **1.06×**.
+
+`(True, True, True, False)` → **`G-NOT-RECOVERABLE`**, one region of thirty-six, asserted a member of the
+enumerated set.
+
+### 4.4 What this answers, in the goal-3 frame the F22 fence permits — and it is a NEGATIVE
+
+The product question of design §1 was: *is any landed knob on `D01` pinned against the physics in a recoverable
+way?*
+
+**Answer: no.** The reasoning, entirely from the pre-registered statistic:
+
+1. **`MinStarBoundingBoxSize` landed at 6 against a shipped default of 5** — the one knob that visibly sits at
+   an extreme. Its flow (`L1`) releases 9 537 candidates and **3** reach acceptance. Lowering it recovers
+   nothing; it is not holding real stars.
+2. **`MaxDistortion` landed at 0.5, mid-axis** (declared axis 0.1–1.0, step 0.1). It is not at an extreme, and
+   opening it two and three steps yields 9.1 % and 8.3 % pass-through with the balance absorbed one gate later.
+3. **`BrightnessSensitivity` is fenced** ([F84](followups.md) / `RULE S16`) and the scorer refuses to name it in
+   any verdict string. No statement here is evidence for or against a sensitivity bound.
+4. **The misses are structural, not knob-shaped.** Of `FN_total(M0)` = 50 249, the `NO CANDIDATE (structure
+   gap)` bucket holds **8 931** and `TooSmall` holds **11 372** — **40.4 % of all misses live upstream of the
+   two gates F99 named**, and no setting of either gate can reach them.
+
+**So the wave's own product question closes with a negative, and that is a real answer.** `D01`'s recall gap is
+the physics of a 19.4 ″/px rig with a ~0.7 px kernel, not an over-tightened optimizer landing. Design §1 said
+this is *"not a recall question; §2.7 fences that"* — and the F22 fence is what makes the negative honest
+rather than disappointing: even the joint's 1 572 could not have been quoted as a user benefit on a rig whose
+autofocus already lands at `BestJ 0.994825`.
+
+### 4.5 One thing the pre-registered statistic does NOT answer, named rather than back-filled
+
+**Whether opening `MaxDistortion` costs precision was not measured**, and it is the question wave 31's ship
+(item 4) actually needs.
+
+The statistic reads only the `FALSE-NEGATIVE ATTRIBUTION, HIGH TIER ONLY` block, which carries no false-positive
+count. What it *does* carry is the `ACCEPTED-elsewhere` terminal — a released candidate that was accepted but
+did not match the golden star it was released from — and that column is suggestive:
+
+| cell | gate | accepted & matched (`ΔTP`) | accepted, not matched | unmatched share of acceptances |
+|---|---|---|---|---|
+| `M1` | `TooDistorted` 0.3 | 1 096 | 330 | **23.1 %** |
+| `M4` | `TooDistorted` 0.2 | 1 192 | 390 | **24.7 %** |
+| `M2` | `LowSensitivity` 32.333 | 384 | 44 | 10.3 % |
+| `L3` | `LowSensitivity` 35.333 | 101 | 5 | 4.7 % |
+| `L1` | `TooSmall` 3 | 3 | 0 | 0 % |
+
+**The distortion gate's releases arrive with a two-to-five-times higher unmatched-acceptance share than the
+sensitivity gate's.** `ACCEPTED-elsewhere` is *not* a false positive — design §4.2 defines it as a candidate
+that may be matched elsewhere or fall in a contaminated region — so **this is a signal, not a measurement, and
+it is not scored.** It is recorded here because a ship that lowers `MaxDistortion`'s default or floor needs the
+real precision number, and §10 prices it as a new debt this wave created.
+
+---
+
+## §5 — `RULE W30-D` = `D-STALE`, and I VERIFIED ITS SIX ROWS MYSELF
+
+`D-0` held: **14 rows parsed**, heading matched exactly once, **0 unresolvable**, 6 of 6 declared roots present,
+ledger sha256 and resolution-table sha256 both re-asserted at scoring time. `D-1` came back **False** — **6 of
+10 debt-claiming rows** have a satisfying artifact — and the verdict is `D-STALE`, a FINDING, which is the
+pre-registered prediction.
+
+**The verdict stands and is not re-decided.** But the design charged this wave with naming every already-paid
+row, and **a false "already paid" is exactly as damaging as a false "owed" — worse, in the direction that
+matters, because a false "owed" costs you a re-run while a false "already paid" retires an obligation nobody
+ever met.** So each of the six was checked against what the ledger row actually claimed.
+
+### 5.1 The six rows, verified
+
+| # | row | matched artifact | genuine? |
+|---|---|---|---|
+| 1 | **the 42 m `optimize` gate** | `/mnt/d/hf_w29/l/opt/L{0..4}/attempt01/optimize_summary.txt` | **NO — matcher over-reach, twice over** |
+| 2 | **the closing `V29`** | `/mnt/d/hf_w29/vdrift_w29_CLOSING.txt`, 18:18:01Z | **YES — genuine, paid 15 min AFTER the ledger** |
+| 3 | **`P-D08` at `n = 3`** | `/mnt/d/hf_w26/pd08` + the published `RESULT` section | **YES — genuine, paid 7 h BEFORE the ledger** |
+| 4 | **localising `D01`** | `/mnt/d/hf_w30/w30g_manifest.tsv`, 19:52:10Z | **TRUE BUT CIRCULAR — paid by this wave, 13 min before it scored itself** |
+| 5 | a full paired 18-cell S1 arm | `/mnt/d/hf_w25/s1_arm_w25.sh` | **NO — matcher over-reach, twice over** |
+| 6 | `S27-1` and wave 27's three mutants | `/mnt/d/hf_w27/s27_*` (6 files) | **NO — matcher over-reach** |
+
+**Tally: 2 genuine, 1 true-but-circular, 3 false.**
+
+**Row 1 — FALSE.** The matched files are per-cell optimizer runs from wave 29's own `L`-arm. `L0`'s summary
+opens *"Runs root: `D:\SyntheticAutofocusBank\D01_ultrawide_40mm`; **Runs: 1 (attempt01)**"* — **one dataset,
+one run.** The row means the `Q27-V1` **8-dataset** gate: 42 m measured, ~5.2 m/run, predicted `G-PASS`, 8 of 8
+bit-identical to K8. A single-dataset optimize is not that gate. **And the row does not claim a debt at all** —
+its own third column reads *"**NOT OWED this wave, and it is checked rather than asserted.**"* Two independent
+errors: wrong referent, and a row that disclaims the debt scored as claiming one.
+
+**Row 2 — GENUINE, and it is the class the rule was built for, one clock-tick displaced.** The spec
+`^vdrift_w\d+_CLOSING\.txt$` under the ledger-scoped root is exactly right. `vdrift_w29_CLOSING.txt` has mtime
+18:18:01Z. Wave 29's roll call was **18:03:36Z**. **The ledger was true when it was written and became stale
+fourteen minutes later.** Design §2.2 had already verified independently that it is a genuine closing run — it
+post-dates `fp_AFTER.txt` (18:04:27Z) and the cross-wave check (18:05:04Z) — so the row is correctly flagged.
+
+**Row 3 — GENUINE, and it is the strongest one.** `P-D08` at `n = 3` was measured 09:06–09:08Z, published in
+`docs/synthetic-af-bank-followups-w26-pd08-followon.md` under a heading *"`# RESULT — P-D08 is REFUTED at n =
+3`"*, and committed as `e42e2df` at 09:09:37Z — **seven hours before wave 29 opened its branch.** The rule
+resolved it to scope `any` and found it under `/mnt/d/hf_w26/pd08` and in the docs directory. **This is the row
+that justifies the whole rule**, and it is found precisely by the scope distinction the rule makes mechanical.
+
+**Row 4 — TRUE BUT CIRCULAR, and this is a predicate defect, not a matcher defect.** The satisfying artifact is
+`w30g_manifest.tsv`, written at **19:52:10Z by wave 30's own arm**, and scored as "already paid" at 19:53:49Z —
+**ninety-nine seconds later.** The row was honestly open when wave 29 wrote it; wave 30 discharged it; the rule
+then reported the discharge as evidence that the ledger was stale. **`D-1` has no time ordering against the
+ledger document's own timestamp**, so a row paid seven hours *before* the ledger (row 3), a row paid fourteen
+minutes *after* it (row 2), and a row paid *by the checking wave itself* (row 4) are all scored identically.
+
+**Row 5 — FALSE, twice over.** (a) The match is `s1_arm_w25.sh`, the arm's **shell script**. A script is not a
+run; the file's own header describes what it *would* do. (b) The row's own text is *"Unchanged:
+`W-UNEXERCISED` means a **second** arm buys a second `SAME 13`."* **The row explicitly concedes that wave 25's
+arm ran and declines to run another.** Wave 25's arm is the row's premise, not its discharge.
+
+**Row 6 — FALSE.** The glob `^s27.*$` matched six files from wave 27's **`S27-4` do-no-harm arm**
+(`s27_after/`, `s27_arm_w27.sh`, `s27_manifest.tsv`, `s27_score.txt`, `s27_4_score.txt`,
+`s27_2_mutant_MS3.log`). The debt is two specific and quite different things, both recorded as open by wave
+27's own results:
+
+- **`S27-1`'s route agreement** — §7.3: *"`S27-1`'s route agreement was **not adjudicated**, by the scorer's
+  own printed statement"*, and §8.6 adds that the fifth field (`protectedDetections`) is single-routed and needs
+  a **pre-registered** second route.
+- **`M-S1` / `M-S2a` / `M-S2b` run records** — §7.4: *"`M-S3` now has a run record; `M-S1`, `M-S2a` and `M-S2b`
+  remain testimony."*
+
+**The one mutant that IS evidenced is `M-S3`, and `M-S3` was never the debt** — `s27_2_mutant_MS3.log` is
+precisely the record wave 27 said it *did* have. Worse, `s27_score.txt` opens with a controller annotation
+stating *"THIS FILE'S `>>> RULE R27 = R-DIFFERS` BANNER IS WRONG FOR THIS ARTIFACT AND MUST NOT BE QUOTED"* —
+so one of the six matches is a file the series has already marked unquotable. **This row would have retired a
+control that has been open for four waves and that two wave-27 ship-clauses relied upon.**
+
+### 5.2 What this says about `W30-D`'s own predicate
+
+**The verdict `D-STALE` survives** — it needs one genuine stale row and there are two (three if row 4 counts) —
+but the finding's magnitude is **2, not 6**, and the report must say so.
+
+Four things follow, and none of them is a repair:
+
+1. **`D-1` conflates three different facts** into one boolean: *the ledger was wrong when written* (row 3),
+   *the ledger has since been discharged by someone else* (row 2), and *the checking wave discharged it itself*
+   (row 4). Only the first is what "a hand-carried ledger rots" means. **A `paid_at < ledger_written_at`
+   comparison is the missing predicate**, and both timestamps are already in the rule's own manifest
+   (`LEDGER_DOC_SHA` pins the document; every match prints an mtime).
+
+2. **The rule replaced a hand-carried list with a hand-carried regex.** The resolution table's specs —
+   `^.*optimize.*\.(txt|log)$`, `^s1_arm.*$`, `^s27.*$` — are **filename globs typed by a human**, exactly the
+   kind of artefact the rule exists to stop trusting. Three of the six matched a file whose *name* contains the
+   row's word and whose *content* is a different thing entirely. **The list rots the same way; it just rots
+   silently, and in the more dangerous direction.**
+
+3. **`D-0` cannot see this, by construction, and that is the transferable class.** `D-0` asserts every row
+   resolves to **exactly one** predicate — and it did, 14 of 14, unresolvable 0. **A validity clause that checks
+   a row resolves *uniquely* cannot check that it resolves *correctly*.** This is the same shape as §8.1's
+   stale-`split()`-needle finding: an assertion that a key is *present* is not an assertion that it is the
+   *right* key.
+
+4. **The half of the rule that works is the scope distinction, and it should be kept.** It is what found row 3
+   (a MEASUREMENT, scope `any`, discharged wherever its artifact lives), and it is what correctly left **the
+   wave-29 BEFORE fingerprint** and **the three scorers' self-test captures** unsatisfied — both scoped
+   `ledger`, both genuinely not paid, both correctly reported so. **Every unsatisfied result the rule produced
+   is right.** The rule's errors are entirely one-directional: toward false "already paid."
+
+**`RULE W30-D` is not repaired and is not re-scored.** The above is reported, per design §12's standing rule
+that *"a clause whose population is unsatisfiable is a FINDING and is not repaired."*
+
+---
+
+## §6 — `W30-FP` = `PRESERVED`, and the trimmed root set paid for itself
+
+**1 230 of 1 230 byte-identical, 0 moved.** Six declared roots, per-root populations identical on both sides,
+asserted equal **before any hash was compared** ([F91](followups.md)):
+
+| root | population |
+|---|---|
+| `/mnt/d/SyntheticAutofocusBank/D01_ultrawide_40mm` | 32 |
+| `/mnt/d/SyntheticAutofocusBank` (`-name synthetic_meta.json`) | 19 |
+| `/mnt/d/hf_w25/exe` | 248 |
+| `/mnt/d/hf_w29` | 181 |
+| `/mnt/d/hf_w28/nc` | 310 |
+| `/mnt/d/hf_w25/table18` | 440 |
+| **after `realpath` dedup (1 of 1 231 dropped)** | **1 230** |
+
+Self-test `27 of 27`, including F91's own shape (*"differing MEMBERSHIP is UNEVALUATED, never a false
+VIOLATED"*), the empty-tree refusal, and an explicitly named design finding it did **not** repair:
+
+> *"DESIGN FINDING, NAMED NOT REPAIRED: `/mnt/d/hf_w18/seedA0` is READ by every cell (the seed tree the
+> settings are copied from) and is NOT in the declared read-only population, so an accidental write there would
+> not be caught by this wave's fingerprint."*
+
+**The §2.6 trim is measured and it delivered.** The sweeps' durations are not directly recorded — see §8.3 —
+but they are bounded by the surrounding artifact mtimes: **BEFORE ≤ 60 s** (bounded below by `fp_selftest.txt`
+at 19:23:56Z, above by `fp_BEFORE.txt` at 19:24:56Z) and **AFTER ≤ 105 s**. Against **wave 29's measured
+11 m 42 s** over 41.8 GB and its ~24 m two-sided owing, and against this design's own 3 m-per-side price. The
+17 GB `hf_w25/after` and 15 GB `hf_w25/before` roots were dropped with stated reasons and neither was read.
+**Justifying each entry cut a ~24 m obligation to under 3 m, and both sides were actually taken.**
+
+---
+
+## §7 — `RULE V30` = `V-CLEAN` twice, and the series' only falsifiable forward claim hit 4 of 4
+
+### 7.1 Both runs, and they are byte-identical
+
+| run | when | `-A` | `-B` | `-C` | verdict |
+|---|---|---|---|---|---|
+| open, over the **populated** root | 19:34:09Z | 12 of 12 resolve | 5 026 candidates, **0** findings | 667 candidates, **0** findings | **`V-CLEAN`** |
+| **closing** | 19:55:59Z | identical | identical | identical | **`V-CLEAN`** |
+
+`diff` of the two files: **identical**. Realized tuple `(True, True, True)`, **12** regions enumerated,
+`uncovered: 0`, membership asserted. Self-test **`37 of 37`**.
+
+**[F95](followups.md)'s remedy ran in both halves from the pre-registration rather than from a debt**, which is
+what wave 29 could not say: wave 29 ran the pre-flight over an empty root and paid its closing run late.
+
+### 7.2 [F103](followups.md)'s forward prediction — written one wave early, and all four legs confirmed
+
+Design §7 wrote, before the measurement:
+
+| leg | predicted at wave 29 | **measured at wave 30** | |
+|---|---|---|---|
+| `/mnt/d/hf_w28` **expires** as the `-B` fixture | 100 findings → **0** | **`-B` = 0** | ✓ |
+| `/mnt/d/hf_w29` becomes the new live `-B` fixture | large non-zero | **`-B` = 311**, first at `fp_w29.sh:47` | ✓ |
+| `/mnt/d/hf_w24` remains the durable `-C` fixture | **2**, fourth wave running | **`-C` = 2** (`gate_w24.sh:221`, `prov_w24.py:179`) | ✓ |
+| `/mnt/d/hf_w26` and `/mnt/d/hf_w27` stay asserted-silent | `-B` = 0 both | **0 and 0** | ✓ |
+
+**Four of four.** The load-bearing artifact is `vdrift_selftest_w30.txt` clause `[5b]`, which re-measures all
+five fixtures inline at 19:26:49Z and prints the expiry as a demonstration rather than a description:
+*"`/mnt/d/hf_w26` yields ZERO `V30-B` findings — **THE EXPIRY IS DEMONSTRATED**, which is why the `-B` fixture
+is pinned separately and re-measured every wave."* The standalone probe captures corroborate it.
+
+**This is the second consecutive test of the only falsifiable forward claim this series makes about its own
+instruments, and it passed both times.** A pinned per-clause fixture goes silent exactly one wave later, on
+schedule, and an instrument that inherits its fixture pin instead of re-measuring it will report a clean zero
+over a dead population.
+
+### 7.3 All three generations of the `historical_ranges` repair are carried and all four ends demonstrated
+
+Self-test clause `[6]` keeps every end all three generations established and invents none:
+
+- generation 1 (wave 27): the block is exempt (index 2) and the file after it is **not** (index 6);
+- generation 1 again: the **definition** of `HISTORICAL_BLOCKS` opens nothing — it is not an instance of itself;
+- generation 2 (wave 28): a line that *mentions* a marker without opening a bracket opens nothing;
+- generation 3 (wave 29, [F101](followups.md)): an unbalanced brace **inside a string** opens nothing, so the
+  tail of the file stays inside the checked population;
+- and the end a bare *"it reports findings now"* would miss: **a token INSIDE the declared historical literal is
+  NOT reported**, so the exemption survives the repair.
+
+F101's durable point — *each generation's self-test tested only the ends the previous generation broke* — is
+answered by keeping all four ends in one clause.
+
+### 7.4 A deviation: the BEFORE sweep did NOT precede every read of a declared root
+
+Design §6 put this in bold and priced it:
+
+> **"The BEFORE sweep is the FIRST thing any instrument does — Step 2 […] before `V30`'s fixture probes read
+> `/mnt/d/hf_w29` […]. The sweep is not a measurement; it is the baseline the measurements are judged against,
+> and it must predate every read of a declared root, including `V30`'s own probes."**
+
+**It did not.** The five fixture probes ran at **18:58:02–18:58:52Z**; `fp_BEFORE.txt` closed at **19:24:56Z**,
+**twenty-six minutes later**. `/mnt/d/hf_w29` is declared root #4 and the probe read it (311 `-B` findings).
+
+**Measured consequence: none.** `W30-FP` came back `PRESERVED`, 1 230 of 1 230, 0 moved, so nothing was
+written by the probes. **But the requirement the design put in bold was not honoured, and it is the same shape
+as wave 29's failure one step milder** — wave 29 took no BEFORE at all and it cost `W29-FP` its verdict on four
+of six roots. The lesson is unchanged and the ordering must be enforced by the driver, not by intent.
+
+### 7.5 Two smaller artifact defects, named not repaired
+
+- **`instrumentcheck/vdrift_selftest.txt` is 0 bytes** (19:27:53Z). The real capture,
+  `vdrift_selftest_w30.txt`, is 4 637 bytes and says `SELFTEST V30 37 of 37`. Harmless here because the real one
+  exists — but **an empty capture in an instrument-check directory reads exactly like a run**, and it is the
+  same family as [F95](followups.md)'s empty-population certification.
+- **The five probe captures predate the final `verify_derivation_w30.py`** (probes 18:58Z; checker mtime
+  19:01:05Z). They were produced by a version of the instrument that is no longer on disk. This does **not**
+  weaken §7.2, because clause `[5b]` of the self-test re-measures all five fixtures at 19:26:49Z with the final
+  checker and returns the same numbers — but the standalone captures should not be cited on their own.
+
+---
+
+## §8 — FINDINGS, by severity
+
+### 8.1 HIGH — a stale `split()` needle in `score_w30g.py`'s own self-test, which no checker in this apparatus can see
+
+**The defect.** `score_w30g.py`'s self-test clause `[6]` — the [F84](followups.md) / `RULE S16` sensitivity
+fence, one of the two fences the design declared load-bearing — sliced the artifact with
+
+```python
+reading = txt.split("READING: more than a tenth")[-1].split("FORBIDDEN")[0]
+```
+
+**The emitter stopped producing that text when the bar became computed.** `G-SINGLE-BINDS`'s reading line is now
+formatted from `G2_BAR` (`score_w30g.py:857`): *"READING: more than %.0f%% of the released mass reached
+acceptance…"*. The literal *"a tenth"* no longer appears anywhere in the output.
+
+**Why it was silent.** `str.split()` on an **absent** needle returns a **one-element list**, so `[-1]` handed
+back **the whole document**. The check below it — *"the fenced name appears in no verdict sentence"* — stopped
+being about a verdict sentence at all and became a document-wide absence check that passes trivially, because a
+correct run never emits the phrase anywhere. **It would have passed forever, on every future wave, while
+asserting nothing.**
+
+**What caught it, and what could not — this is the transferable half.**
+
+- The **blocking pre-flight** flagged the stale phrase **only where it was printed.** It found the emitter's
+  copy, not the self-test's.
+- **`V30-C` structurally cannot see this copy.** `V30-C` scans **printing lines** for typed ordinals and counts;
+  its population this wave was **667 lines** — *"printing lines 980, of which 273 carry a format slot and are
+  skipped."* **A needle passed to `split()` is not printed output.** It is excluded from `V30-C`'s population by
+  construction, not by accident.
+
+> **A checker that looks for typed ordinals in printed output cannot find a stale ordinal used as a KEY.**
+
+**The remedy, local and permanent.** Assert the anchor is **present**, and assert the slice is a **proper**
+substring so it can never widen to the whole text again:
+
+```python
+READING_ANCHOR = "READING: more than "
+check(READING_ANCHOR in txt, "the verdict-sentence anchor is PRESENT, so the slice below cannot silently widen")
+reading = txt.split(READING_ANCHOR)[-1].split("FORBIDDEN")[0]
+check(reading != txt and len(reading) < len(txt), "and the slice is a PROPER substring of the output, not the whole document")
+```
+
+**The self-test went `57 of 57` → `59 of 59`** — `instrumentcheck/score_g_selftest.txt` (19:19:11Z) versus
+`w30g_selftest.txt` (19:33:44Z) — and the anchor was shortened to the stable prefix so a change in the bar's
+formatting cannot re-break it.
+
+**Class.** This is [F102](followups.md)'s class — *a clause whose population quietly went empty while still
+printing a pass* — recurring in the wave that built F102's remedy, and in a form F102's remedy does not cover.
+F102's remedy makes populations **printable and refusable**; that works for populations the instrument
+*computes*. **The slice above is a population the instrument never counted**, so there was nothing to print.
+The generalisation: **`str.split()`, `str.partition()`, `re.search().group()` and every other "locate by
+literal" idiom silently degrades to a no-op or to the identity when its literal goes stale, and a population
+counter placed on the *output* cannot observe the *key*.**
+
+### 8.2 HIGH — `W30-D`'s row predicates are filename globs, and 3 of its 6 findings are over-reach
+
+Fully set out in §5.2. The one-line form: **a ledger checker built to stop a hand-carried list from rotting
+was itself built on a hand-carried list of filename regexes, and it rots in the direction that retires
+obligations nobody met.** Its scope machinery is sound and every *unsatisfied* result it produced is correct;
+every one of its three errors is a false "already paid."
+
+### 8.3 MEDIUM — the fingerprint records no start time, so the sweep rate could not be re-measured
+
+`fp_BEFORE.txt` and `fp_AFTER.txt` open directly with `ROOT …` and close with the population assertion. Neither
+carries a start timestamp or an elapsed figure, so the ~61 MB/s constant wave 29 measured could only be
+**bounded** this wave (§6), not re-measured. Wave 29 paid ~12 m per sweep on instinct-priced roots precisely
+because that constant did not exist yet; **losing the ability to refresh it is a slow leak.** Two lines in
+`w30_sweep` fix it.
+
+### 8.4 MEDIUM — `M4` is inside `G-2`'s pooled `recapture` despite being declared "fenced out of every verdict branch"
+
+Design §4.3 and §13 both say `M4` is *"fenced out of every verdict branch by construction, so cutting it changes
+no verdict."* In the implementation `M4` is in `G-1` (correctly — it is a conservation check) **and in `G-2`'s
+pooled `Σ R_g`**, which does carry a verdict. **The scorer handled this honestly**, printing both figures and
+the reconciliation:
+
+```
+recapture = sum capture_g / sum R_g       : 0.9243  (bar 0.90)
+recapture EXCLUDING the fenced cell(s) M4 : 0.9288
+the two agree on G-2, so the fenced cell does not change this verdict
+```
+
+So no verdict moves and the claim *"cutting it changes no verdict"* is true **as measured**. But it was not
+true **by construction**, which is what the design asserted, and had the two figures straddled 0.90 the wave
+would have had a fenced cell deciding a verdict. Named, not repaired.
+
+### 8.5 LOW — the design's hand-typed 7-gate chain was wrong; the instrument's extraction was right
+
+Covered in §3.1. Recorded as a **positive** about the instrument and a **negative** about typing an ordering
+into a design table. Design §14's own standing constraint — *"ordinals and counts COMPUTED, never typed,
+including the gate order"* — is exactly why the arm caught it.
+
+### 8.6 LOW — an empty capture and stale probe captures
+
+Covered in §7.5.
+
+---
+
+## §9 — CONTROLLER DEVIATIONS, all five, stated plainly
+
+**(i) ONE PR, at the owner's instruction, overruling the design.** Design §0 pre-registered a fresh branch
+`ghilios/…wave30` off `…wave29` with `--base ghilios/…wave29`, and argued at length that *"the mechanism that
+stops accretion is the PR base, and nobody set it,"* so that wave 30's PR would be *"the first PR in this family
+whose diff is one wave."* **The owner instructed instead: one PR for all four waves.** #197 was re-targeted to
+`…wave27` and **merged**; **#199 was closed**; waves 27–30 now sit on the single branch
+`ghilios/synthetic-af-bank-followups-wave27` = **PR #196**, base `develop`.
+
+**Recorded as an overrule, not as a design success.** The honest split is: the design's **diagnosis** — that the
+PR *base*, not the branch, is what stops accretion, and that #197's `develop` base made its own diff carry three
+waves — was correct and was acted on (the re-targeting the design recommended and declined to do itself was
+done). The design's **prescription** — a fourth branch with a stacked base, one wave per PR — was rejected in
+favour of consolidation. **Design §0's stated goal of a one-wave PR diff was not achieved and will not be.**
+
+**And the consolidation has one measured consequence for this wave's own gate check.** Design §9's reversal
+check is `git diff --name-only <base> HEAD -- '*.cs'`. Against the **PR's** base it is **not empty** — it
+returns **7 C# files** from wave 27's ship (`3584c30`) and wave 28's ship (`5cdef12`):
+
+```
+Joko.NINA.Plugins.HocusFocus.Tests/Golden/TruthDisclosureTests.cs
+Joko.NINA.Plugins.HocusFocus.Tests/Utility/DetectionBinningResolverTests.cs
+Joko.NINA.Plugins.HocusFocus/Utility/DetectionBinningResolver.cs
+TestApp/BankVerifyRunner.cs
+TestApp/GoldenEvalRunner.cs
+TestApp/SynthBank/GoldenFromTruth.cs
+TestApp/SynthBank/TruthDisclosure.cs
+```
+
+Against **wave 30's own base** (`0b86a2e`, wave 29's close) it is **empty**, and
+`git ls-files --others --exclude-standard -- '*.cs'` is **empty**. **Wave 30 changed no C# and the 42 m gate is
+not owed by wave 30**; those seven files' gate obligations belong to waves 27 and 28. **But `<base>` in design
+§9 was written assuming one wave per PR, and the consolidation makes it ambiguous** — a later reader running
+§9's check as literally written against the PR base would conclude wave 30 owes a gate it does not. The check
+must name the **wave's** base explicitly from here on.
+
+**(ii) The branch was rebased onto `develop @ ec06bec` and force-pushed mid-wave**, at the owner's standing
+instruction, with `--force-with-lease`. `ec06bec` (*"Merge pull request #198 from ghilios/ghilios/af-row-wrap-narrow"*)
+is verified an ancestor of `HEAD` `1e7de32`. **It was done between waves, with no wave-30 measurement yet
+taken** — the pre-registration commit was the only wave-30 commit in the branch at the time — so no artifact,
+manifest, provenance hash or binary reference is affected, and `W30-FP` (`PRESERVED`) confirms nothing on disk
+moved. Recorded because a force-push during a measurement wave is the kind of thing that has to be either
+declared or discovered.
+
+**(iii) A false alarm on the arm, and the alarm was mine.** I checked for a live `TestApp` process **6 seconds
+after launch**, saw zero, and reported a possible abort — **before confirming the arm was alive in its
+settings-edit phase.** The arm copies and edits a settings tree before it invokes the binary, so a zero process
+count at t+6 s is the expected reading, not a symptom. **The check was right to make** — an arm that dies
+silently and leaves a partial manifest is a real failure mode this series has paid for — **and the alarm was
+mine, not the arm's.** The remedy is a threshold, not fewer checks: the arm's own first cell header
+(`=== W30G M0 … 19:34:40Z ===`) appeared 7 s after `W30G_ARM_START`, and *that* line, not `ps`, is the liveness
+signal.
+
+**(iv) The BEFORE fingerprint did not precede `V30`'s fixture probes** — §7.4. Design §6's bolded ordering
+requirement was not met; measured consequence none.
+
+**(v) Step 7, the results-table `K` column, was not run.** `kcol_w30.py` was written and self-tests `21 of 21`;
+no column was emitted and `docs/synthetic-af-bank-results-table.md` is unchanged. Per design §13's own rule for
+this item — *"if it is cut, it must be WITHDRAWN or paid, not re-listed"* — **§10 withdraws it.**
+
+---
+
+## §10 — WHAT WAS NOT RUN, AS A CHECKABLE LEDGER
+
+**`W30-D` is the reason this section has a different shape.** Wave 29's §11 was prose in a third column, and
+`W30-D` showed what happens next: a later wave inherits it, and — however the checking is done — some rows rot
+in one direction and some in the other. **So every row below carries a literal search path that returns the
+answer**, and the rows this wave will not pay are **withdrawn by name**, not carried.
+
+| # | not run | price | scope | **search path — run this to check the row** | state |
+|---|---|---|---|---|---|
+| 1 | the 42 m `optimize` gate (`Q27-V1`, 8 datasets) | 42 m | wave 30 | `git diff --name-only 0b86a2e..HEAD -- '*.cs'` ∪ `git ls-files --others --exclude-standard -- '*.cs'` → **both empty** | **NOT OWED** — run, not asserted (§9). Owed by the wave that ships anything from design §10 |
+| 2 | the unit suite | ~4 m | wave 30 | same command as row 1 | **VACUOUSLY SATISFIED.** Baseline for the wave that changes C# is **3997**, not 3973 |
+| 3 | **the results-table `K` column** | 12 m | cross-wave | `ls /mnt/d/hf_w30/w30k_*.txt` → absent; `grep -c hfrMinEffective docs/synthetic-af-bank-results-table.md` → **0** | **WITHDRAWN.** Owed by waves 28, 29 **and** 30 and unpaid by all three. Design §13: a debt carried three waves is one nobody intends to pay. `kcol_w30.py` stays on disk (self-test `21 of 21`); any later ship can run it in ~2 m |
+| 4 | **`S27-1`'s route agreement + `M-S1`/`M-S2a`/`M-S2b` records** | ~20 m | wave 27 | `grep -l 'S27-1' /mnt/d/hf_w27/*.txt`; `ls /mnt/d/hf_w27/s27_2_mutant_MS{1,2a,2b}.log` → absent | **WITHDRAWN**, formally, after **four** waves on the cut list — per design §16 and wave 29 §13. §5.1 row 6 shows `W30-D` falsely reported it paid |
+| 5 | wave 29's BEFORE fingerprint | ~12 m | wave 29 | `ls /mnt/d/hf_w29/fp_BEFORE.txt` → absent | **WITHDRAWN — UNRECOVERABLE.** A BEFORE taken now is an AFTER. Correctly reported unsatisfied by `W30-D` |
+| 6 | wave 29's three scorer self-test captures | ~5 m | wave 29 | `ls /mnt/d/hf_w29/w29{s,r,l}_selftest.txt` → absent | **WITHDRAWN.** A retrospective capture proves the scorers pass *now*, which is not the gate. Wave 30 captured its **own six** (§ roll call), which is the habit that matters |
+| 7 | **precision at the opened `MaxDistortion` settings** | ~5 m | **NEW, created by wave 30** | `grep -n 'precision\|FALSE POSITIVE' /mnt/d/hf_w30/g/out/M{1,3,4}/attempt01/golden_eval.txt` | **OWED by any ship that lowers `MaxDistortion`.** §4.5: 23–25 % of the distortion gate's acceptances did not match the star they were released from. The pre-registered statistic cannot resolve it |
+| 8 | `MaxDistortion` doses below 0.2 | ~3 m each | wave 30 | `grep maxdist_intended /mnt/d/hf_w30/w30g_manifest.tsv` → 0.5, 0.3, 0.2 | **NOT OWED.** The axis has 10 steps; wave 30 measured **3** and says so. §4.2 shows the marginal dose already yields 4.1 % |
+| 9 | a full paired 18-cell S1 arm | ~2 h 40 m | cross-wave | `ls /mnt/d/hf_w25/{before,after}` → present, from wave 25's arm | **NOT OWED.** `W-UNEXERCISED`: a **second** arm buys a second `SAME 13`. §5.1 row 5 shows `W30-D` falsely reported it paid |
+| 10 | new datasets between 1.4 and 19.4 ″/px | ≥ 1 h render | cross-wave | `ls -d /mnt/d/SyntheticAutofocusBank/D*` → 20, none in the band | **OPEN, twelve waves.** The coverage hole, and the only route to a **blind** wide-field dataset. Outside `W30-D`'s declared search set, which the rule correctly reported as `CNL-OUT-OF-REACH` rather than clean |
+| 11 | the blur/layer decoupling build ([F92](followups.md)) | ~45 m + 10 m (+42 m to ship) | cross-wave | `ls /mnt/d/hf_w3*/exe` → only `/mnt/d/hf_w25/exe` and `/mnt/d/hf_w27/exe` | **OPEN**, unchanged |
+| 12 | the `A4` truth-model gap | 20 m code **+ 42 m gate** | cross-wave | `grep -rn 'truthModel' Joko.NINA.Plugins/TestApp/SynthBank/` | **OPEN**, and [F96](followups.md) makes it more urgent, not less |
+| 13 | anything on real frames | — | permanent | — | The bank has no real under-sampled dataset ([F35](followups.md), [F43](followups.md)) |
+
+**Four withdrawals in one section is the point, not an accident.** Rows 3–6 have been carried between two and
+four waves each. `W30-D` proves a carried row is not free: it accumulates until something has to check it, and
+the checking is where the errors are. **A row that will not be paid should be deleted with a reason, and these
+four are.**
+
+---
+
+## §11 — REGISTER ENTRIES, READY TO PASTE
+
+The register's highest existing entry is **F103**. These continue from it. Design §16 sketched F104–F107 under
+a different assignment; the numbering below is the one that ships, and the mapping is noted where it differs.
+
+---
+
+### F104 — `D01`'s two candidate gates release 36 660 high-tier candidates and re-capture takes 92 %: the joint is material and ADDITIVE, so F99's joint-recovery claim is refuted at a pre-registered bar
+
+**Status:** Closed — the product question is answered, and answered negatively · found 2026-08-13, wave 30,
+`RULE W30-G` = **`G-NOT-RECOVERABLE`** · `/mnt/d/hf_w30/w30g_score.txt`, `w30g_manifest.tsv`
+
+**[F22](#f22) FENCE, inline and mandatory:** on `D01_ultrawide_40mm` the detector's HFR over-reads by a large
+factor below ~1.1 px measured HFR and its autofocus already lands at `BestJ 0.994825`. **No count in this entry
+may be quoted as a recall or focus improvement for a user.** The only frame in which it may be read is goal 3 —
+*is a landed knob sitting at an extreme against the physics?*
+
+A 2×2 factorial on `MaxDistortion` (0.5 → 0.3) and `BrightnessSensitivity` (36.333 → 32.333, four axis steps
+**computed** from the product's own declaration), five run cells and two imported from wave 29, on
+`D01_ultrawide_40mm`, 9 frames per cell, on the B15 binary already on disk.
+
+| quantity | value |
+|---|---|
+| `Σ R_g` over all single-knob cells | **36 660** |
+| `Σ capture_g` | **33 884** |
+| `recapture` (pooled) | **0.9243** — bar 0.90 → **`G-2` True** |
+| `recapture` excluding the fenced `M4` | 0.9288 (agrees) |
+| `FN_total(M0)` | **50 249** |
+| material bar, **computed** as `0.01 × FN_total(M0)` | **502.5** |
+| `ΔTP(M3)`, the joint | **+1 572** |
+| `Σ ΔTP` over the unfenced singles `M1`+`M2` | **+1 480** |
+| `ΔTP(joint) ≥ 502.5` | **True** |
+| `ΔTP(joint) ≥ 2 × 1 480 = 2 960` | **False** → **`G-3` False** |
+
+**The joint IS material** (3.1× the bar; 3.1 % of all misses) **and it is essentially additive**: the
+interaction term is **+92**, a multiple of **1.06×** against a pre-registered bar of 2×.
+
+**Re-capture dominates, and the mechanism is one column of the published matrix.** `TooDistorted` at 0.3
+releases **12 090** candidates and **`LowSensitivity` absorbs 9 676 of them — 80.0 %.** Relaxing
+`LowSensitivity` by 11 % on top converts **92** of those 9 676 — **0.95 %**. A 36 σ bar relaxed by 11 % does not
+turn a low-fill blob into a detection, which is exactly the mechanism the pre-registration gave for predicting
+this outcome.
+
+**Goal-3 answer, and it is a negative.** No landed knob on `D01` is pinned against the physics in a recoverable
+way. `MinStarBoundingBoxSize` at 6 (against a shipped default of 5) is the one knob at an extreme, and its flow
+releases 9 537 candidates of which **3** reach acceptance. `MaxDistortion` landed mid-axis. **40.4 % of the
+misses live upstream of both gates** — `NO CANDIDATE (structure gap)` 8 931 and `TooSmall` 11 372 — where no
+setting of either gate can reach them. `D01`'s recall gap is the physics of a 19.4 ″/px rig with a ~0.7 px
+kernel.
+
+**Two rival predictions were registered before the data**, in the same pre-registration section, attached to
+two distinct terminal verdicts of the same 36-region tree: `G-JOINTLY-BOUND` (F99's) and `G-NOT-RECOVERABLE`
+(the design's). The data landed in the second. **Neither document could have claimed a hit it did not call**,
+and this is the strongest evidential form the series has produced.
+
+**Not measured, and owed by any ship that acts on this:** precision at the opened settings. 23–25 % of the
+distortion gate's acceptances were `ACCEPTED-elsewhere` — accepted but not matched to the star they were
+released from — against 5–10 % for the sensitivity gate. That is a signal, not a measurement; the pre-registered
+statistic reads only the false-negative attribution block. ~5 m to resolve.
+
+*(Design §16 assigned F104 to this verdict; the assignment holds.)*
+
+---
+
+### F105 — `golden_eval`'s first-rejection-wins attribution CONSERVES on real data, 5 of 5 cells, integer-exact — so waves 28's and 29's gate-count differences are safe to read
+
+**Status:** Closed — the model is checked · found 2026-08-13, wave 30, `RULE W30-G` clause `G-1` = HOLDS ·
+`/mnt/d/hf_w30/w30g_score.txt`
+
+Relaxing exactly one gate `g` changes no other threshold, so the report's attribution must satisfy, **exactly,
+in integers**:
+
+> `ΔNO-CANDIDATE = 0`; `ΔFN_h = 0` for every `h` strictly upstream of `g`; and
+> `R_g = Σ_{h downstream of g} ΔFN_h + ΔContaminated + ΔACCEPTED-elsewhere + ΔTP`
+
+**Five single-knob cells, five exact balances, no tolerance**, with every upstream invariant and the pre-chain
+`BloomSuppressed` stage returning zero:
+
+| cell | gate (position of 11) | `R_g` | balance |
+|---|---|---|---|
+| `M1` | `TooDistorted` (4) | 12 090 | ✓ |
+| `M2` | `LowSensitivity` (6) | 486 | ✓ |
+| `M4` | `TooDistorted` (4) | 14 425 | ✓ |
+| `L1` | `TooSmall` (1) | 9 537 | ✓ |
+| `L3` | `LowSensitivity` (6) | 122 | ✓ |
+
+Two of these (`L1`, `L3`) were pre-computed from wave 29's published artifacts before the pre-registration and
+balanced then. **Three (`M1`, `M2`, `M4`) were blind by design §8 and balanced on first contact.**
+
+**What it licenses.** The `G-MODEL-BROKEN` branch of the tree read: *"the report's first-rejection-wins
+attribution does not conserve, and **every gate-count difference in waves 28 and 29 is unsafe.**"* It did not
+fire. **First-rejection-wins is the correct model of the `FALSE-NEGATIVE ATTRIBUTION` block, and every
+Δ-on-a-bucket waves 28 and 29 published can be read as a flow rather than as a coincidence.** This is the first
+checked model of these reports in eleven waves, and it was granted by measurement, not by argument.
+
+**It can fail, and the failure is exercised.** Self-test `[2]` moves one bucket by one on a live fixture and the
+balance breaks; `[9]` drives a non-conserving cell to `G-MODEL-BROKEN` with a non-zero exit.
+
+**A design difference the instrument reported rather than repaired.** The design's hand-typed §4.1(c) chain had
+**7** gates; the arm's run-time extraction found **11** (`…, TooFlat, HFRAnalysisFailed, TooLowHFR,
+Contaminated`) plus the pre-chain `BloomSuppressed`. The design's formula named contamination as a separate
+terminal **and** the chain contains it as the last gate; counted twice it would have doubled. The scorer
+partitioned once, printed the difference, and **the five exact balances are themselves the proof that the
+11-gate partition is right** — the 7-gate one could not have balanced.
+
+---
+
+### F106 — A hand-carried debt ledger rots in BOTH directions, and the rot is measured: `P-D08` was published seven hours before the wave that listed it as owed
+
+**Status:** Open — the class is structural · found 2026-08-13, wave 30, `RULE W30-D` = **`D-STALE`** ·
+`/mnt/d/hf_w30/w30d_score.txt`
+
+`RULE W30-D` parsed wave 29's §11 *"WHAT WAS NOT RUN"* table out of the committed document (sha256 re-asserted
+at scoring time), resolved each of **14** rows to exactly one predicate with a declared **scope**, and searched
+six roots plus the docs directory. `D-0` held (14 parsed, heading matched once, 0 unresolvable, 6 of 6 roots
+present). `D-1` returned **False**: 6 of 10 debt-claiming rows have a satisfying artifact.
+
+**Two rows are genuinely stale**, and one of them is why the rule exists:
+
+- **`P-D08` at `n = 3`** — measured 09:06–09:08Z, published under a heading *"`# RESULT — P-D08 is REFUTED at
+  n = 3`"*, committed `e42e2df` at 09:09:37Z, artifacts at `/mnt/d/hf_w26/pd08/`. Wave 29's ledger listed it
+  **owed** at 18:05Z the same day. **Seven hours, inside a single day's run.** The cause: the search was for an
+  artifact *under the wave's own root* rather than for the measurement wherever it lives.
+- **the closing `V29`** — `vdrift_w29_CLOSING.txt`, 18:18:01Z, fourteen minutes **after** wave 29's roll call.
+  The ledger was true when written and stale by the time it was read.
+
+**This is [F85](#f85)'s class recurring** — a closed, shipped correction re-measured as an open defect — **and
+the gap is now under twelve hours.** The remedy is not to fix a row. It is to stop inheriting the list: resolve
+each row to a **checkable predicate with a declared scope**, where a **per-wave obligation** is discharged only
+under the ledger wave's own root and a **measurement** is discharged wherever its artifact lives. Applying the
+per-wave scope to a measurement row is the exact error that produced this stale debt, and the scope distinction
+is what found it.
+
+**Wave 30's own §10 ledger is written in that form** — one literal search command per row — and **withdraws
+four rows** rather than carrying them a further wave.
+
+*(Design §16 assigned F106 to the stale debt; the assignment holds. See F107 for the rule's own defect.)*
+
+---
+
+### F107 — A ledger checker whose row predicates are FILENAME globs converts a false "owed" into a false "already paid", which is the worse error: 3 of 6 on its first run
+
+**Status:** Open — diagnosed, unrepaired by design · found 2026-08-13, wave 30, verifying `RULE W30-D`'s own
+output · `/mnt/d/hf_w30/w30d_score.txt`, `/mnt/d/hf_w29/l/opt/L0/attempt01/optimize_summary.txt`,
+`/mnt/d/hf_w25/s1_arm_w25.sh`, `/mnt/d/hf_w27/s27_*`
+
+`RULE W30-D` named **six** already-paid rows. Checked against what each ledger row actually claimed:
+**two genuine, one true-but-circular, three false.**
+
+| row | matched | verdict on the match |
+|---|---|---|
+| **the 42 m `optimize` gate** | `hf_w29/l/opt/L{0..4}/…/optimize_summary.txt` | **FALSE.** Each is *"Runs root: `D01_ultrawide_40mm`; **Runs: 1**"* — a per-cell optimize from wave 29's own arm, not the 8-dataset `Q27-V1` gate. **And the row's own text reads "NOT OWED this wave"** — a row that disclaims the debt was scored as claiming one |
+| a full paired 18-cell S1 arm | `hf_w25/s1_arm_w25.sh` | **FALSE, twice.** The match is a **shell script**, not a run record; and the row's own text says *"a **second** arm buys a second `SAME 13`"* — wave 25's arm is the row's premise, not its discharge |
+| `S27-1` and wave 27's three mutants | `hf_w27/s27_*` (6 files) | **FALSE.** The glob matched wave 27's **`S27-4`** do-no-harm arm. The debt is `S27-1`'s **route agreement** (wave 27 §7.3: *"not adjudicated, by the scorer's own printed statement"*) and the **`M-S1`/`M-S2a`/`M-S2b`** records (§7.4: *"remain testimony"*). The one evidenced mutant, `M-S3`, was **never the debt**. One of the six matches, `s27_score.txt`, is a file the series has already annotated as unquotable |
+| localising `D01` | `hf_w30/w30g_manifest.tsv` | **TRUE BUT CIRCULAR.** Written by **wave 30's own arm** at 19:52:10Z and scored "already paid" at 19:53:49Z — **99 seconds later** |
+
+**Three defects, in increasing order of transferability.**
+
+1. **The specs are hand-typed filename regexes** — `^.*optimize.*\.(txt|log)$`, `^s1_arm.*$`, `^s27.*$`. The
+   rule replaced a hand-carried *list* with a hand-carried *regex*. **It rots the same way and it rots
+   silently**, because a glob that matches too much produces a confident wrong answer where a glob that matches
+   nothing produces a visible "not satisfied."
+
+2. **`D-1` has no time ordering.** A row paid seven hours *before* the ledger, a row paid fourteen minutes
+   *after* it, and a row paid *by the checking wave itself* all score identically. `paid_at <
+   ledger_written_at` is the missing comparison, and **both timestamps are already in the rule's own
+   manifest.** Without it, a wave that discharges an inherited debt will report itself as evidence that the
+   ledger rotted.
+
+3. **The validity clause cannot see any of this, by construction.** `D-0` asserts every row resolves to
+   **exactly one** predicate — 14 of 14, unresolvable 0, correctly. **A validity clause that checks a row
+   resolves *uniquely* cannot check that it resolves *correctly*.** This is the same shape as [F108](#f108):
+   asserting a key is *present* is not asserting it is the *right* key.
+
+**The direction of the error is what makes this high severity.** A false "owed" costs a re-run. **A false
+"already paid" retires an obligation nobody met** — row 1 would have retired the 42 m gate, row 6 a control
+open four waves that two wave-27 ship-clauses relied upon.
+
+**What works and should be kept:** the **scope distinction**. Every *unsatisfied* result the rule produced is
+correct — the wave-29 BEFORE fingerprint and the three scorer self-test captures were both scoped `ledger` and
+both correctly reported not satisfied — and the scope is what found `P-D08`. **The rule is not repaired and not
+re-scored**; `D-STALE` stands on its two genuine rows.
+
+---
+
+### F108 — A stale literal passed to `split()` silently widened a self-test's slice to the whole document, and no checker in this apparatus can see it: a stale ordinal used as a KEY is not printed output
+
+**Status:** Closed in the instrument (fixed and the fix asserted) · Open as a class · found 2026-08-13, wave 30
+· `/mnt/d/hf_w30/score_w30g.py:1176-1192`, `instrumentcheck/score_g_selftest.txt` (57) vs
+`w30g_selftest.txt` (59)
+
+`score_w30g.py`'s self-test clause `[6]` — the [F84](#f84) / `RULE S16` sensitivity fence, one of two fences the
+design declared load-bearing — sliced the artifact with the needle **`"READING: more than a tenth"`**. **The
+emitter stopped producing that text when the material bar became computed**: the `G-SINGLE-BINDS` reading line
+is now formatted from `G2_BAR` (`:857`, *"READING: more than %.0f%% of the released mass reached acceptance…"*)
+and the literal *"a tenth"* appears nowhere in the output.
+
+**`str.split()` on an absent needle returns a ONE-ELEMENT list**, so `[-1]` handed back **the whole document**.
+The assertion below it — *"the fenced name appears in no verdict sentence"* — stopped being about a verdict
+sentence and became a document-wide absence check that passes trivially. **It would have passed forever while
+asserting nothing.**
+
+**What caught it, and what structurally could not:**
+
+- the **blocking pre-flight** flagged the stale phrase **only where it was printed** — it found the emitter's
+  copy, not the self-test's;
+- **`V30-C` cannot see this copy at all.** `V30-C` scans **printing lines** for typed ordinals and counts; its
+  population this wave was **667** (*"printing lines 980, of which 273 carry a format slot and are skipped"*).
+  **A needle passed to `split()` is not printed output**, so it is outside `V30-C`'s population by construction.
+
+> **A checker that looks for typed ordinals in output cannot find a stale ordinal used as a KEY.**
+
+**The remedy is local and permanent:** assert the anchor is **present**, and assert the slice is a **proper**
+substring so it can never widen to the whole text again. The anchor was shortened to the stable prefix
+`"READING: more than "`. **Self-test `57 of 57` → `59 of 59`.**
+
+**Class and generalisation.** This is [F102](#f102)'s class — *a clause whose population quietly went empty
+while still printing a pass* — recurring **in the wave that built F102's remedy**, in a form that remedy does
+not cover: F102 makes populations printable and refusable, which works for populations the instrument
+**computes**, and **this slice was a population nothing ever counted.** The general rule: **`split()`,
+`partition()`, `find()`, `re.search(...).group()` and every other locate-by-literal idiom degrades silently to a
+no-op or to the identity when its literal goes stale, and a population counter on the *output* cannot observe
+the *key*.** Every such call needs its key asserted present and its result asserted a proper part.
+
+---
+
+### F109 — Waves 27–30 ship as ONE PR at the owner's instruction, and the design's stacked-base prescription was overruled: only the PR base prevents accretion, but consolidation is the owner's call
+
+**Status:** Closed — decided by the owner · 2026-08-13, wave 30 · `gh pr list`, `git merge-base`
+
+**Measured at wave 30's pre-registration:** #196 (`…wave27`) and #197 (`…wave29`) both targeted **`develop`**,
+so #197's own diff carried waves 27, 28 **and** 29 plus wave 27's C# ship — **25 files.** Wave 29 had opened a
+fresh branch specifically so *"#196 does not carry a third section"* and succeeded at that; **it did not stop
+the accretion, it moved it.** The design's diagnosis was that the mechanism is the PR **base**, not the branch.
+
+**The diagnosis was acted on; the prescription was rejected.** The design pre-registered a fourth branch with
+`--base ghilios/…wave29`, to make *"the first PR in this family whose diff is one wave."* **The owner instructed
+one PR instead.** #197 was re-targeted to `…wave27` (the design's own §0 recommendation, which it had declined
+to perform itself) and **merged**; **#199 was closed**; the branch was **rebased onto `develop @ ec06bec` and
+force-pushed** with `--force-with-lease`. Waves 27–30 now sit on `ghilios/synthetic-af-bank-followups-wave27` =
+**PR #196**, base `develop`, titled *"Waves 27-30: …"*.
+
+**Design §0's goal of a one-wave PR diff was not achieved and will not be.** Recorded as an overrule, not as a
+design success.
+
+**One measured consequence for the gate check.** Design §9's reversal check is
+`git diff --name-only <base> HEAD -- '*.cs'`. Against the **PR's** base it returns **7 C# files** from waves
+27's and 28's ships. Against **wave 30's own** base (`0b86a2e`) it is **empty**, as is
+`git ls-files --others --exclude-standard -- '*.cs'`. **Wave 30 changed no C# and owes no gate** — but `<base>`
+was written assuming one wave per PR, and a later reader running the check literally against the PR base would
+conclude otherwise. **From here on the check must name the wave's base explicitly.**
+
+---
+
+### AMENDMENTS TO EXISTING ENTRIES
+
+**[F99](#f99) — AMEND IN PLACE.** Append:
+
+> **AMENDED 2026-08-13, wave 30, `RULE W30-G` = `G-NOT-RECOVERABLE`
+> (`/mnt/d/hf_w30/w30g_score.txt`).**
+>
+> **The mechanism holds and is now quantified on the gate this entry named.** `TooDistorted` at
+> `MaxDistortion` 0.3 releases **12 090** high-tier candidates on `D01` and **`LowSensitivity` re-captures
+> 9 676 of them — 80.0 %.** At 0.2: 14 425 released, 11 652 re-captured. **This entry's central observation —
+> that a gate's entire yield can be absorbed one and two gates downstream, and that a `FN_total` difference
+> cannot see it — is confirmed on a second knob and a second gate.** Its methodological half, *"wave 30's rule
+> over sequential gates must read the per-gate flow, not the net,"* is **vindicated and superseded**: the flow
+> is now a conservation identity that balances exactly and can fail ([F105](#f105)).
+>
+> **The substantive hypothesis is REFUTED at the pre-registered bar.** This entry claimed *"`D01`'s binding
+> constraint is `TooDistorted`, **jointly with** `LowSensitivity`, and no single-knob change recovers it."*
+> Measured on the 2×2: `ΔTP(joint) = +1 572` against `Σ ΔTP(singles) = +1 480` — an interaction of **+92**, a
+> multiple of **1.06×** against the pre-registered bar of **2×**. **The pair does not bind jointly; the joint
+> is essentially additive.** It *is* material (1 572 ≥ the computed bar of 502.5) — so the second half of the
+> claim, *"no single-knob change recovers it,"* is also wrong in the direction that matters: `M1` alone
+> delivers 1 096, itself above the material bar. **[F22](#f22) fence: none of these counts may be quoted as a
+> recall or focus benefit; the frame is goal 3 only.**
+>
+> **Status → Closed.** The hypothesis was stated so it could be wrong, it was pre-registered as `PREDICTION A`
+> against a rival `PREDICTION B` in wave 30's design §4.6, and the data chose. That is the entry working as
+> intended.
+
+**[F98](#f98) — APPEND.** Wave 30 is the **first measurement of the low end** of the `MaxDistortion` axis.
+Measured at 0.3 and 0.2 on `D01`: no collapse, `R_g` = 12 090 and 14 425, pass-through 9.1 % and 8.3 %, marginal
+pass-through on the second dose **4.1 %**. **Part 1 (the instrument finding) is untouched.** **Part 2 (bound the
+axis at ~π/4 and rename) gains support at the top and gains a NEW precondition at the bottom**: 23–25 % of the
+distortion gate's acceptances at the opened settings were `ACCEPTED-elsewhere` (accepted, not matched to the
+star they were released from) against 5–10 % for the sensitivity gate. **A ship that bounds the axis at the top
+is supported; a ship that lowers the default at the bottom is not yet supported and owes a ~5 m precision
+measurement** (§10 row 7). The axis has 10 steps and wave 30 measured 3 of them.
+
+**[F103](#f103) — APPEND.** **The forward prediction hit 4 of 4, second consecutive wave.** Predicted at wave
+29 and measured at wave 30 (`vdrift_selftest_w30.txt` `[5b]`, 19:26:49Z): `/mnt/d/hf_w28` expired from **100
+`-B` findings to 0**; `/mnt/d/hf_w29` became the live `-B` fixture at **311**; `/mnt/d/hf_w24` held as the
+durable `-C` fixture at **2**, fourth wave running; `/mnt/d/hf_w26` and `/mnt/d/hf_w27` stayed silent at
+**0**. **A pinned per-clause fixture goes silent exactly one wave later, on schedule.** The expired roots are
+kept and asserted silent, so the expiry is demonstrated rather than described. **Wave 31's prediction, if there
+is one:** `/mnt/d/hf_w29` expires to 0 and `/mnt/d/hf_w30` becomes the live `-B` fixture.
+
+**[F94](#f94) — APPEND.** The `None` enumeration plus the **realized-tuple membership assertion** ran in **four**
+instruments this wave (`W30-G` 36 regions, `W30-D` 6, `V30` 12, `W30-FP` 18), every one printing `uncovered: 0`
+**and** its own realized tuple **and** `member of the enumerated set: True`. **It caught nothing this wave** —
+every tuple was inside its domain — and that is the honest report. What it *did* demonstrate is that the
+assertion can discriminate: `score_w30g.py`'s self-test `[13]` shows a tuple carrying `None` **is** a member and
+a tuple outside the declared domains **is not**, so the assertion can fail. **A check that cannot fire in a
+given wave is still worth its cost only if its firing end is exercised, and it was.**
+
+**[F102](#f102) — APPEND.** Every clause in every wave-30 instrument printed `candidates: N   findings: M`.
+**No clause printed an unexpected `N = 0` and no instrument refused with `POPULATION-EMPTY`** — the populations
+were 5/7/8/3/4/4/2 (`G-0`'s seven), 5 (`G-1`), 36 660 (`G-2`), 2 (`G-3`), 14 and 10 (`W30-D`), 12/5 026/667
+(`V30`), 1 230 (`W30-FP`). **But F102's class recurred anyway, in a place populations cannot reach** — see
+[F108](#f108). **F102's remedy covers populations the instrument computes; it does not cover a literal used as
+a key, which nothing counts.** The remedy is not weakened, it is bounded, and the bound should be written into
+it.
+
+**[F95](#f95) — APPEND.** Wave 30 ran the pre-flight **over a populated root** (7 files, 12 `-A` candidates,
+5 026 `-B`, 667 `-C`) **and at the close**, both from the pre-registration rather than from a debt, and the two
+runs are **byte-identical**. **Both halves of the remedy, from the start, for the first time.** One deviation
+against F95's neighbour requirement is recorded in §7.4: the `W30-FP` BEFORE sweep ran **26 minutes after**
+`V30`'s five fixture probes read `/mnt/d/hf_w29`, against design §6's bolded ordering. Consequence measured:
+none (`PRESERVED`, 0 moved). **The ordering must be enforced by the driver, not by intent.**
+
+**[F21](#f21) — APPEND.** Estimate vs actual, wave 30, sixth consecutive wave under on the analysis halves:
+
+| step | est | actual |
+|---|---|---|
+| 1 — write all 7 instruments | 60 m | **~39 m** (18:54:08 → 19:33:44Z) |
+| 2 — `W30-FP` BEFORE | 5 m | **≤ 60 s** |
+| 3 — `V30` pre-flight + 5 fixture probes | 15 m | **~7 m** |
+| 4 — the 5-cell arm | 25 m wall / ~15 m compute | **17 m 37 s wall / 1 057 s compute** |
+| 5 — `W30-G` scoring | 12 m | **~15 s** to emit |
+| 6 — `W30-D` | 15 m | **~2 m** |
+| 7 — the `K` column | 12 m | **NOT RUN** (§10 withdraws it) |
+| 8 — AFTER + closing `V30` | 8 m | **~2 m** |
+| **Steps 1–8 excluding 7** | **~140 m** | **~62 m — 56 % under** |
+
+**Two figures were priced from a measured rate and one of them was mildly optimistic.** The arm was priced at
+~950 s from wave 29's 145–198 s per cell and came in at **1 057 s, 11 % over** — because wave 29's two fastest
+cells were its two *dead* ones, so the reference rate was biased low. **A rate measured over an arm containing
+dead cells under-prices an arm with none.** The sweep price (3 m/side, from 61 MB/s over a trimmed 2.4 GB root
+set) was **generous by ~3×**: both sides completed in ≲ 2 minutes. **New constant handed forward:** 1 230 files
+across 6 declared roots sweep in **under a minute** on DrvFs. **And it could only be bounded, not measured** —
+see §8.3: the fingerprint records no start time.
+
+**`S27-1` and wave 27's three mutants — WITHDRAWN**, formally, after four waves on the cut list, per design §16
+and wave 29 §13. **And note that [F107](#f107) shows `RULE W30-D` falsely reported this row already paid** — it
+matched wave 27's `S27-4` arm. The withdrawal is on the merits, not on that match.
+
+**`docs/synthetic-af-bank-results-table.md`'s `K` column — WITHDRAWN**, per design §13's own rule for this item.
+Owed by waves 28, 29 and 30; unpaid by all three. `kcol_w30.py` remains on disk with a `21 of 21` self-test and
+can be run in ~2 m by any later ship.
+
+---
+
+## §12 — WAVE 31, PRICED AND GOAL-SCORED — AND THE RECOMMENDATION IS TO STOP
+
+**Run hard stop `2026-08-14T00:45:17Z`. It is `2026-08-13T19:56:41Z`. Remaining: 4 h 48 m.**
+
+Wave 29 §13 wrote: *"items 2 and 4 above are the last two product questions this bank can answer without new
+data, and once they are closed, the next wave that cannot name a product question should stop rather than audit
+its own instruments a fourth time."* **Item 2 is now closed** (§4, F104). Design §17 committed in advance to
+the consequence: *"after wave 30, this bank has no unanswered product question that another synthetic arm can
+address."* **The measurement bears that out.**
+
+### 12.1 What is actually left
+
+| # | candidate | price | compute | goals | state after wave 30 |
+|---|---|---|---|---|---|
+| **3** | choose among F82's three fixes, pre-registered before reading | ~40 m to choose | — | **2** ✓✓ | **Ready. Needs no new measurement.** `W29-S`/`W29-R` supplied everything a choice needs. Ship price is separate: ~45 m + a 3-cell re-run + **42 m gate** for candidate (3) |
+| **4** | bound the `MaxDistortion` axis at ~π/4 and rename it | ~20 m code **+ 42 m gate** | — | **3** ✓ | **The top bound is supported and needs no new arm.** The bottom is **not** — F98's amendment adds a ~5 m precision precondition (§10 row 7) |
+| **7** | precision at the opened `MaxDistortion` settings | ~5 m | ~0 | **3** ✓ | **New, created by this wave.** Cheap. Blocks any bottom-end default change |
+| — | new datasets 1.4–19.4 ″/px | ≥ 1 h render | ≥ 1 h | 1, 3 | **The only route to a new blind population.** Twelve waves open |
+
+**Every remaining item is a SHIP or a 5-minute rescore. Not one of them is a wave.**
+
+### 12.2 The recommendation: **STOP the wave series.**
+
+**Four reasons, in order of weight.**
+
+1. **The series has run out of measurements, by its own pre-registered accounting.** Items 3 and 4 are C#
+   changes with a 42 m gate and a 3997-baseline unit run. They belong in ordinary feature branches with ordinary
+   pre-registration, not in a numbered wave carrying rules, verdict trees, fingerprints and a pre-flight. **A
+   wave is an apparatus for taking a verdict from a measurement. Neither remaining item has a verdict to take.**
+
+2. **This wave's two NEW rules both shipped with a defect their own self-tests passed over.** `score_w30g.py`
+   carried a stale `split()` needle that no checker in the apparatus can see ([F108](#f108)), and `RULE W30-D`
+   produced **3 false "already paid" out of 6** on its first outing ([F107](#f107)) — in the direction that
+   retires obligations nobody met. That is not a reason to distrust `G-NOT-RECOVERABLE`, which rests on a
+   control that reproduced 8 of 8 and an identity that balanced 5 of 5. **It is a reason to stop building new
+   rules.** The apparatus's defect rate is not falling: F95 (wave 28), F101/F102/F103 (wave 29), F107/F108
+   (wave 30), each one subtler than the last and each found only because the *next* wave went looking.
+
+3. **The findings have shifted decisively toward the apparatus, which is the pattern wave 29 named as the stop
+   trigger.** Of this wave's six new entries, **two are about HocusFocus** (F104's negative answer, F105's
+   licence for waves 28–29's arithmetic) and **four are about the instruments** (F106, F107, F108, F109). Wave
+   29 called this out at a milder ratio and said the wave after should stop rather than *"audit its own
+   instruments a fourth time."* Wave 30 was the fourth. A wave 31 would be the fifth.
+
+4. **The clock does not fit a ship.** 4 h 48 m holds **one** C# change with its 42 m gate and its unit run, at
+   best, with no margin for the gate failing or the build differing. This series has never run a ship wave; the
+   last four have been measurement waves with no build, so the failure modes of a ship wave are untested by this
+   apparatus. **A ship that overruns the hard stop is worse than a ship deferred.**
+
+**The charter's formal stop condition — two consecutive waves producing no register-worthy finding — is NOT
+met**, and that should be said plainly rather than glossed. Waves 29 and 30 both produced product findings.
+**The recommendation to stop is therefore a judgement, not a trigger**, and it rests on reason 1: the bank has
+no unanswered product question that another synthetic arm can address, which is what design §17 predicted in
+advance and what §4 confirms.
+
+### 12.3 If the remaining time is to be spent, spend it here — and not as a wave
+
+In priority order, each independently valuable and none requiring the wave apparatus:
+
+1. **Item 3 — choose among F82's three fixes (~40 m, goal 2).** The highest value per minute on the list. **The
+   choice can be written and committed without shipping**, so it owes no gate and cannot overrun. `RULE D20`'s
+   fence forbade choosing in the wave that proposed candidate (3); it does not forbid this.
+2. **§10 row 7 — the ~5 m precision rescore** at `M1`/`M3`/`M4`'s opened settings. It closes the one gap wave
+   30 knowingly left and it unblocks the bottom half of item 4.
+3. **Item 4's top bound only (~20 m + 42 m gate, goal 3).** Supported by F98 part 1 analytically and by wave
+   29's measured collapse at 0.9. **Do not touch the bottom of the axis until row 7 is paid.**
+
+**And if none of that is done, the honest position is that wave 30 closed the bank's last arm-answerable
+product question with a negative, and the right next move is either new data (the 1.4–19.4 ″/px render, ≥ 1 h)
+or nothing.**
+
+---
+
+## §13 — HANDOFF
+
+**Branch** `ghilios/synthetic-af-bank-followups-wave27`, **PR #196** (`OPEN`, base `develop`), carrying **waves
+27, 28, 29 and 30**, rebased onto `develop @ ec06bec`. #197 `MERGED`, #199 `CLOSED`. Commits: `1e7de32`
+(wave 30 pre-registration), plus this results commit.
+
+**Read first, in this order:** §1 (why two predictions is the strongest form) · §4 (the capture matrix and the
+additive joint) · §5 (`W30-D`'s six rows, verified) · F105, F107, F108 · §12's stop recommendation.
+
+**Do not repeat:**
+
+- **(a)** slicing an artifact with a literal you do not assert is present — `str.split()` on an absent needle
+  returns the whole document and your check silently stops checking ([F108](#f108));
+- **(b)** resolving a ledger row to a **filename** glob — three of six matched a file whose name carried the
+  row's word and whose content was a different thing ([F107](#f107));
+- **(c)** scoring a debt "already paid" without comparing the artifact's mtime to the **ledger's own**
+  timestamp — otherwise the wave that pays a debt reports itself as evidence the ledger rotted;
+- **(d)** typing a gate ordering into a design table — the design's 7-gate chain was wrong and the arm's
+  run-time extraction of 11 was right (§3.1);
+- **(e)** taking the fingerprint after any read of a declared root — §7.4, one step milder than wave 29's
+  failure and the same shape;
+- **(f)** pricing an arm from a reference rate measured over an arm containing **dead** cells — it under-prices
+  by ~11 % (F21 append);
+- **(g)** inheriting a fixture pin ([F103](#f103)) — `/mnt/d/hf_w29` is next to expire.
+
+**Standing:** never push `develop`; commit with `322725+ghilios@users.noreply.github.com` as author **and**
+committer; pass scorers WSL paths; `--out` mandatory and refusing; `--rule` asserted against the file's own
+declared name; populations printed and refusing on an unexpected zero; trees enumerated over the **actual**
+domain with `None` included and the realized tuple asserted a **member**; one `TestApp.exe` at a time; no
+directory rebuilt mid-wave; **name the wave's own base explicitly in every `git diff` gate check**, because the
+PR's base now spans four waves (§9).
+
+**The instruments are on disk under `/mnt/d/hf_w30/`. All six with their own self-test are clean** —
+`score_w30g.py` (59), `w30g_arm_w30.sh` (58), `score_w30d.py` (37), `verify_derivation_w30.py` (37),
+`fp_w30.sh` (27), `kcol_w30.py` (21); the seventh, `layout_w30.sh`, has no self-test of its own because it
+**is** the shared population expression and counter the other six assert through. `kcol_w30.py` in particular is a paid-for, unused instrument: it emits the
+results-table `K` column from `truthModel.max(hfrMin, hfrMinEffective)` in ~2 minutes, and §10 withdrew the
+column rather than pretending it will be run.

--- a/docs/synthetic-af-bank-results-table.md
+++ b/docs/synthetic-af-bank-results-table.md
@@ -3,25 +3,82 @@
 Rows: 20 of 20. Precision/recall scored by `golden eval --params optimized --opt-results <w18>/attempt01`, match=center, match-radius=12, pixel-scale=header, on B15 (BuildId d79dae73); all 20 verified against each log's own snapshot-source line.
 Optimize columns from wave 18's pinned seedA0 arm. Binning recommendation from wave 25's AFTER arm (B15, S1) -- a DIFFERENT instrument, labelled. Truth from each dataset's synthetic_meta.json.
 
+**Scoring mode: `golden+truth-protected`.** B15 carries `TruthProtection` (shipped `aaf26e8`, 2026-08-03), so a
+detection on a real rendered star the golden policy dropped is excluded from the false-positive count. **The
+report itself does not say so** -- `golden eval` emits no scoring mode, unlike `bank-verify`, which is the defect
+wave 27 fixes and the direct cause of the withdrawn banner below. For runs produced before 2026-08-03 the mode
+is `golden` (unprotected) and the two are not comparable.
 
-## READ THE PRECISION COLUMN AS A LOWER BOUND
+**Reproducibility:** B15 regenerates this entire population byte for byte -- `RULE R27` = `R-IDENTICAL`, 20 cells,
+420 artifacts, 0 differences (`/mnt/d/hf_w27/repro_all_score.txt`).
 
-Measured after this table was built (`/mnt/d/hf_w26/pd08/F31_truth_rescore.txt`, 2026-08-13 09:29Z, zero
-TestApp minutes): the detections `golden eval` scored for `D08_c11_2800mm` were re-matched against each frame's
-`*.truth.json` -- the renderer's COMPLETE star list -- at the same 12.0 px radius the golden scoring uses.
 
-**Of the 150 detections the golden calls false, 137 (91.3 %) match a REAL rendered star.** The golden reference
-lists **9** stars on a frame where the renderer placed **126**. `D08`'s true precision is therefore nearer
-**0.997** than the **0.966** in the table below, and every `1.000` in the column is a floor rather than a
-ceiling -- the reference under-lists, most heavily at extreme defocus, and the detector is scored down for
-finding what the reference omitted ([F31](followups.md)).
+## CORRECTION, 2026-08-13 (wave 27): the previous banner here was WRONG, and it is withdrawn
 
-**The 13 genuine junk detections are real, and they are localised:** all 13 fall on the two extreme wing frames
-and **zero** on any of the seven interior frames. That is a detector-at-its-limit observation, not a reference
-artifact, and it is the only measured false-positive behaviour on the bank.
+**This section previously read "READ THE PRECISION COLUMN AS A LOWER BOUND" and claimed the reference
+under-lists real stars, that `D08`'s true precision was nearer `0.997` than `0.966`, and that every `1.000` was
+a floor. All of that is false, and it is corrected in place rather than deleted so the error is visible.**
 
-**Recall is unaffected by this correction** and remains the weak axis -- and it is tier-dependent, which is why
-`recall@high` and `recall@all` are both printed and a bare "recall" never is.
+The precision column **is already truth-corrected**. `TruthProtection` shipped on **2026-08-03** (`aaf26e8`) and
+is wired into **both** `GoldenEvalRunner.cs:301-307` and `BankVerifyRunner.cs:464-466`: a detection landing on a
+real rendered star the golden policy dropped (tier `omitted` or `merged-into`) is excluded from the
+false-positive count, at exactly the match radius matching itself uses. B15 -- the binary that produced every
+row below -- carries it.
+
+**What the withdrawn banner actually measured was a pre-repair quantity.** Wave 26's re-score
+(`/mnt/d/hf_w26/pd08/F31_truth_rescore.txt`) re-derived false positives from the golden's `stars` list **alone**,
+consulting neither the golden's own `unresolved` boxes nor `TruthProtection`. Of its 150, **139 had already been
+excluded** by the run that produced this table -- 50 by `unresolved`, 89 by truth protection -- and `golden eval`
+reported **`FP = 11`**. Two different fields, both called "false positive" ([F68](followups.md) part 1).
+
+Verified on `D08` at best focus, from the artifacts: **119 detections = 81 in golden `stars` boxes (TP) + 15 in
+`unresolved` boxes + 23 truth-protected, `FP = 0`** -- exactly what the log prints.
+
+**So `D08`'s `0.966` is `308 TP / (308 + 11 FP)` with protection applied, and the nineteen `1.000` rows carry
+`FP = 0` after it. `1.000` is a CEILING here, not a floor.**
+
+**The genuine junk detections number 11, not 13** (two of the 13 sit inside a golden `unresolved` box and were
+already excluded), **and they are localised**: `golden eval`'s own per-frame FP column for `D08` reads 3 on
+`13672`, 8 on `14328`, and **zero on all seven interior frames**. That is a detector-at-its-limit observation and
+it is the only measured false-positive behaviour on the bank.
+
+**Recall is untouched by truth protection by explicit design** (*"a protected star is not promoted to a required
+find"*) and remains the weak axis -- and it is tier-dependent, which is why `recall@high` and `recall@all` are
+both printed and a bare "recall" never is.
+
+## SEVEN ROWS ARE SCORED AT A DETECTION BINNING THE OPTIMIZER DOES NOT USE -- `RULE D27`, and it MOVED
+
+`golden eval` prints, on 7 of the 20 cells below, *"this run's derived detection binning is 2 ... but it is being
+scored at 1. Pass `--detection-binning` to score it at its own factor; `optimize` uses the derived one by
+default."* Those 7 are exactly the rows whose `det binning rec` column reads `rec 2 / applied 2 vs 2 MATCH`, so
+their precision/recall and their binning columns rest on contradictory assumptions.
+
+Re-scored at the optimizer's own factor on the same binary (B15, no build, `/mnt/d/hf_w27/table18_b2/`),
+**all 6 blind datasets moved** at the 0.01 bar this table prints to (`RULE D27` = **`D-MOVED`**):
+
+| dataset | recall@high f1 -> f2 | recall@all f1 -> f2 | prec f1 -> f2 |
+|---|---|---|---|
+| D08_c11_2800mm *(not blind)* | 1.000 -> 1.000 | 0.978 -> **1.000** | 0.966 -> **0.997** |
+| D09_c14_3800mm | 0.911 -> **1.000** | 0.949 -> **0.991** | 1.000 -> 1.000 |
+| D10_rc16_3250mm_sparse | 1.000 -> 1.000 | 0.965 -> **1.000** | 1.000 -> 1.000 |
+| D12_c14_585_afbin2 | 0.720 -> **0.776** | 0.705 -> **0.729** | 1.000 -> 1.000 |
+| **D14_cdk14_2563mm_e47** | 0.862 -> **0.995** | 0.641 -> **0.937** | 1.000 -> 1.000 |
+| D15_cdk20_3454mm_e47 | 0.920 -> 0.885 | 0.961 -> **0.949** | 1.000 -> 1.000 |
+| D17_cdk14_oiii5 | 1.000 -> 1.000 | 0.875 -> **1.000** | 1.000 -> 1.000 |
+
+**The factor-1 column below UNDERSTATES recall on those seven rows** -- `D14` by **30 points**. `D15` is the only
+one that fell, by 0.012. The factor-1 values are kept below because they are what was published and what the
+optimize columns were produced alongside; read the seven against this table.
+
+Validity: `D27-V1` (each factor-2 log prints `; detectionBinning 2` and no longer prints the `scored at 1` NOTE)
+**7 of 7**, with its FAIL end run on a real factor-1 cell; `D27-V2` (coordinate-collapse guard,
+`recall@all >= 0.25`) **7 of 7**, min `0.729`. The invocation differs from the one that produced the table below
+by `--detection-binning 2` and a `--profile-id` pin **demonstrated inert** (`D09` re-run at factor 1 with the pin:
+20 of 20 artifacts byte-identical).
+
+*Coincidence worth naming so nobody reads it as vindication:* the withdrawn banner guessed `D08`'s precision at
+`0.997`, and `0.997` is what factor-2 scoring gives. The mechanisms are unrelated -- the banner's own arithmetic
+yields `0.972`, and factor 2 helps because the wing-frame junk largely disappears at half resolution.
 
 | dataset | prec | recall@high | recall@all | opt time (s) | score BestJ (from BaselineJ) | sigma Best (from Baseline) | exposure rec vs optimal | det binning rec vs optimal | BrightnessSensitivity (effective gate) |
 |---|---|---|---|---|---|---|---|---|---|

--- a/docs/wave27-register-correction-survey.md
+++ b/docs/wave27-register-correction-survey.md
@@ -1,0 +1,717 @@
+# Wave 27 — register-correction survey: the F31 misreading, inventoried
+
+**Working document.** Produced by the wave-27 survey agent, 2026-08-13, branch
+`ghilios/synthetic-af-bank-followups-wave27`. No code, no commits, no edits to any file listed below —
+this is the line-anchored inventory the controller decides from.
+
+---
+
+## 0. THE ARITHMETIC, REPRODUCED — this settles it
+
+Every claim in this survey rests on one reproduction. Wave 26's re-score
+(`/mnt/d/hf_w26/pd08/F31_truth_rescore.txt`) and `golden eval`'s own report are **both correct**; they
+report **two different quantities**, and wave 26 read the first as if it were the second.
+
+Re-derived here from the same on-disk artifacts (`/mnt/d/hf_w25/table18/D08_c11_2800mm/attempt01/detected_f*.csv`
+against `/mnt/d/SyntheticAutofocusBank/D08_c11_2800mm/attempt01/*.golden.json` + `*.truth.json`, centre-in-box
+match on `stars` as the run used, 12.0 px radius for protection):
+
+| focuser | det | **not in `stars`** | in golden `unresolved` | within 12 px of `omitted`/`merged-into` | within 12 px of ANY truth | **FP after protection** |
+|---|---|---|---|---|---|---|
+| 13672 | 10 | 4 | 1 | 0 | 0 | **3** |
+| 13754 | 16 | 3 | 0 | 3 | 3 | **0** |
+| 13836 | 48 | 19 | 7 | 12 | 19 | **0** |
+| 13918 | 92 | 27 | 9 | 18 | 27 | **0** |
+| 14000 | 119 | **38** | **15** | **23** | 38 | **0** |
+| 14082 | 97 | 32 | 9 | 23 | 32 | **0** |
+| 14164 | 45 | 16 | 7 | 9 | 16 | **0** |
+| 14246 | 16 | 2 | 1 | 1 | 2 | **0** |
+| 14328 | 15 | 9 | 1 | 0 | 0 | **8** |
+| **total** | 458 | **150** | **50** | **89** | **137** | **11** |
+
+- The **150** and the **137** are wave 26's numbers, reproduced exactly.
+- `golden eval`'s reported `FP=11` is reproduced exactly
+  (`/mnt/d/hf_w25/table18/D08_c11_2800mm/attempt01/golden_eval.txt`: `OVERALL: TP=308 FP=11 FN=7 precision=0.966`,
+  per-frame FP column `3 0 0 0 0 0 0 0 8`).
+- **50 + 89 = 139 of the 150 were already excluded** by the run that produced the owner's table: 50 by the
+  golden's own `unresolved` boxes, 89 by `TruthProtection`. Wave 26's re-score consulted **neither**.
+- The controller's `D08 @ 14000` decomposition is confirmed to the unit: **119 = 81 TP + 15 `unresolved` +
+  23 truth-protected, FP = 0.**
+- **The "13 junk" figure is also wrong**, by 2: `150 − 137 = 13` detections have no truth star within 12 px,
+  but **2 of them (one per wing frame) sit inside a golden `unresolved` box** and are therefore already excluded.
+  The correct count of genuinely spurious detections on `D08` is **11**, which is what `golden eval` prints.
+
+**Wiring confirmed live at B15.** `GoldenEvalRunner.cs:301-307` and `BankVerifyRunner.cs:464-466` both call
+`TruthProtection.ExcludeProtected(GoldenMatch.ExcludeUnresolved(...))`. The repair landed 2026-08-03 in
+`aaf26e8` (14:56 EDT), refined by `5c382a1` (17:04 EDT); `867d41c` re-baselined. `aaf26e8` touched **both**
+runners in the same commit.
+
+---
+
+## 1. FINDINGS, ranked by load on the owner's deliverable
+
+Severity key: **FALSE** (states something untrue) · **STALE** (was true, superseded) ·
+**MISLEADING** (technically defensible, reads wrong) · **CORRECT-AND-LOAD-BEARING** (cite as counter-evidence,
+do not touch) · **GAP** (nothing false; a missing disclosure that let the misreading happen).
+
+---
+
+### FINDING 1 — **FALSE** · `docs/synthetic-af-bank-results-table.md:7-24` · *the owner's deliverable, top of page*
+
+**#1 most load-bearing.** This is the banner the owner reads first.
+
+**Line 7, as written:**
+```
+## READ THE PRECISION COLUMN AS A LOWER BOUND
+```
+
+**Lines 13-17, as written:**
+```
+**Of the 150 detections the golden calls false, 137 (91.3 %) match a REAL rendered star.** The golden reference
+lists **9** stars on a frame where the renderer placed **126**. `D08`'s true precision is therefore nearer
+**0.997** than the **0.966** in the table below, and every `1.000` in the column is a floor rather than a
+ceiling -- the reference under-lists, most heavily at extreme defocus, and the detector is scored down for
+finding what the reference omitted ([F31](followups.md)).
+```
+
+Four separate false statements:
+1. *"the precision column is a lower bound"* — it is not; the column is truth-protected at source.
+2. *"`D08`'s true precision is nearer 0.997 than 0.966"* — `0.966` **is** the truth-protected number
+   (`308/(308+11)`). `0.997` is not a precision the bank can produce under any policy; it is an artifact of
+   re-deriving FP from `stars` alone and then re-adding 137.
+3. *"every `1.000` in the column is a floor rather than a ceiling"* — the nineteen `1.000` rows all read
+   `FP=0` **after** protection (verified in all 20 `golden_eval.txt` files, §2 below). 1.000 is a ceiling by
+   arithmetic; nothing can lift it.
+4. *"the detector is scored down for finding what the reference omitted"* — it is not, and has not been since
+   2026-08-03.
+
+**Lines 19-21, as written:**
+```
+**The 13 genuine junk detections are real, and they are localised:** all 13 fall on the two extreme wing frames
+and **zero** on any of the seven interior frames. That is a detector-at-its-limit observation, not a reference
+artifact, and it is the only measured false-positive behaviour on the bank.
+```
+**MISLEADING + off by 2.** The localisation claim is **correct and survives** — but the count is **11**, not 13
+(§0), and it does not need the re-score to establish: `golden_eval.txt`'s own per-frame FP column already says
+`3` and `8` on the wings and `0` on all seven interior frames.
+
+**Line 23-24** (*"Recall is unaffected by this correction and remains the weak axis"*) — **CORRECT and worth
+keeping**, but it is currently framed as a rider on a correction that did not happen.
+
+**Minimal replacement for lines 7-21:**
+```
+## The precision column is truth-protected, and it is a measurement — not a lower bound
+
+Scored with the F31 repair live (`TruthProtection`, on `develop` since 2026-08-03, wired into both
+`GoldenEvalRunner.cs:301-307` and `BankVerifyRunner.cs:464-466`). A detection landing on a real rendered star
+the golden policy dropped -- tier `omitted` or `merged-into` -- is excluded from the false-positive count, at
+exactly the match radius matching itself uses. `D08`'s `0.966` is `308 TP / (308 + 11 FP)` with that protection
+applied; the nineteen `1.000` rows carry `FP = 0` after it. **1.000 is a ceiling here, not a floor.**
+
+**The 11 genuine junk detections are real, and they are localised:** `golden eval`'s own per-frame FP column for
+`D08` reads 3 on `13672`, 8 on `14328`, and **zero on all seven interior frames**. That is a
+detector-at-its-limit observation, and it is the only measured false-positive behaviour on the bank.
+
+**Recall is the weak axis**, and it is tier-dependent, which is why `recall@high` and `recall@all` are both
+printed and a bare "recall" never is.
+```
+*(Also worth adding to line 3-4's provenance block: the run's scoring mode, since the artifact does not record
+it — see FINDING 12.)*
+
+---
+
+### FINDING 2 — **FALSE** · `docs/waves22+-handoff-prompt.md:172` · *the top backlog item the next run opens on*
+
+**#2 most load-bearing.** This directs the next wave's first 1-2 hours at work that is already done.
+
+**As written (line 172, the `#1` row):**
+```
+| **1** | **Re-measure precision against `*.truth.json`, not `*.golden.json`, across the bank** | **~1–2 h, NO
+product code, NO binary** | **3, and it re-scores the owner's table** | **NO** | **Now the prerequisite for
+every objective-shaped decision, and demonstrably cheap.** ... Measured on `D08` on 2026-08-13: **91.3 % of
+golden-false detections are REAL rendered stars**, `0.30` expected by chance. **This is why [F23](followups.md)
+is `won't fix as written` — its evidence base was this same artifact — so without a truth-based pass, F23 and
+[F83](followups.md) are BOTH undecidable.** The owner's results table's precision column is a lower bound until
+this runs |
+```
+
+Three defects: (a) the item is **already discharged** (wave 2, 2026-08-03) and shipped; (b) *"the precision
+column is a lower bound until this runs"* is false; (c) the F23 clause is **half true and must be split** —
+F23's *original* evidence base genuinely was the pre-repair metric (correct), but that does **not** make F23 or
+F83 "undecidable" today, because F23 was already re-measured at `afbank-verify/5`
+(`followups.md:1458-1490`) and the re-measurement is what voided it.
+
+**Minimal replacement — strike the item and replace it with what actually remains:**
+```
+| ~~**1**~~ | ~~**Re-measure precision against `*.truth.json`, not `*.golden.json`**~~ **ALREADY DONE —
+2026-08-03, wave 2 (`aaf26e8` / `5c382a1`), shipped as `TruthProtection` and wired into BOTH
+`GoldenEvalRunner` and `BankVerifyRunner`.** Wave 26's `91.3 %` re-derived false positives from the golden's
+`stars` list alone, ignoring both the golden's `unresolved` boxes and `TruthProtection`; of its 150,
+**139 were already excluded** by the run that produced the table (50 unresolved + 89 truth-protected) and
+`golden eval` reported **FP = 11**, precision **0.966**, exactly as printed. **The owner's table is correct as
+published.** F23 was re-measured at `afbank-verify/5` and is voided on that re-measurement, not undecidable.
+See [F31](followups.md) | done | 3 | no | struck |
+| **1** | **Disclose the scoring mode in `golden eval`** — it prints none, so no reader of a `golden_eval.txt`
+can tell whether protection was applied | **~30 m, TestApp only** | instrument integrity | yes | `bank-verify`
+prints `scoring: golden+truth-protected (N ... protected)` (`BankVerifyRunner.cs:302-306`) and persists
+`scoringMode`/`protectedStars`; `golden eval` emits nothing equivalent to console, `golden_eval.txt`, either
+CSV, or any JSON. **This omission is the direct cause of the wave-26 misreading** |
+```
+
+**Line 171 (the struck `~~1~~` row)** carries the same `91.3 % reference omission` clause — **FALSE**, same fix.
+
+**Line 188, as written:**
+```
+**Is another wave worth it? YES, and the answer changed on 2026-08-13.** The old item 1 ran and was refuted,
+which removed the last measured support for acting on the sensitivity pin — but the same afternoon's work
+showed that **the bank's precision numbers are measured against a reference that under-lists by an order of
+magnitude at defocus.** So the next run has a genuine, binary-free, ~1–2 h opening item (the truth re-score)
+whose result decides two long-open entries (F23, F83) and re-scores the owner's deliverable. ...
+```
+**FALSE** (the middle clause and everything downstream of it). Minimal replacement:
+```
+**Is another wave worth it?** The old item 1 ran and was refuted, which removed the last measured support for
+acting on the sensitivity pin. The truth re-score that looked like a follow-on **was already shipped in wave 2**
+and the bank's precision numbers are truth-protected; what the 2026-08-13 exercise actually exposed is that
+`golden eval` does not disclose its scoring mode, which is a ~30 m instrument fix. **After that, item 8 —
+recall on wide fields — is the largest untouched product gap in the series** and is worth a design before it is
+worth an arm.
+```
+
+**Lines 14 / 17 / 67** (the three-line state block and the "next" pointer) route the reader to §1c; they carry
+no false precision claim themselves, but *"one item needs ~2 minutes and no binary"* (line 17) refers to the
+already-struck P-D08 item. **STALE**, cosmetic.
+
+---
+
+### FINDING 3 — **FALSE** · `docs/waves27+-autonomous-prompt.md:152-163` · *§7, the charter for the run in progress*
+
+**#3 most load-bearing.** Verbatim propagation of FINDING 2 into the live charter's "what is open" section.
+
+**As written (lines 154-160):**
+```
+**Start there.** Its item **1** is the one to open on:
+
+> **Re-measure precision against `*.truth.json`, not `*.golden.json`.** ~1–2 h, **no product code, no binary, no
+> gate.** The renderer's complete star list ships beside every frame — **126** stars where the golden lists **9**
+> at extreme defocus. Measured on `D08`: **91.3 %** of golden-false detections are **real rendered stars**, 0.30
+> expected by chance. **[F23](followups.md) is `won't fix as written` because its evidence base was this same
+> artifact**, so until a truth-based pass exists, **F23 and [F83](followups.md) are both undecidable** and the
+> owner's results table's precision column is a lower bound.
+```
+
+**Minimal replacement:**
+```
+**Start there.** Its item 1 is **struck** — the truth re-score it proposes shipped on 2026-08-03 (`aaf26e8`,
+`TruthProtection`, wired into both `GoldenEvalRunner` and `BankVerifyRunner`), and wave 26's `91.3 %` was a
+re-derivation of the PRE-REPAIR quantity. The owner's table is correct as published. The item that replaces it:
+
+> **Make `golden eval` disclose its scoring mode.** ~30 m, TestApp only. `bank-verify` prints
+> `scoring: golden+truth-protected (N real-but-unboxed truth stars protected ...)` and persists
+> `scoringMode`/`protectedStars`; `golden eval` prints nothing, writes nothing, and has no JSON at all — which
+> is exactly how a post-repair report was read as a pre-repair one ten days later.
+```
+
+Note lines 165-170 (**recall on wide fields**) and 171-178 (**fenced/rejected**) are unaffected and correct.
+
+---
+
+### FINDING 4 — **FALSE** · `docs/followups.md:432-514` · **F84**, the register entry that carries the misreading
+
+**#4 most load-bearing** — this is where the next reader looks it up.
+
+**Line 459-462 (state-of-play item 4), as written:**
+```
+4. **It does not measurably cost precision.** `P-D08` **REFUTED at n = 3**: `D01` (gate 0.2234) and `D16`
+   (0.1969) both carry base precision **1.000 with ZERO false positives**. And `D08`'s apparent cost is
+   **91.3 % reference omission** — 137 of its 150 golden-false detections match a **real rendered truth star**
+   at the same 12 px radius, against **0.30** expected by chance. That is [F31](#f31)'s mechanism, quantified.
+```
+**The first sentence is CORRECT and stands.** The `91.3 %` sentence is **FALSE**. Minimal replacement for the
+second half:
+```
+   And `D08`'s residual `11` false positives are **already truth-protected** — the run that produced the table
+   excluded 139 of 150 non-`stars` detections (50 by the golden's own `unresolved` boxes, 89 by
+   `TruthProtection`). Wave 26's `91.3 %` re-derived the PRE-REPAIR quantity; it does not describe the scored
+   metric. `D08`'s `0.966` is a measurement.
+```
+
+**Lines 476-479, as written:**
+```
+**But do NOT simply switch it on.** F23 is `Won't fix as written` **because its evidence base was VOID** — the
+precision collapse it was built to stop (0.993 -> 0.451 on `D09`) was measured against the same under-listing
+golden this entry quantifies at 91.3 %. **Enabling a penalty calibrated against void evidence would trade real
+recall for an artifact.** The decision needs (2) first.
+```
+**MISLEADING — half correct, and this is the half the survey brief warns about.** F23's *wave-1* evidence
+genuinely was pre-repair, and *"do not switch it on"* stands. What is false is *"this entry quantifies at
+91.3 %"* (it does not; F31 quantified it at 96.1 % on D09 pre-repair and then **repaired it**) and *"the
+decision needs (2) first"*. Minimal replacement of the last two clauses:
+```
+... was measured against the pre-repair golden-only metric that [F31](#f31) repaired on 2026-08-03. Re-measured
+at `afbank-verify/5`, F23's effect is real but ~1/5 the reported size (`followups.md` F23's void banner).
+**Enabling a penalty calibrated against the pre-repair numbers would trade real recall for an artifact** — but
+the re-measurement that decides it already exists.
+```
+
+**Lines 481-486 (item 2 of "what is owed"), as written:**
+```
+**(2) Re-measure precision against `truth.json`, not `golden.json`. ~1-2 h, no product code.** This is the
+prerequisite for every objective decision, and it is now demonstrably cheap: ... A truth-based precision pass
+would give **the first honest precision numbers on this bank** and would say whether a precision term is worth
+adding at all. **Without it, F23 and F83 are both undecidable.**
+```
+**FALSE in full — delete the item and renumber.** *"the first honest precision numbers on this bank"* is
+precisely what wave 2 delivered. Minimal replacement:
+```
+**(2) ~~Re-measure precision against `truth.json`~~ — ALREADY SHIPPED (2026-08-03, `aaf26e8` + `5c382a1`).**
+`TruthProtection` protects every `omitted`/`merged-into` truth star from FP scoring at the match radius, in
+BOTH `golden eval` and `bank-verify`, and the null control (`precisionNull` 0.000-0.012 on the wave-2 offline
+matrix; 0.000-0.169 across all 51 `bank-verify` config rows) shows the repaired metric measures rather than
+saturates. What is NOT shipped is **disclosure**: `golden eval` prints no scoring mode. ~30 m, TestApp only.
+```
+
+**Line 508, as written:** `**no measured precision** — \`P-D08\` refuted at n = 3, and \`D08\`'s cost 91.3 % artifact.`
+**FALSE** in its second clause. Replace with: `... and \`D08\`'s residual 11 FPs are already truth-protected and
+confined to the two wing frames.` The **kill list itself (lines 503-508) is correct and stands.**
+
+**Lines 512-514 (the one-sentence version), as written:**
+```
+**The pin is currently harmless, is a real optimum of an objective that cannot see precision, and the only thing
+worth doing before touching it is measuring precision against the renderer's truth instead of a reference that
+under-lists by an order of magnitude at defocus.**
+```
+**FALSE in its second half.** Minimal replacement:
+```
+**The pin is currently harmless, is a real optimum of an objective that cannot see precision, and the precision
+measurement that would price it already exists — the bank has been scored against the renderer's truth since
+2026-08-03, and it reads 0.966-1.000.**
+```
+
+**Lines 496-499 (item 4, the 13 junk detections)** — **MISLEADING, off by 2**: it is **11**, and the claim needs
+no re-score at all (`golden_eval.txt`'s own per-frame FP column already localises them). Otherwise correct and
+worth keeping as an open item.
+
+**Line 435** (`reframed by [F31](#f31) and [F23](#f23)`) — leave; F31 *is* the right cross-reference, it was
+just read backwards.
+
+---
+
+### FINDING 5 — **STALE/FALSE** · `docs/followups.md:650-661` · **F83** caveat 3
+
+**As written (656-661):**
+```
+3. **`D08`'s 11 false positives sit exactly where F31 says the reference is incomplete** — **3 on frame `13672`
+   and 8 on frame `14328`, the two extreme wing frames, and 0 on all seven interior frames.** F31 measured the
+   mechanism on **this dataset by name**: ... The base cell accepts 10 and 15 on frames whose golden
+   holds 9. **So the +0.034 may be real faint stars the golden omits rather than junk**, and separating the two
+   needs a re-score against each frame's own `*.truth.json` — F31's own method, **not run**.
+```
+
+The **frame localisation is correct**. The conclusion is **FALSE**: the separation was already performed by the
+scorer. Verified here: on `13672` and `14328`, **zero** of the 11 residual FPs are within 12 px of *any* truth
+star. Minimal replacement of the final sentence:
+```
+   **The separation is already in the number.** Those 11 are the residue after `TruthProtection` excluded every
+   detection within the match radius of an `omitted`/`merged-into` truth star; re-checked against
+   `*.truth.json`, **none of the 11 has any truth star within 12 px.** They are junk, and the `+0.034` is a
+   real precision gain — one confined to two extreme-defocus frames.
+```
+This is a **strengthening** of F83's `P-D08` result, not a weakening: caveat 3 currently withholds a conclusion
+the data supports.
+
+**Caveats 1 and 2 (lines 652-655) are CORRECT-AND-LOAD-BEARING and must not be touched.** Caveat 2's quote of
+F31's saturation warning is still exactly right, and the null control (FINDING 15) is its answer.
+
+---
+
+### FINDING 6 — **STALE** · `docs/followups.md:682` · F83 option (c)
+
+**As written:** `... But it makes \`J\` depend on the golden, whose precision F31 shows is a **lower bound**
+that evaporates at the sweep wings`
+
+**Minimal replacement:** `... But it makes \`J\` depend on the golden. The golden's \`stars\` list DOES evaporate
+at the sweep wings (D08: 81 at focus, 9 at the extreme frame) — precision is protected against that,
+**recall@all is not**, so a labelled \`J\` would be reading a recall denominator that shrinks with defocus.`
+
+*(This preserves the objection, which is real, and re-bases it on the half of the mechanism that is still true.)*
+
+---
+
+### FINDING 7 — **STALE** · `docs/followups.md:690` · F83's next step
+
+**As written:** `**Score it against \`*.truth.json\` as well as the golden**, or caveat 3 above applies to the
+replication too.`
+
+**Minimal replacement:** `Its \`golden eval\` score is already truth-protected, so caveat 3 does not apply to
+the replication.` *(The replication itself already ran — see the struck item 1 in the handoff — so this line
+may simply be deleted.)*
+
+---
+
+### FINDING 8 — **MISLEADING (title only)** · `docs/followups.md:2851` · **F31**'s heading
+
+**As written:**
+```
+### F31 — Synthetic-bank precision is NOT exact: the golden omits real stars, and they score as false positives
+```
+The status line immediately below says **Done**, but the **title is in the present tense**, and the title is
+what gets grepped, quoted and linked. Wave 26 cited F31 four times while reading the title's claim as current.
+
+**Minimal replacement:**
+```
+### F31 — ~~Synthetic-bank precision is NOT exact: the golden omits real stars, and they score as false positives~~ → REPAIRED: detections on dropped truth stars are protected from FP scoring
+```
+*(Same treatment F23 and F24 already carry — strikethrough plus the resolution — so the register is internally
+consistent about how a closed-and-inverted entry is titled.)*
+
+**Optional, and cheap:** a one-line marker at line 2896, immediately before *"Why it matters — this also
+inverts the bank's selling point"* — the paragraph wave 26 quoted — reading
+`**(As found, 2026-08-03. Repaired the same day; see "Re-scored with the repair in place" below.)**`. That
+paragraph (2896-2899) is **CORRECT AS HISTORY** and must stay; it just needs a tense marker, since it is the
+single most quotable sentence in the entry and is three paragraphs above its own repair.
+
+---
+
+### FINDING 9 — **HISTORICAL RECORD, annotate in place** · `docs/synthetic-af-bank-followups-w26-pd08-followon.md:103-152`
+
+This is where the 91.3 % was produced. **It is the record of a wave that ran and it must not be rewritten to
+conclude otherwise.** The measurement itself is arithmetically correct; only its interpretation is wrong.
+
+**Where the annotation belongs: immediately after line 103's heading**, i.e. between
+`# F31's caveat, SETTLED — 91.3 % of \`D08\`'s "false positives" are real stars the golden omits` (line 103)
+and the `Measured 2026-08-13T09:29Z` paragraph (line 105) — so no reader reaches the table without it.
+
+**Annotation text:**
+```
+> ## ⚠ CORRECTED 2026-08-13 (wave 27) — THIS SECTION MISREADS ITS OWN INPUT
+>
+> The measurement below is arithmetically correct and reproduces exactly. **Its interpretation is not.** The
+> `FP vs golden` column re-derives false positives from the golden's `stars` list ALONE. The scorer that
+> produced the owner's table excludes two further populations: the golden's own `unresolved` boxes
+> (**50** of the 150) and, since the [F31](followups.md) repair of 2026-08-03 (`aaf26e8`, `TruthProtection`,
+> wired into `GoldenEvalRunner.cs:301-307`), every detection within the match radius of an `omitted`/
+> `merged-into` truth star (**89** of the 150). `golden eval` reported **FP = 11**, precision **0.966** —
+> already truth-protected. **The `150` is the PRE-REPAIR quantity and the `0.997` does not exist under any
+> scoring policy.** The two conclusions below invert accordingly: conclusion 1 is withdrawn; conclusion 2
+> stands, with the count corrected from 13 to **11** (two of the 13 sit inside a golden `unresolved` box).
+```
+
+The heading itself (line 103) should also be struck through in place —
+`# ~~F31's caveat, SETTLED — 91.3 % ...~~ → the caveat was already closed in wave 2; see the correction below`
+— since it is what the handoff and the charter quote.
+
+**Lines 143-150** (the "What this does to the sensitivity story" bullets) carry the error forward. Line 145
+(`- \`D08\`'s apparent precision cost is **91.3 % reference omission**;`) needs the same in-place strike.
+**Lines 149-152 (the F83 paragraph) are CORRECT and unaffected** — `J` still carries no precision term, and the
+final sentence's irony now cuts the other way, which is worth recording rather than deleting.
+
+---
+
+### FINDING 10 — **HISTORICAL RECORD, annotate in place** · `docs/synthetic-af-bank-followups-wave26-results.md:475-483` (§8.3 caveat 3)
+
+Wave 26's results doc predates the re-score (it says the re-score was *"not run"*), so its text is **honest for
+the wave it records** — it is the downstream `w26-pd08-followon.md` that ran it and misread it. Two touches:
+
+**Lines 481-483, as written:**
+```
+   stars the golden omits, rather than junk.** Distinguishing the two requires re-scoring against each frame's
+   own `*.truth.json` — F31's own method — **which this wave did not run**.
+```
+**Annotation, appended in place (do not alter the sentence):**
+```
+   > **Corrected 2026-08-13 (wave 27):** the distinction was already made by the scorer. `golden eval` has
+   > applied `TruthProtection` since 2026-08-03, so these 11 are the residue AFTER truth protection; none has a
+   > truth star within 12 px. They are junk. The follow-on that claimed 91.3 % re-derived the pre-repair
+   > quantity — see `docs/synthetic-af-bank-followups-w26-pd08-followon.md`.
+```
+
+**Lines 539-541 (§ option (c)):** `it makes \`J\` depend on the golden, and §8.3 plus [F31](followups.md) say
+the golden's precision is a **lower bound** that evaporates at the sweep wings.` — **STALE**, same correction as
+FINDING 6, but as an in-place annotation rather than a rewrite.
+
+**Line 630** (`| **[F31](followups.md)** | **CITED** — §8.3's caveat is F31's mechanism, on F31's own named
+dataset |`) — **MISLEADING**; it cites F31's *defect* where F31's *repair* was the applicable half. One-line
+annotation: `(wave 27: cited to F31's pre-repair mechanism; F31's repair had been live since 2026-08-03.)`
+
+**Line 472** (quoting F31's saturation warning) — **CORRECT-AND-LOAD-BEARING**, leave alone.
+
+---
+
+### FINDING 11 — **CONTRADICTION IN SOURCE (root cause)** · `GoldenFromTruth.cs` · *report, do not fix*
+
+`TruthProtection.cs:30-33` names this explicitly:
+> *"the policy's own doc comments say so in two places that contradict each other"*
+
+**The two comments, verbatim:**
+
+`Joko.NINA.Plugins/TestApp/SynthBank/GoldenFromTruth.cs:34-36`
+```csharp
+/// <summary>The star was dropped entirely: it produces no box anywhere in <see cref="GoldenFrame"/>,
+/// so a detector reporting something at its location should be scored as a false positive.</summary>
+public const string Omitted = "omitted";
+```
+
+`Joko.NINA.Plugins/TestApp/SynthBank/GoldenFromTruth.cs:76-84`
+```csharp
+/// <summary>
+/// Peak-pixel SNR floor: at/above this (but below <see cref="LowSnr"/>) a star is real but
+/// <see cref="SyntheticTier.Unresolved"/> — neither a required find nor a false positive. Below it the
+/// star is <see cref="SyntheticTier.Omitted"/> entirely. This idealized noise model has no matched
+/// filter and no local background estimate, so below ~3.5σ its own peak-pixel test cannot vouch for
+/// visibility with any confidence; scoring a detection there as a false positive would be punishing a
+/// detector for something the reference itself cannot certify either way.
+/// </summary>
+public double UnresolvedSnr { get; init; } = 3.5;
+```
+
+They state opposite policies for the *same* population. **`:34-36` is the one that is now factually wrong**:
+since `aaf26e8`, a detection on an `omitted` star is **not** scored as a false positive on the synthetic bank.
+
+**A third site repeats the wrong version at runtime** — `GoldenFromTruth.cs:744-748` writes it into every
+golden sidecar's per-star `Reason` field:
+```csharp
+reason = $"peak SNR {F(comp.CombinedSnr)} < unresolvedSnr {F(thresholds.UnresolvedSnr)}"
+    + (members.Count > 1 ? $" (combined over {members.Count} merged stars)" : "")
+    + " -> omitted; a detection here should count as a false positive";
+```
+This string is **on disk in every `*.golden.json` in the bank**, so anyone inspecting a sidecar reads the
+pre-repair policy from the data itself. That is a strong candidate for the actual root cause of the wave-26
+misreading and is worth a wave-27 fix on its own.
+
+**Minimal replacements** (report only — the survey does not apply them):
+- `:34-36` → `/// <summary>The star was dropped from the golden entirely: it produces no box anywhere in <see cref="GoldenFrame"/>. On the SYNTHETIC bank a detection at its location is NOT a false positive — <see cref="TruthProtection"/> protects it from FP scoring at the match radius (F31, 2026-08-03), because the reference cannot certify a sub-3.5σ star either way. The tier means "absent from the golden", not "spurious".</summary>`
+- `:748` → `" -> omitted; TruthProtection protects a detection here from FP scoring (F31)"`
+
+---
+
+### FINDING 12 — **GAP (the mechanism that allowed all of the above)** · `GoldenEvalRunner.cs`
+
+`golden eval` **never states which scoring policy it used.** See §3, answer 3. This is the single change that
+would have made the wave-26 misreading impossible, and it is ~30 m of TestApp code.
+
+---
+
+### FINDING 13 — **STALE (retired charter)** · `docs/waves22-27-autonomous-prompt.md:216`
+
+**As written:** `... **Score against \`*.truth.json\` as well as the golden** — [F31](followups.md) |`
+Superseded by `docs/waves27+-autonomous-prompt.md`, and the item is struck in the handoff. The file carries
+**no superseded banner** — worth one line at the top rather than an edit to line 216. Low priority.
+
+---
+
+### FINDING 14 — **GAP** · `.claude/docs/golden-star-set.md`
+
+Documents `golden eval` end-to-end for the **real** bank and never mentions that on the **synthetic** bank the
+same command applies `TruthProtection`. Nothing in it is false (line 51's `unresolved` discussion is the real
+bank's `budget-truncated` population, a different thing; line 87's *"HF has ~perfect precision but low recall"*
+is a real-bank statement and correct). But a reader sent here to interpret a synthetic `golden_eval.txt` learns
+nothing about protection. **Minimal addition**, after the `golden eval` bullet around line 61:
+```
+- **On the SYNTHETIC bank only**, `golden eval` and `bank-verify` additionally protect detections landing on
+  real rendered stars the golden policy dropped (`*.truth.json`, tiers `omitted`/`merged-into`) from the
+  false-positive count, at the match radius — `TestApp/SynthBank/TruthProtection.cs`, F31. Real-bank runs have
+  no truth sidecar, so the path is a no-op and real-bank numbers are unaffected. `bank-verify` announces this
+  (`scoring: golden+truth-protected`); **`golden eval` does not**, so date the run against 2026-08-03.
+```
+
+---
+
+### FINDINGS 15-20 — **CORRECT-AND-LOAD-BEARING** · cite these, change nothing
+
+| # | file:lines | what it says | why it is the counter-evidence |
+|---|---|---|---|
+| 15 | `docs/synthetic-af-bank-followups-wave2-results.md:15,36-79,122` | the repair, the offline validation matrix, `precisionNull` 0.000-0.012, `truthViolations` 0 on all 51 rows, and the `/3`-vs-`/4`-vs-truth agreement to 0.006 | **The primary counter-evidence.** It is the document that already answered wave 26's question, on five datasets, in wave 2 |
+| 16 | `docs/followups.md:1458-1490` (F23's void banner) | *"THE EVIDENCE BASE ABOVE IS VOID … re-measured at `afbank-verify/5`"*, with the before/after table | Shows F23 was **re-measured, not left undecidable**. Directly refutes FINDING 2's "both undecidable" |
+| 17 | `docs/followups.md:2901-2957` (F31's repair half) | the `/4` re-score, the saturation caution, the null control, the `/5` shipping note, the lesson | The entry contains its own refutation of the wave-26 reading, three paragraphs below the sentence wave 26 quoted |
+| 18 | `docs/followups.md:8615-8688` (**F11**) | precision is a lower bound on **REAL-bank** runs whose faint tier was `--budget-montages`-truncated | **Do NOT sweep this in.** Different bank, different mechanism (QA budget vs SNR tiering), no `TruthProtection` path (real frames have no `*.truth.json` — `TruthProtection.LoadForImage` returns null and scoring is unchanged), **still valid and still open** |
+| 19 | `docs/af-bank-noiseclip-sweep-results.md:103,119,124,149` | *"Precision is a lower bound, not the true value"* | **REAL bank.** F11's mechanism. Correct, leave alone |
+| 20 | `docs/synthetic-af-bank-improvements-summary.md:68-69,93` | *"The synthetic bank's precision metric was wrong and is repaired (F31) … Null-controlled"*, *"A repaired `golden eval` precision/recall path (F31), so a bank precision number means what it says"* | The owner-facing summary **already says the repair shipped, and names `golden eval` specifically.** This document and the results-table banner contradict each other today |
+
+**Two more that need a careful read, not a change:**
+
+- `docs/synthetic-af-bank-design.md:12` — *"So `bank-verify` precision is a **lower bound**"* — this is the
+  **REAL** bank, in the Problem statement. **CORRECT.** Line 26 — *"precision becomes exact rather than a lower
+  bound"* — is the synthetic bank's design promise; F31 found it unmet **and then met it**. Both stand.
+- `docs/synthetic-af-bank-baseline-results.md:26` — *"Golden precision (D06, `golden eval`) **1.000** — 205 TP,
+  **0 FP**. Exact, not a lower bound"* — this is the sentence F31 opens by quoting as overclaimed. **Its
+  numbers are pre-repair and should not be re-used as-is** (the `205 TP` cell is a `/3`-era vector). But the
+  *claim* it makes has since been made true: `D06` at wave 18's optimized vector reads `TP=304 FP=0`,
+  precision **1.000**, under the repaired metric (§2). The page is pre-repair (created 2026-08-02) and carries
+  only a `SUPERSEDED` marker at line 115 pointing at the JSON. **MIXED-VINTAGE, flagged under Q4 below.**
+
+---
+
+## 2. Q1 — Is any published number in this series wrong as a result?
+
+**No. The controller's reading is CONFIRMED: every number in `docs/synthetic-af-bank-results-table.md` is
+correct as printed, and only the interpretive banner is false.**
+
+Verified directly against the twenty source reports the table cites
+(`/mnt/d/hf_w25/table18/D*/attempt01/golden_eval.txt`, B15, `BuildId d79dae73`, i.e. ten days post-repair):
+
+| | |
+|---|---|
+| `D08_c11_2800mm` | `OVERALL: TP=308 FP=11 FN=7 precision=0.966` → **`0.966` is correct as printed**, and it is the truth-protected value |
+| the other **19** rows | all read `FP=0` → `precision=1.000`, **after** protection. `D01` 13624/0, `D02` 11743/0, `D03` 1690/0, `D04` 28622/0, `D05` 10533/0, `D06` 304/0, `D07` 1266/0, `D09` 222/0, `D10` 111/0, `D11` 297/0, `D12` 232/0, `D13` 598/0, `D14` 767/0, `D15` 244/0, `D16` 447/0, `D17` 182/0, `D18` 29264/0, `D19` 5656/0, `D20` 8683/0 |
+| recall columns | untouched by the repair **by construction** — `TruthProtection` changes the FP side only; a protected star is never promoted to a required find (`TruthProtection.cs`, *"Recall is deliberately untouched"*). Every `recall@high` / `recall@all` in the table is comparable to every previously published number |
+| the non-precision columns | opt time, `BestJ`/`BaselineJ`, σ, exposure and binning recommendations, `BrightnessSensitivity` — none reads the golden's FP side at all |
+
+`0.997` does not correspond to any policy: truth-direct scoring on `D08` would give `445/458 = 0.972`, and the
+protected golden metric gives `308/319 = 0.966`. **The `0.997` in the banner is not a precision figure the bank
+can produce.**
+
+**One caveat the correction should carry forward, because it is real and independent of all this:** the
+precision instrument has thin dynamic range at these vectors — 19 of 20 rows at exactly 1.000 — which is F83
+caveat 2 and F31's own saturation warning. The **answer** to that is the null control (Q2), and the honest
+statement is *"precision is a measurement whose null is ~0, and 19 of 20 datasets have no measurable false
+positives at their landed vector"* — not *"the column is a lower bound"*.
+
+---
+
+## 3. Q2 — Was F31's null control ever generalised beyond `D09`?
+
+**Partly — and the part that covers the owner's table was never generalised at all, because `golden eval` has
+no null control.** There are **two distinct controls** in F31 and they have different reach:
+
+**(a) The coordinate-alignment null** — `followups.md:2886-2887`:
+> *"detections match truth at 100% as-is, 2.3% at 0.5× or 2× scale (chance), 0% under a 300 px shift"*
+
+**`D09` only. Never re-run on any other dataset, in any later wave.** It is a *coordinate-system* sanity check
+(are truth and detection in the same frame?), and the standing discipline applies verbatim: **a control
+demonstrated on one dataset is a control demonstrated on one dataset.**
+
+**(b) The `precisionNull` wraparound control** — `TruthProtection.ShiftForNullControl`, `NullShiftX/Y = 317/211`.
+**This one WAS generalised**, and immediately:
+- wave 2's offline matrix: **5 datasets** (`D09`, `D13`, `D17`, `D11`, `D12`), nulls **0.0000-0.0093**
+  (`synthetic-af-bank-followups-wave2-results.md:41-46`);
+- shipped into `bank-verify` at `afbank-verify/5` (`BankVerifyRunner.cs:480-484`) and reported **per config
+  row**: *"null control 0.000-0.169, `truthViolations` 0 on all 51 rows"* (wave-2 results line 15) — 17 datasets
+  × 3 arms;
+- promoted to an instrument gate: `precisionNullMax` 0.20, `truthViolationsMax` 0, in
+  `docs/synthetic-af-bank-expectations.json`.
+
+**The gap that matters for wave 27:** `golden eval` implements **neither** control. `ShiftForNullControl` and
+`CountWithinRadius` are called **only** from `BankVerifyRunner`. So the twenty rows of the owner's results
+table — all produced by `golden eval` — carry **no `precisionNull` and no `truthViolations`**. The 19×1.000
+column has never been null-tested *on the runs that produced it*; the assurance is transferred from
+`bank-verify` runs at different vectors. That is a defensible transfer and it should be **stated**, not
+assumed — and porting both guards to `golden eval` is a natural pairing with FINDING 12.
+
+**No later wave re-ran (a), and no wave has null-controlled a `golden eval` run.**
+
+---
+
+## 4. Q3 — Does `golden eval` report its scoring mode anywhere?
+
+**No. Nowhere. Not to the console, not to `golden_eval.txt`, not to either CSV, and it writes no JSON at all.**
+Confirmed by reading every write site in `GoldenEvalRunner.cs`.
+
+**What `bank-verify` does** (`BankVerifyRunner.cs:296-306`, persisted at `:344` / `:671` / `:779`):
+```csharp
+var scoringMode = truthByFocuser.Count > 0 ? "golden+truth-protected" : "golden";
+Console.WriteLine($"  scoring: {scoringMode}"
+    + (truthByFocuser.Count > 0
+        ? $" ({protectedStars} real-but-unboxed truth stars protected from FP scoring across {truthByFocuser.Count} frames)"
+        : " (no truth sidecars; false positives scored against the golden alone)"));
+```
+plus `scoringMode` / `protectedStars` / `precisionNull` / `truthViolations` / `scoredFraction` persisted per
+config row in its JSON.
+
+**What `GoldenEvalRunner` emits, exhaustively:**
+
+| artifact | write site | says anything about protection? |
+|---|---|---|
+| console header | `:149-150` (`Profile:`, `Output: … params=… match=… iou=… pixelScale=…`) | **no** |
+| console per-run | `:196` `matchRadius`, `:260` `pixelScale`, `:271` derived-binning note, `:388` per-frame `golden= accepted= TP= FP= FN=` | **no** |
+| `golden_eval.txt` | `:733`; header built at `:663-679` — `params`, `pixelScale`, `matchRadius`, `match`, detector knobs, defocus knobs | **no** |
+| `golden_eval_frames.csv` | `:647`; header `focuser,params,golden,accepted,TP,FP,FN,precision,recall,f1,recallHigh,recallHighMed,recallAll,fnAcceptedElsewhere,fnNoCandidate,fnRejected` | **no** |
+| `golden_eval_regions.csv` | `:659` | **no** |
+| `false_negatives_f*.csv`, `detected_f*.csv` | per frame | **no** (detection dumps only) |
+| **any JSON** | — | **`golden eval` writes none** |
+
+Structurally: `WriteReports(...)` (`:631-634`) is not even *passed* the truth dispositions —
+`truthDispositions` is a local inside the per-frame loop at `:300` and dies there. Nothing downstream can
+report it even if it wanted to.
+
+**What a reader must consult today to learn whether protection was applied — the full list:**
+1. The **run's date**, compared against **2026-08-03 ~15:00 EDT** (`aaf26e8`). Nothing else in the artifact
+   carries the answer.
+2. `git log --format='%h %ad' aaf26e8 5c382a1 -- Joko.NINA.Plugins/TestApp/SynthBank/TruthProtection.cs`, to
+   fix that boundary.
+3. `GoldenEvalRunner.cs:301-307`, to confirm the call site exists in the binary that ran.
+4. The bank folder itself, for `*.truth.json` sidecars beside the frames (absent ⇒ no protection possible).
+5. `TruthProtection.cs`'s class doc, for what the protected population is.
+6. A `bank-verify` run over the same bank, whose `scoring:` line answers by proxy.
+7. **Or**: recompute it, as §0 does — which is what wave 26 half-did and stopped one exclusion short.
+
+`golden_eval.txt` also carries **no BuildId** (checked: neither the report nor
+`/mnt/d/hf_w25/table18/D08_c11_2800mm.log`), so even a build-identity route is closed. **This omission is the
+proximate cause of the entire misreading.**
+
+---
+
+## 5. Q4 — How far back does the ambiguity go?
+
+### The criterion a reader can apply
+
+**The bright line is the commit `aaf26e8`, 2026-08-03 14:56 EDT** — it wired `TruthProtection` into **both**
+`GoldenEvalRunner.cs` and `BankVerifyRunner.cs` in one change. Refinements: `5c382a1` (same day, 17:04 —
+symmetric centroid predicate, `precisionNull`, `truthViolations`, `scoredFraction`).
+
+**Which test to apply depends on which tool produced the number:**
+
+| number came from | criterion | reliability |
+|---|---|---|
+| `bank-verify` | the **`afbank-verify/N` harness tag**, quoted in every doc that reports one. **`/2` and `/3` = PRE-REPAIR. `/4` = repaired but SATURATING (2·HFR protection — reads 1.000 on all 17 datasets; do not trust an all-1.000 `/4` figure). `/5` = the shipped metric.** | **exact and self-declaring** — the tag is in the artifact |
+| `golden eval` | **the run's date only.** Before 2026-08-03 15:00 EDT ⇒ pre-repair; after ⇒ repaired. There is no tag, no BuildId, no scoring line | **weak** — external to the artifact; see Q3 |
+| a wave-numbered doc | **wave ≤ 1 ⇒ pre-repair. Wave 2 (2026-08-03) is the repair wave. Wave ≥ 3 ⇒ post-repair** | good, and the easiest to apply |
+
+### Documents that are PRE-REPAIR in whole or in part
+
+| file | vintage | status |
+|---|---|---|
+| `docs/f23-objective-precision-term-results.md` | added 2026-08-03 (`fec6733`), wave 1, `afbank-verify/3` | **Wholly pre-repair.** Its precision numbers (0.451 etc.) are the voided set. Its own `/4` reference near the end is the correction landing |
+| `docs/synthetic-af-bank-baseline-results.md` | added **2026-08-02** (`62747f2`), later edited by `867d41c` | **MIXES BOTH, and this is the worst offender.** Line 26 (`Exact, not a lower bound`) and line 30's V2 row (`C0 never below 0.942, config A as low as 0.451`) are `/3`; the V3 matrix added by `867d41c` is `/5`. The `SUPERSEDED` marker at **line 115** is buried mid-document and points at the JSON, not at the headline table. **A reader who stops at the Headline table (lines 20-35) gets pre-repair numbers with no warning** |
+| `docs/af-bank-noiseclip-sweep-results.md` | 2026-06-23, `afbank-verify/2` | Pre-repair by date — **but it is a REAL-bank document**, so `TruthProtection` never applied to it and its "lower bound" language is F11's, correct, and unaffected |
+| `docs/synthetic-af-bank-design.md` | 2026-08-02 | Design intent, not measurements. Its `/3` reference at line 417 is a pre-repair log excerpt |
+| `docs/followups.md` **F23 body** (`:1403-1456`) | wave 1 | Pre-repair — **but correctly fenced** by the void banner at `:1458`. This is the model for how a pre-repair block should be marked |
+
+### Documents that are POST-REPAIR
+
+`docs/synthetic-af-bank-followups-wave2-results.md` (the repair wave, `/4` and `/5` explicitly labelled) and
+**everything from wave 3 onward**, including `docs/synthetic-af-bank-results-table.md` (created 2026-08-13,
+`7e98915`, scored on B15 `d79dae73`) and all of wave 26. **The `91.3 %` misreading is not a vintage problem —
+it is a post-repair document re-deriving a pre-repair quantity by hand.**
+
+### Documents that mix both without saying so
+
+1. **`docs/synthetic-af-bank-baseline-results.md`** — as above. **The one file that needs a vintage banner at
+   the top**, not just at line 115. Minimal addition after line 8:
+   > `> **VINTAGE.** The Headline and V2 tables on this page were measured at \`afbank-verify/3\`, BEFORE the F31
+   > repair of 2026-08-03 (\`aaf26e8\`). Every precision figure in them is the pre-repair quantity. The V3 matrix
+   > below is \`/5\` and is current. Recall figures are unaffected in both.`
+2. **`docs/synthetic-af-bank-results-table.md`** — mixes a post-repair table with a pre-repair *interpretation*
+   (FINDING 1). Fixing the banner fixes the mixing.
+3. **`docs/followups.md` F31 itself** — its first half is the defect as found and its second half is the repair,
+   separated only by a sub-heading. It is the document wave 26 mis-sampled. FINDING 8's title strike plus the
+   one-line tense marker at `:2896` closes this.
+
+---
+
+## 6. Count by severity
+
+| severity | count | findings |
+|---|---|---|
+| **FALSE** | **5** | 1 (results table), 2 (handoff §1c item 1 + line 188 + line 171), 3 (waves27+ §7), 4 (F84 — five separate passages), 5 (F83 caveat 3, conclusion half) |
+| **STALE** | **3** | 6 (F83 option c), 7 (F83 next step), 13 (retired charter) |
+| **MISLEADING** | **3** | 8 (F31 title), 10 (wave-26 results §8.3 + line 630), plus the "13 junk" count in 1/4/9 (off by 2) |
+| **HISTORICAL — annotate in place, do not rewrite** | **2** | 9 (`w26-pd08-followon.md`), 10 (`wave26-results.md`) |
+| **CONTRADICTION IN SOURCE (root cause)** | **1** | 11 (`GoldenFromTruth.cs:34-36` vs `:76-84`, plus the on-disk `Reason` string at `:748`) |
+| **GAP** | **2** | 12 (`golden eval` discloses no scoring mode — the proximate cause), 14 (`.claude/docs/golden-star-set.md`) |
+| **CORRECT-AND-LOAD-BEARING — cite, do not touch** | **6+2** | 15-20, plus the two careful-read entries (`synthetic-af-bank-design.md`, `synthetic-af-bank-baseline-results.md` line 26) |
+
+**Not swept in, deliberately:** `docs/followups.md` **F11** (`:8615`) and
+`docs/af-bank-noiseclip-sweep-results.md` — REAL-bank montage-budget truncation, a different and **still-valid**
+mechanism with no `TruthProtection` path (real frames have no `*.truth.json`, so `LoadForImage` returns null and
+scoring is byte-identical to before the repair).

--- a/docs/waves22+-handoff-prompt.md
+++ b/docs/waves22+-handoff-prompt.md
@@ -169,7 +169,8 @@ a **third** derivation-drift shape); the gate **deliberately skipped** and repla
 | # | item | price | goal | needs a binary? | why |
 |---|---|---|---|---|---|
 | ~~**1**~~ | ~~**`PREDICTION P-D08` at `n = 3`**~~ **DISCHARGED 2026-08-13 — and REFUTED.** `seedA1/D01` and `seedA1/D16` both carry base precision **1.000 with ZERO false positives**, so a sub-boundary gate does **not** imply a precision cost. `D08` is one dataset, not a class. And `D08`'s own apparent cost is **91.3 % reference omission** (137 of 150 golden-false detections match a real `truth.json` star, 0.30 expected by chance). See [F84](followups.md) | done | 3 | no | struck |
-| **1** | **Re-measure precision against `*.truth.json`, not `*.golden.json`, across the bank** | **~1–2 h, NO product code, NO binary** | **3, and it re-scores the owner's table** | **NO** | **Now the prerequisite for every objective-shaped decision, and demonstrably cheap.** The renderer's complete star list ships beside every frame (`126` stars where the golden lists `9` at extreme defocus), the detections are already on disk in `golden eval`'s own `detected_f*.csv`, and the match radius is declared in `synthetic_meta.json` (`12.0`). Measured on `D08` on 2026-08-13: **91.3 % of golden-false detections are REAL rendered stars**, `0.30` expected by chance. **This is why [F23](followups.md) is `won't fix as written` — its evidence base was this same artifact — so without a truth-based pass, F23 and [F83](followups.md) are BOTH undecidable.** The owner's results table's precision column is a lower bound until this runs |
+| ~~**1**~~ | ~~**Re-measure precision against `*.truth.json`, not `*.golden.json`, across the bank**~~ **STRUCK by wave 27, 2026-08-13 — ALREADY DONE, and this row was FALSE.** `TruthProtection` shipped **2026-08-03** (`aaf26e8`, refined `5c382a1`) and is wired into **both** `GoldenEvalRunner.cs:301-307` and `BankVerifyRunner.cs:464-466`. [F31](followups.md) records it `Done` **1,600 lines above** the [F84](followups.md) entry that asked for it — the register contradicted itself. Wave 26's `91.3 %` re-derived FPs from the golden's `stars` list **alone**, consulting neither `unresolved` nor `TruthProtection`: of its 150, **139 were already excluded** (50 + 89) and `golden eval` reported **`FP = 11`**, precision **`0.966`**, exactly as published. **The precision column is NOT a lower bound — `1.000` is a ceiling.** F23 was re-measured at `afbank-verify/5` and is voided on that, not undecidable | done | 3 | no | struck |
+| **1** | **Disclose the scoring mode in `golden eval`** — it emits **none** of `bank-verify`'s four truth disclosures | **~75 m, TestApp only** | instrument integrity | yes | `bank-verify` prints `scoring: golden+truth-protected (N … protected)` (`:302-306`) and persists `scoringMode`/`protectedStars`/`precisionNull`/`truthViolations`/`scoredFraction`; **`golden eval` emits nothing equivalent to console, `golden_eval.txt`, either CSV, or any JSON** — `WriteReports` is not even passed the truth dispositions. So no reader of a published `golden_eval.txt` can tell whether protection was applied, what chance alone would score, or what fraction of the detections was judged. **This omission is the direct cause of the wave-26 misreading.** Wave 27 half (A) |
 | **2** | **the [F83](followups.md) DECISION** — (a) raise `DefaultSensitivityLower`, (b) a precision term on unlabelled runs, or (c) label the bank | **a decision, then ~42 m of baseline** | **3** | for (a)/(b) | The measurement is done and the three options are laid out with their evidence and prices. **What is missing is an owner's call**, not an arm. (a) is the option the evidence is most hostile to — F23 already measured a hard floor as worse than doing nothing |
 | **3** | **`lumos`'s zero-star frame** (`RULE L26`) | ~10 m **+ a diagnosis** | 1 | yes | Wave 26 returned **could-not-look**: `af-fit` produced no `af_fit_points.csv`. **The next attempt owes a diagnosis of the missing CSV before it re-runs the same command** |
 | **4** | **the `A4` truth-model gap** | ~20 m | 2 | yes (rebuilds TestApp) | The harness computes the cap boundary from the **requested** sweep, the product from the **fitted** span; they disagree on `D01` r1 by 2×, and `A4` compares against `WasCapped` alone so it now flags floored rounds. **Fix the assertion, not the product**, and keep it out of any arm carrying a product change |
@@ -185,7 +186,25 @@ fences**. [F70](followups.md)(b′) was **rejected by the owner**. [F45](followu
 with `N*` unreachable in `AutoFocusEngine`. [F59](followups.md) is **rejected on the merits**. The wide end of
 [F25](followups.md) is **unmeasured, not untriggered**, and remains so.
 
-**Is another wave worth it? YES, and the answer changed on 2026-08-13.** The old item 1 ran and was refuted, which removed the last measured support for acting on the sensitivity pin — but the same afternoon's work showed that **the bank's precision numbers are measured against a reference that under-lists by an order of magnitude at defocus.** So the next run has a genuine, binary-free, ~1–2 h opening item (the truth re-score) whose result decides two long-open entries (F23, F83) and re-scores the owner's deliverable. **After that, item 8 — recall on wide fields — is the largest untouched product gap in the series** and is worth a design before it is worth an arm.
+**Is another wave worth it? YES — but NOT for the reason this paragraph gave, which was false.**
+
+~~"the same afternoon's work showed that the bank's precision numbers are measured against a reference that
+under-lists by an order of magnitude at defocus … the next run has a genuine, binary-free, ~1–2 h opening item
+(the truth re-score)"~~ — **corrected by wave 27, 2026-08-13.** The reference does under-list, but the scoring
+has **compensated for it since 2026-08-03**; the re-score had already shipped. The 91.3 % measured a
+**pre-repair** quantity that `golden eval`'s own FP field had already excluded.
+
+**What was genuinely open, and what wave 27 found by looking:** `golden eval` carries **none** of the four
+truth-related disclosures its sibling `bank-verify` carries, so its published numbers cannot be interrogated —
+that silence *is* the defect, and it is what let the register contradict itself. Wave 27 ships the disclosures
+(half A), audits whether the correction is sound or saturated across 20 datasets (`RULE T27`), and found that
+**7 of the 20 published rows are scored at a detection binning `optimize` does not use** (`RULE D27` =
+**`D-MOVED`, 6 of 6**; `D14_cdk14_2563mm_e47`'s `recall@all` is understated by **0.296**).
+
+**After that, item 8 — recall on wide fields — remains the largest untouched product gap in the series** and is
+worth a design before it is worth an arm. Note that `RULE D27` has now moved recall on seven rows, so **re-read
+the wide-field gap against the corrected numbers**: `D01`/`D02`/`D03` are all factor-1 datasets and are
+unaffected, which sharpens rather than softens the gap.
 
 > ### DO NOT RE-RUN A FULL PAIRED 20-CELL S1 ARM TO CHASE `D01`
 >

--- a/docs/waves27+-autonomous-prompt.md
+++ b/docs/waves27+-autonomous-prompt.md
@@ -1,5 +1,38 @@
 # Waves 27+ — autonomous run
 
+> # THIS RUN IS COMPLETE, AND THE WAVE SERIES IS RECOMMENDED TO STOP. READ THIS BOX BEFORE ANYTHING BELOW.
+>
+> **Executed 2026-08-13: waves 27, 28, 29 and 30.** All four are on **ONE** branch,
+> `ghilios/synthetic-af-bank-followups-wave27`, and **ONE** PR, **#196** — the owner instructed one PR, and
+> earlier stacked PRs (#197, #199) were consolidated and closed. Results per wave are in
+> `docs/synthetic-af-bank-followups-wave2<7,8,9>-results.md` and `…wave30-results.md`.
+>
+> **The recommendation to stop is a JUDGEMENT, not the charter's trigger.** §3's formal condition — two
+> consecutive waves with no register-worthy finding — is **not met**; waves 29 and 30 both produced product
+> findings. The judgement rests on wave 30 §12: **the synthetic bank has no unanswered product question that
+> another arm can address**, which wave 30's own design predicted in advance and its measurement confirmed.
+> Everything left is a **ship or a five-minute rescore**, and neither has a verdict to take.
+>
+> **§7 below is STALE and its opening item was FALSE.** It directed the run at *"re-measure precision against
+> `*.truth.json`"*, which had **already shipped on 2026-08-13** (`aaf26e8`); the register contradicted itself
+> and the owner's results table carried a **false banner**, now withdrawn. That correction is wave 27's
+> headline. **Do not open on §7.**
+>
+> **What is actually left, none of it a wave** — full ledger in wave 30 results §10, with a search command per
+> row so it can be checked rather than believed:
+>
+> | item | price | goal |
+> |---|---|---|
+> | Implement **F82's decided fix, candidate (3′)** — `docs/f82-fix-choice-decision.md` | 2 h 25 m – 3 h 10 m incl. a **42 m gate that is certainly owed** | 2 |
+> | **First run its validity gate `V-0`** ([F110](followups.md)) — F82's evidence was taken with the detectability bound OFF | ~10 m, and it can **void** the decision | 2 |
+> | Bound the **`MaxDistortion`** axis at ~π/4 and rename it — it is a **minimum** fill ratio ([F98](followups.md)) | ~20 m + 42 m gate | 3 |
+> | Render new datasets at **1.4–19.4 ″/px** | ≥ 1 h | 1, 3 |
+>
+> **The last is the only route to a new blind population, and it has been open twelve waves.** Without it the
+> honest position is that this bank is measured out.
+>
+> **Suite baseline is 3997**, verified by COUNT in CI. Everything below 3997 in this file is stale.
+
 **Read this file, then `docs/waves22+-handoff-prompt.md`, then `docs/followups.md`. Those three are the
 authority; this file only sets the run's boundaries.** Everything you need is on disk. Nothing depends on a
 prior conversation — this prompt is written to survive a `/clear`.

--- a/docs/waves27+-autonomous-prompt.md
+++ b/docs/waves27+-autonomous-prompt.md
@@ -31,7 +31,12 @@
 > **The last is the only route to a new blind population, and it has been open twelve waves.** Without it the
 > honest position is that this bank is measured out.
 >
-> **Suite baseline is 3997**, verified by COUNT in CI. Everything below 3997 in this file is stale.
+>
+> **Suite baseline is 4039**, verified by COUNT out of the CI log, and the arithmetic closes exactly:
+> `develop @ ec06bec` is **4015** in its own CI log, this branch is **4039**, and the difference of **24** is
+> precisely this run's additions (19 `TruthDisclosureTests` + 5 `DetectionBinningResolverTests`). The earlier
+> figure of **3997** was correct before the rebase; `develop` gained **42** tests from PR #198 in the meantime.
+> **Everything below 4039 in this file is stale, including 3973 and 3997.**
 
 **Read this file, then `docs/waves22+-handoff-prompt.md`, then `docs/followups.md`. Those three are the
 authority; this file only sets the run's boundaries.** Everything you need is on disk. Nothing depends on a

--- a/docs/waves27+-autonomous-prompt.md
+++ b/docs/waves27+-autonomous-prompt.md
@@ -153,12 +153,23 @@ exposures, `lumos` exits rc=3, `Panos`'s σ-fit claim belongs to `af-fit` and no
 
 **Start there.** Its item **1** is the one to open on:
 
-> **Re-measure precision against `*.truth.json`, not `*.golden.json`.** ~1–2 h, **no product code, no binary, no
-> gate.** The renderer's complete star list ships beside every frame — **126** stars where the golden lists **9**
-> at extreme defocus. Measured on `D08`: **91.3 %** of golden-false detections are **real rendered stars**, 0.30
-> expected by chance. **[F23](followups.md) is `won't fix as written` because its evidence base was this same
-> artifact**, so until a truth-based pass exists, **F23 and [F83](followups.md) are both undecidable** and the
-> owner's results table's precision column is a lower bound.
+> ~~**Re-measure precision against `*.truth.json`, not `*.golden.json`.** ~1–2 h, no product code, no binary, no
+> gate … until a truth-based pass exists, **F23 and [F83](followups.md) are both undecidable** and the owner's
+> results table's precision column is a lower bound.~~
+>
+> **STRUCK by wave 27, 2026-08-13 — IT WAS ALREADY DONE.** `TruthProtection` shipped **2026-08-03** in `aaf26e8`
+> and is wired into **both** `GoldenEvalRunner.cs:301-307` and `BankVerifyRunner.cs:464-466`;
+> [F31](followups.md) records it as `Done` **1,600 lines above** the [F84](followups.md) entry that asked for it.
+> Wave 26's `91.3 %` re-derived false positives from the golden's `stars` list **alone**, consulting neither the
+> golden's `unresolved` boxes nor `TruthProtection`: of its 150, **139 were already excluded** by the run that
+> produced the owner's table (50 + 89) and `golden eval` reported **`FP = 11`**. **The precision column is not a
+> lower bound; it is truth-corrected, and `1.000` is a ceiling.** F23 was re-measured at `afbank-verify/5` and is
+> voided on that re-measurement, not undecidable.
+>
+> **What was actually open, and is what wave 27 ran:** `golden eval` emits **none** of `bank-verify`'s four
+> truth disclosures (`scoringMode`/`protectedStars`, `precisionNull`, `truthViolations`, `scoredFraction`), so no
+> reader of a `golden_eval.txt` can tell whether protection was applied or what chance alone would score — the
+> mechanism that produced the misreading. See `docs/synthetic-af-bank-followups-wave27-design.md`.
 
 Then, in order: the **F83 decision** (an owner's call, not an arm) · **`lumos`** (~10 m **+ a diagnosis of the
 missing `af_fit_points.csv`**) · the **`A4` truth-model gap** (~20 m) · **[F82](followups.md)** (fix choice

--- a/plans/synthetic-af-bank-followups-wave27-plan.md
+++ b/plans/synthetic-af-bank-followups-wave27-plan.md
@@ -1,0 +1,410 @@
+# Wave 27 — execution plan
+
+**Design (the authority): `docs/synthetic-af-bank-followups-wave27-design.md`.** This file is the controller's
+step-by-step. Where the two disagree, the design wins and the disagreement is a finding.
+
+**Vessel:** PR #195 MERGED → `git checkout develop && git pull && git checkout -b ghilios/synthetic-af-bank-followups-wave27`
+off `develop @ e19a779`.
+
+**Hard stop: 2026-08-14T00:45:17Z.** Budget ~5 h 20 m against a ~6 h ceiling. **Cut order if it overruns:
+(D) → (A)'s build half. (B) and (C) are never cut.**
+
+**Record ACTUAL against ESTIMATE in every step's row of `/mnt/d/hf_w27/TIMING.tsv`** (`step`, `est_min`,
+`actual_min`, `note`), written by the controller as each step closes. The estimate/actual pair is itself a
+deliverable ([F21](../docs/followups.md)).
+
+---
+
+## Step 0 — commit the pre-registration BEFORE any measurement (est 10 m)
+
+```bash
+cd /home/ghilios/src/hocus-focus
+git checkout develop && git pull && git checkout -b ghilios/synthetic-af-bank-followups-wave27
+git log --oneline -1                       # must be e19a779
+git add docs/synthetic-af-bank-followups-wave27-design.md \
+        plans/synthetic-af-bank-followups-wave27-plan.md \
+        docs/wave27-register-correction-survey.md
+GIT_COMMITTER_NAME="George Hilios" GIT_COMMITTER_EMAIL="322725+ghilios@users.noreply.github.com" \
+  git commit --author="George Hilios <322725+ghilios@users.noreply.github.com>" \
+  -m "W27 pre-registration: backlog item 1 SHIPPED on 2026-08-03 -- the wave audits the correction instead"
+git push -u origin ghilios/synthetic-af-bank-followups-wave27
+```
+
+**Nothing below runs until this is pushed.**
+
+---
+
+## Step 1 — BLOCKING pre-flight (est 10 m)
+
+### 1.1 Derive the instruments
+
+```bash
+mkdir -p /mnt/d/hf_w27
+cd /mnt/d/hf_w27
+sed -e 's/w26/w27/g' -e 's/W26/W27/g' -e 's/_26/_27/g' -e 's/\b26\b/27/g' \
+    /mnt/d/hf_w26/verify_derivation_w26.py > /mnt/d/hf_w27/verify_derivation_w27.py
+```
+
+Then **hand-widen** `verify_derivation_w27.py`, and the widening must be **demonstrated**, not asserted:
+
+| what | required |
+|---|---|
+| `WAVE` | `27`; `PREV` computed as `WAVE - 1`, never typed |
+| `KNOWN_BAD_ROOT` | **`"/mnt/d/hf_w26"`**, `KNOWN_BAD_WAVE = 26` — **pinned to a NAMED older root in source.** *A regression fixture that is "whatever came before" has a shelf life of one wave* |
+| token pattern | must match an identifier token with **both** an optional `_prefix` **and** an optional `_suffix` (`w26_gate_log_wsl` **and** `G26_START`). **`\b` cannot see `_`** ([F80](../docs/followups.md), three demonstrated gaps) |
+| `EXPECTED_PATHS` | rewritten for wave 27: `/mnt/d/hf_w25/exe` (B15, the BEFORE binary), `/mnt/d/hf_w25/table18` (the population), `/mnt/d/hf_w27/exe` (B16, only if (A) builds), `D:\hf_w25\exe` and `D:\hf_w25\table18` (**Windows forms — `TestApp` takes Windows paths**), `/mnt/d/hf_w26` (the pinned FAIL fixture) |
+| **interface check** | **verify the PREDECESSOR'S INTERFACE SURVIVED, not just its spelling.** `layout_w27.sh` must expose the same function names the drivers call; wave 25's `layout_w25.sh` exposed a different API from wave 24's and no renaming scheme could have repointed three call sites that no longer existed under any name |
+
+### 1.2 Run it, BOTH directions, and READ THE OUTPUT
+
+```bash
+cd /mnt/d/hf_w27
+python3 verify_derivation_w27.py /mnt/d/hf_w26 2>&1 | tee /mnt/d/hf_w27/v27_failend.txt   # MUST report drifts
+python3 verify_derivation_w27.py /mnt/d/hf_w27 2>&1 | tee /mnt/d/hf_w27/v27_clean.txt     # MUST report none
+grep -c 'DRIFT' /mnt/d/hf_w27/v27_failend.txt      # must be > 0
+grep -c 'DRIFT' /mnt/d/hf_w27/v27_clean.txt        # must be 0
+```
+
+**`RULE V27` = `V-CLEAN` only when the second run reports zero drifts AND the first reports more than zero.**
+A pre-flight that passes everything is not a pre-flight. **Read the printed lines, not `$?`** — wave 26's
+self-test returned a clean rc from inside its caller's `source` line while doing nothing.
+
+### 1.3 LF endings
+
+```bash
+cd /mnt/d/hf_w27 && file *.sh *.py | grep -i crlf && echo "FAIL: CRLF present" || echo "OK: LF only"
+```
+
+---
+
+## Step 2 — the shared layout and the manifest (est 5 m)
+
+**`/mnt/d/hf_w27/layout_w27.sh` — write it, and it contains NO `--self-test` dispatcher.** Wave 26's fired
+inside its caller's `source` line, terminated it, and printed a clean PASS. The self-test lives in
+`layout_w27_selftest.sh`, which sources the layout and runs the checks.
+
+```bash
+bash /mnt/d/hf_w27/layout_w27_selftest.sh 2>&1 | tee /mnt/d/hf_w27/layout_selftest.txt
+grep -E '^SELFTEST .* [0-9]+ of [0-9]+$' /mnt/d/hf_w27/layout_selftest.txt   # READ THIS LINE
+```
+
+**`/mnt/d/hf_w27/t27_manifest.sh` — the driver that DISCOVERS the population and writes the manifest.** The
+scorer reads paths **only** out of it and never rebuilds one from a template ([F74](../docs/followups.md)).
+
+```bash
+bash /mnt/d/hf_w27/t27_manifest.sh 2>&1 | tee /mnt/d/hf_w27/w27_manifest.log
+wc -l /mnt/d/hf_w27/t27_manifest.tsv        # 180 data rows + header
+cat /mnt/d/hf_w27/T27_MANIFEST_READY        # written by the DRIVER, last, only on success
+```
+
+Manifest columns: `dataset`, `focuser`, `detected_csv`, `fn_csv`, `truth_json`, `golden_json`, `fits`,
+`capture_binning`, `derived_det_binning`, `scored_det_binning`, `naxis1`, `naxis2`.
+Header lines: `ROOT=/mnt/d/hf_w25/table18`, `NEAR_MISS_ROOT=/mnt/d/hf_w25/table`,
+`BANK=/mnt/d/SyntheticAutofocusBank`, `PARAMS_SOURCE=D:\hf_w18\seedA0`.
+
+**Assertions the driver makes, and it writes `T27_MANIFEST_READY` only if ALL pass:**
+`180` rows · `20` distinct datasets · exactly `9` frames each · every one of the 20 logs' `params:` line contains
+`D:\hf_w18\seedA0\` (`T27-V5`, the path trap) · the root basename is `table18` · every `truth_json` and
+`golden_json` exists.
+
+**Use `-print0 | sort -z | xargs -0` for every file sweep.** `xargs` splits on the space in
+`/mnt/d/Autofocus Bank`, and a fingerprint written the naive way once recorded 20 landings instead of 42.
+
+---
+
+## Step 3 — the scorer, and its self-test in BOTH directions (est 10 m)
+
+### 3.1 What the controller must write: `/mnt/d/hf_w27/score_t27_w27.py`
+
+**`--out` is MANDATORY. Without it the scorer must `exit 2` and write nothing** — not a warning, a refusal.
+Wave 25 lost its scoring artifact twice to a stdout redirect into a job-scoped temp directory.
+
+| flag | behaviour |
+|---|---|
+| `--manifest PATH` | required; the **only** source of artifact paths |
+| `--out PATH` | **required; refuse with rc 2 if absent** |
+| `--rule T27` | run `T27-V0`, `T27-V1`, `T27-V3`, S1/S2/S3, and emit the verdict |
+| `--protection off` | `T27-V0`'s **FAIL end** and the correction's size, in one computation |
+| `--coords native` | `T27-V1`'s FAIL arm |
+| `--self-test` | must print `SELFTEST T27 <n> of <n>`; **never dispatched from a sourced file** |
+| `--emit-marker` | write `/mnt/d/hf_w27/T27_PASSED` **from the code that computed the verdict**, on `rc == 0` and only then ([F75](../docs/followups.md)) |
+
+**Predicates — mirror the product exactly** (`T27-V0` is what proves the mirror is faithful):
+
+1. **TP** — `GoldenMatch.Match` centre mode: a detection's `(cx, cy)` inside a golden `stars` rect, greedy pairing.
+2. **Unresolved exclusion** — `GoldenMatch.ExcludeUnresolved` with the **`Covers`** predicate: centre-in-box
+   **OR** `IoU(rect, detection bbox) > 0`. The detection bbox comes from the CSV's `x,y,w,h`. The product keeps
+   the dilated predicate here **deliberately**; do not "fix" it.
+3. **Truth protection** — `ExcludeProtected` with the **centroid** predicate: Euclidean distance from `(cx, cy)`
+   to a truth entry's `(BinnedCenterX, BinnedCenterY)` ≤ `12.0`, for `Tier ∈ {omitted, merged-into}` only.
+4. **The null** — `TruthProtection.ShiftForNullControl` verbatim: shift the **DETECTIONS**, not the catalogue, by
+   `(317, 211)` with `Wrap(v, extent) = ((v % extent) + extent) % extent`, at `Δ1 = (317, 211)`,
+   `Δ2 = (-317,-211)`, `Δ3 = (317,-211)`, `Δ4 = (-317, 211)`. **The rule reads `Δ1`**; the spread over four is
+   reported, not thresholded.
+5. **`A_all`** — rasterise golden `stars` rects, golden `unresolved` rects and 12 px protection discs onto a
+   lattice of stride **4 px**, offset **(2, 2)**; report `A_all`, `A_golden`, `A_protOnly`.
+
+**Column reading, stated so it cannot drift** ([F68](../docs/followups.md) part 5): detections are the CSV's
+**`cx,cy`** (the centroid), never `x,y` (the bbox origin); truth positions are **`BinnedCenterX/Y`**, never
+`Star.CxPixels/CyPixels`; the reproduction target is each log's **`OVERALL:`** line, not the frames CSV
+(re-summing the CSV is a second route and therefore a second bug).
+
+**Empty-set and could-not-look, guarded BEFORE any field read** — the seven states of design §7, each printed by
+name. **Newtonsoft writes NaN/Infinity as the STRINGS `"NaN"`/`"Infinity"`**; the reader must handle both.
+
+**Every ordinal and count COMPUTED, never typed:** `19` = `len(datasets) - len(NOT_BLIND)`; `18`/`2` from
+`captureBinning`; `7`/`13` from the logs' `NOTE:` lines; `180`/`20`/`9` from the manifest — each **asserted**.
+
+### 3.2 Run the self-test, both directions
+
+```bash
+python3 /mnt/d/hf_w27/score_t27_w27.py --self-test 2>&1 | tee /mnt/d/hf_w27/t27_selftest.txt
+grep -E '^SELFTEST T27 [0-9]+ of [0-9]+$' /mnt/d/hf_w27/t27_selftest.txt      # READ THE LINE
+python3 /mnt/d/hf_w27/score_t27_w27.py --manifest /mnt/d/hf_w27/t27_manifest.tsv --rule T27 ; echo "rc=$?"
+#   ^ NO --out: must print a refusal and rc=2, and write NOTHING
+ls /mnt/d/hf_w27/t27_score.txt 2>/dev/null && echo "FAIL: wrote output without --out"
+```
+
+---
+
+## Step 4 — `RULE T27`, half (B). Zero TestApp minutes (est 65 m)
+
+**Every command passes WSL paths (`/mnt/d/...`). A Windows path yields UNEVALUATED and looks like a failed arm.**
+
+```bash
+S=/mnt/d/hf_w27/score_t27_w27.py ; M=/mnt/d/hf_w27/t27_manifest.tsv
+
+# 4.1  T27-V0 reproduction -- PASS end, 20 of 20 exact
+python3 $S --manifest $M --rule T27 --out /mnt/d/hf_w27/t27_v0.txt
+grep -E 'T27-V0 .* 20 of 20' /mnt/d/hf_w27/t27_v0.txt
+
+# 4.2  T27-V0 FAIL end AND the correction's size, one computation
+python3 $S --manifest $M --rule T27 --protection off --out /mnt/d/hf_w27/t27_v0_failend.txt
+grep -E 'DIFFERS' /mnt/d/hf_w27/t27_v0_failend.txt        # must be non-empty
+
+# 4.3  T27-V1 coordinate gate, both arms
+python3 $S --manifest $M --rule T27 --coords binned --out /mnt/d/hf_w27/t27_v1_binned.txt
+python3 $S --manifest $M --rule T27 --coords native --out /mnt/d/hf_w27/t27_v1_native.txt
+#      V1-a: bit-identical on the 18 captureBinning=1 datasets
+#      V1-b: binned - native >= 0.30 on D11 and D12  <- the FAIL end, RUN and PRINTED
+
+# 4.4  S1/S2/S3, four offsets, 180 frames, and the verdict
+python3 $S --manifest $M --rule T27 --full --emit-marker --out /mnt/d/hf_w27/t27_score.txt
+cat /mnt/d/hf_w27/T27_PASSED        # written by the scorer, on rc==0 only
+```
+
+### 4.5 `RULE R27` — ALREADY RUN. Adopt it, and DECLARE THE DEVIATION (est 0 m)
+
+`R27 = R-IDENTICAL`: B15 regenerates the whole published population byte for byte — **20 cells, 420 files,
+0 differences, 0 could-not-look** (`/mnt/d/hf_w27/repro_all_score.txt`, driver `repro_all_w27.sh`, scorer
+`score_repro_w27.py` self-testing **6 of 6** with `--out` mandatory, paths through
+`repro_all_manifest.tsv`).
+
+**It ran BEFORE pre-registration.** The results document must quote `R-IDENTICAL` and say *"opportunistic, not
+pre-registered"* **in the same sentence**. Design §5.6a carries the reasoning for why adopting it is legitimate
+(it is a determinism control on the instrument, reads nothing in T27's verdict tree, and has exactly one
+interesting outcome) and why the deviation is still declared rather than laundered.
+
+**`R27` is load-bearing for `S27-4`:** without it a B16-vs-`table18` byte difference could be the treatment or
+run-to-run noise. With `R-IDENTICAL` in hand, **any difference is the treatment.**
+
+**Only one `TestApp.exe` at a time. Never run NINA during any arm. `TestApp.exe` eats a `while read` loop's stdin
+unless you redirect `< /dev/null`.**
+
+---
+
+## Step 5 — `RULE D27`, half (D). B15, no build (est 25 m, ~2 m compute)
+
+```bash
+# 5.1 derive the arm driver from the one that made table18 -- then PRE-FLIGHT the derivation
+sed -e 's/w25/w27/g' -e 's/table18/table18_b2/g' \
+    /mnt/d/hf_w25/table_arm18_w25.sh > /mnt/d/hf_w27/d27_arm_w27.sh
+python3 /mnt/d/hf_w27/verify_derivation_w27.py /mnt/d/hf_w27 2>&1 | tee /mnt/d/hf_w27/v27_d27.txt
+#    ^ MANDATORY: this is exactly the sed-derivation path F80 exists for
+```
+
+Add `--detection-binning 2` to the invocation. Population: the **7** datasets computed from the `table18` logs'
+`NOTE:` lines (`D08 D09 D10 D12 D14 D15 D17`), asserted `== 7`; 63 frames asserted. Binary: **B15** at
+`/mnt/d/hf_w25/exe`, `TestApp.dll` sha256 `2fb0c8fdb26f11f9c912dce6d3bc3b599e8b9abab7ee4fdd0a61ace0aac42e67`
+(**hash the dll, never the apphost** — `TestApp.exe` is byte-identical across six distinct binaries,
+[F66](../docs/followups.md)). Pin `--settings` **and** `--profile-id` on every cell.
+
+```bash
+bash /mnt/d/hf_w27/d27_arm_w27.sh 2>&1 | tee /mnt/d/hf_w27/w27_d27.log     # ~2 m
+grep -c 'derived detection binning' /mnt/d/hf_w27/table18_b2/*.log          # D27-V1: must be 0 on all 7
+grep -h 'pixelScale:' /mnt/d/hf_w27/table18_b2/*.log                        # must carry '; detectionBinning 2'
+
+# 5.2 D27-V1 FAIL END, run and printed
+/mnt/d/hf_w25/exe/TestApp.exe golden eval --runs 'D:\SyntheticAutofocusBank\D09_c14_3800mm' \
+  --params optimized --opt-results 'D:\hf_w18\seedA0\D09_c14_3800mm\attempt01\optimized_settings.json' \
+  --match center --pixel-scale header --out 'D:\hf_w27\d27_failend\D09' \
+  --settings 'D:\hf_w11\pinned_settings_w11.json' --profile-id 'ce3f3e63-8fd3-4b72-a0ca-d90db9441382' \
+  < /dev/null 2>&1 | tee /mnt/d/hf_w27/d27_failend/D09.log
+grep 'derived detection binning' /mnt/d/hf_w27/d27_failend/D09.log   # the NOTE MUST return -> FAIL end shown
+
+python3 /mnt/d/hf_w27/score_t27_w27.py --manifest /mnt/d/hf_w27/t27_manifest.tsv --rule D27 \
+  --b2-root /mnt/d/hf_w27/table18_b2 --out /mnt/d/hf_w27/d27_score.txt
+```
+
+`D27-V2`: `recall@all ≥ 0.25` on all 7. Verdict over the **6** non-`D08` datasets (count COMPUTED); `D08` printed
+`[not blind]`.
+
+---
+
+## Step 6 — half (A): the port, the tests, the mutants (est 50 m)
+
+Delegate to a **CODE agent**; the controller verifies every claim itself.
+
+Port the four disclosures from `BankVerifyRunner` into `GoldenEvalRunner` — `scoringMode` + `protectedStars`
+(`:287-306`, `:344`), `precisionNull` (`:478-489`, `:513`), `truthViolations` (`:470-474`, `:517-521`),
+`scoredFraction` (`:510-512`) — into the console line, `golden_eval.txt` and `golden_eval_frames.csv`.
+`GoldenEvalRunner.WriteReports` must now be **passed the truth dispositions**. Honour the house rule at
+`GoldenEvalRunner.cs:669`: *"Report the mode actually used — a hardcoded label here silently misattributes every
+stored report."*
+
+Plus the **doc-comment-only** fix to `GoldenFromTruth.cs:34-36` vs `:76-84`. **Do NOT change the `Reason` string
+generation and do NOT regenerate the 180 sidecars** (design §6.2).
+
+**Every new test shown RED against a NAMED MUTANT** — a revert will not build, since this is new API:
+
+| mutant | change | test that must go red |
+|---|---|---|
+| `M-S1` | delete the `protectedStars` accumulation | the protected-count test |
+| `M-S2` | hard-code `scoringMode = "golden"` | the mode test |
+| `M-S3` | return the unshifted detections from the null path | the `precisionNull` test |
+
+**The mutation harness keeps a BYTE BACKUP taken before each mutation and restores it in a `finally`** — never
+`git checkout --`, which once reverted a working tree carrying the feature under measurement and silently deleted
+it. Assert source sentinels after every mutant and abort on `WORKING TREE DAMAGED`.
+
+---
+
+## Step 7 — build B16, provenance, `Q27-V1`, and `S27-4` (est 35 m)
+
+```bash
+cd /home/ghilios/src/hocus-focus
+dotnet.exe build "$(wslpath -w Joko.NINA.Plugins/TestApp/TestApp.csproj)" -c Release -o 'D:\hf_w27\exe' \
+  2>&1 | tee /mnt/d/hf_w27/build_b16.log
+sha256sum /mnt/d/hf_w27/exe/TestApp.dll /mnt/d/hf_w27/exe/NINA.Joko.Plugins.HocusFocus.dll \
+  | tee /mnt/d/hf_w27/binary_provenance_w27.txt        # DLLS, never the apphost
+find Joko.NINA.Plugins -name '*.cs' -newermt "$(date -r /mnt/d/hf_w27/exe/TestApp.dll '+%F %T')"   # MUST be empty
+```
+
+Record the `BuildId` and assert it **novel against the sixteen** recorded ids (the count printed by the prov
+script must be **computed from `len(PRIOR_BUILD_IDS)`**, never typed). **Never rebuild mid-wave.**
+
+### `Q27-V1` — the reach-scoped gate discharge, with its FAIL end RUN
+
+```bash
+BASE=$(grep -oE '[0-9a-f]{7,40}' /mnt/d/hf_w25/binary_provenance_w25.txt | head -1)   # READ B15's tree hash
+echo "B15 tree = $BASE"                                # do NOT assume the previous wave's HEAD (wave 24 did)
+git diff --name-only "$BASE"..HEAD -- '*.cs' | tee /mnt/d/hf_w27/q27_diff.txt
+# discharge iff the intersection with the reachable set is EMPTY:
+grep -E 'Joko.NINA.Plugins.HocusFocus/|TestApp/(OptimizationDiagnosticRunner|HarnessSettingsStore|OptimizationRunDiscovery|ParamsDump|StubBehaviorSelectors|DiagnosticUtil|Program)\.cs' \
+  /mnt/d/hf_w27/q27_diff.txt | tee /mnt/d/hf_w27/q27_reach.txt
+# FAIL END, RUN: the same check against a diff known to include plugin files must NOT be empty
+git diff --name-only <B14_tree>..HEAD -- '*.cs' | grep -cE 'Joko.NINA.Plugins.HocusFocus/'
+```
+
+**Empty `q27_reach.txt` ⇒ the gate is discharged**, replaced by `Q27-V0` (hash identity + BuildId novelty) and
+`S27-4`. **Non-empty ⇒ run the full 42 m gate** (`score_w12.py`, `prov_w26.py --self-test`). Either way the wave
+reports which happened and **never calls a discharge a pass**.
+
+### `S27-4` — do-no-harm, provable by bytes
+
+```bash
+bash /mnt/d/hf_w27/s27_arm_w27.sh 2>&1 | tee /mnt/d/hf_w27/w27_s27.log   # B16, all 20 cells, ~4 m
+python3 /mnt/d/hf_w27/score_t27_w27.py --manifest /mnt/d/hf_w27/t27_manifest.tsv --rule S27 \
+  --b16-root /mnt/d/hf_w27/table18_b16 --out /mnt/d/hf_w27/s27_score.txt
+```
+
+Required: **360 of 360** `detected_f*.csv` + `false_negatives_f*.csv` byte-identical to `table18`'s;
+`TP`/`FP`/`FN` unchanged on **20 of 20**; `S27-1` route agreement on four fields × 20 datasets;
+`S27-5` `truthViolations = 0` on 20 of 20. **Any byte or count that moves blocks the ship.**
+
+---
+
+## Step 8 — the suite, by COUNT (est 5 m)
+
+```bash
+powershell.exe -NoProfile -Command "Get-Process testhost,vstest.console -EA SilentlyContinue | %{ \$_.Kill() }"
+cd /home/ghilios/src/hocus-focus
+dotnet.exe test "$(wslpath -w Joko.NINA.Plugins/Joko.NINA.Plugins.sln)" -c Debug --nologo \
+  2>&1 | tee /mnt/d/hf_w27/suite.log ; echo "SUITE_EXIT=$?"
+grep -E 'Failed:.*Passed:.*Total:' /mnt/d/hf_w27/suite.log
+```
+
+**Baseline 3973** (`/mnt/d/hf_w27/SUITE_BEFORE_3973.txt`, this branch, HEAD). **Name every added test and the
+delta BEFORE anything is called green** ([F37](../docs/followups.md): verify by COUNT, never the tick).
+Do not pipe to `tail` — it masks the exit code. **`dotnet test <sln>` does NOT build `TestApp`**; Step 7's build
+is the compile check. `SendAsync_WritesOnABackgroundThread` is a known flake — do not chase it.
+
+---
+
+## Step 9 — the AFTER fingerprints, KEPT in files (est 5 m)
+
+```bash
+bash /mnt/d/hf_w27/fp_w27.sh table18  > /mnt/d/hf_w27/fp_table18_AFTER.txt
+bash /mnt/d/hf_w27/fp_w27.sh sidecars > /mnt/d/hf_w27/fp_sidecars_AFTER.txt
+diff /mnt/d/hf_w27/fp_table18_BEFORE.txt  /mnt/d/hf_w27/fp_table18_AFTER.txt  && echo "CLASS4 table18 PRESERVED"
+diff /mnt/d/hf_w27/fp_sidecars_BEFORE.txt /mnt/d/hf_w27/fp_sidecars_AFTER.txt && echo "CLASS4 sidecars PRESERVED"
+```
+
+**BEFORE and AFTER must be the same code** (`fp_w27.sh`, `-print0 | sort -z | xargs -0`, population size asserted
+inside the file). **Any difference ⇒ `T-UNEVALUATED`** — the wave's denominators moved under it.
+
+---
+
+## Step 10 — analysis, the record, the push (est 75 m)
+
+Spawn an **ANALYSIS agent**. **Its first action is `ls -la --time-style=full-iso /mnt/d/hf_w27/` with the
+timestamp PRINTED at the top of the results document** — wave 19's doc was falsified by an artifact written 33
+seconds before its own commit. Any row still open at that instant is marked open **in place**.
+
+**It applies the pre-registered rules and MUST NOT re-decide one. An unsatisfiable rule is a FINDING.**
+
+Deliverables:
+
+1. `docs/synthetic-af-bank-followups-wave27-results.md` — `RULE V27`, `RULE T27`, `RULE D27`, `RULE S27`,
+   `Q27-V0/V1`, every estimate-vs-actual from `TIMING.tsv`, and **what was not run, priced**.
+2. **(C) — the register corrections, per `docs/wave27-register-correction-survey.md`, line by line:**
+   * **C1** `docs/synthetic-af-bank-results-table.md:7-21` — replace the banner (four false statements); **fix
+     "13 genuine junk detections" → 11**; keep the "recall is unaffected" paragraph.
+   * **C2** `docs/followups.md` F84 item (2), plus new entries **F85** (three fields named "false positive") and
+     **F86** (the pre-repair `Reason` string on disk in 180 sidecars).
+   * **C3** `docs/waves22+-handoff-prompt.md:171,172,188` — strike item 1 with its reason.
+   * **C4** `docs/waves27+-autonomous-prompt.md:154-160` — **the LIVE charter propagates it verbatim**; correct
+     it or a successor run re-opens item 1 a third time.
+3. Commit with the privacy email, push, open the PR, **verify CI by COUNT read out of the log**.
+
+```bash
+GIT_COMMITTER_NAME="George Hilios" GIT_COMMITTER_EMAIL="322725+ghilios@users.noreply.github.com" \
+  git commit --author="George Hilios <322725+ghilios@users.noreply.github.com>" -m "..."
+git push
+gh run list --branch ghilios/synthetic-af-bank-followups-wave27 --limit 2 \
+  --json status,conclusion,headSha --jq '.[]|"\(.headSha[0:7]) \(.status) \(.conclusion // "-")"'
+```
+
+---
+
+## Step 11 — close the run
+
+Delete the status cron (`CronDelete`) so a finished session is not woken every half hour. Final summary: what
+shipped, what was measured, what was refuted, what remains — **suite verified by COUNT, CI conclusion read out
+of the log.** Correct your own errors in the record, in place, where the owner can see them.
+
+---
+
+## Standing traps, on one screen
+
+* **READ LOGS, NOT EXIT CODES.** A `*_START` line alone is not a running arm — confirm a live `TestApp.exe`.
+* **WSL paths (`/mnt/d/...`) to scorers; Windows paths (`D:\...`) to `TestApp.exe`.**
+* **One `TestApp.exe` at a time. One `dotnet test` at a time. Never NINA during an arm.**
+* **`< /dev/null`** on every `TestApp.exe` invocation inside a loop.
+* **Assert the population size everywhere**; `-print0 | sort -z | xargs -0`.
+* **Ordinals and counts COMPUTED, never typed.**
+* **ASCII logs.** Newtonsoft writes NaN/Infinity as the strings `"NaN"`/`"Infinity"`.
+* **Hash the dlls, never the apphost.** `git diff --name-only <old>..<new> -- '*.cs'` is mandatory provenance for
+  any two-binary rule; **read the BEFORE binary's own provenance file for its tree hash.**
+* **A control written after the arm is not a control.** The BEFORE fingerprints are already taken.
+* **An unsatisfiable clause is a FINDING, not something to repair and re-score.**

--- a/plans/synthetic-af-bank-followups-wave27-plan.md
+++ b/plans/synthetic-af-bank-followups-wave27-plan.md
@@ -6,8 +6,13 @@ step-by-step. Where the two disagree, the design wins and the disagreement is a 
 **Vessel:** PR #195 MERGED → `git checkout develop && git pull && git checkout -b ghilios/synthetic-af-bank-followups-wave27`
 off `develop @ e19a779`.
 
-**Hard stop: 2026-08-14T00:45:17Z.** Budget ~5 h 20 m against a ~6 h ceiling. **Cut order if it overruns:
-(D) → (A)'s build half. (B) and (C) are never cut.**
+**Hard stop: 2026-08-14T00:45:17Z.** Budget **~5 h against ~11.5 h remaining** — **time is NOT the binding
+constraint, so do not cut scope for it.** Cut only what the evidence does not support. If it overruns anyway the
+order is fixed: (D) → (A)'s build half; **(B) and (C) are never cut.**
+
+**Measured rates, and they are new to this series** — the charter's §5 budget table has no `golden eval` row at
+all: the **full 20-dataset arm is 349 s (~6 m)**; a cell ranges **6 s (`D06`) to 46 s (`D01`)**, mean ~17 s.
+**Price a 7-cell arm from the RANGE, not the mean** — `D01` is 7.7× `D06`.
 
 **Record ACTUAL against ESTIMATE in every step's row of `/mnt/d/hf_w27/TIMING.tsv`** (`step`, `est_min`,
 `actual_min`, `note`), written by the controller as each step closes. The estimate/actual pair is itself a

--- a/plans/synthetic-af-bank-followups-wave28-plan.md
+++ b/plans/synthetic-af-bank-followups-wave28-plan.md
@@ -1,0 +1,319 @@
+# Wave 28 — implementation plan
+
+**Spec:** `docs/synthetic-af-bank-followups-wave28-design.md`. Read it first; this file only executes it.
+**Controller runs every measurement.** Subagents' background processes die with their session and their tool
+timeouts cap at 10 minutes.
+
+**Order is load-bearing.** Steps 0–2 are blocking pre-flight. Step 5 (`W28-B`, the verdict) must be scored
+**before** step 7 decides whether ship (2) is owed. Step 3's product change ships **unconditionally** and its
+rule is fixed in the design before any data — do not renegotiate it after step 5.
+
+---
+
+## Step 0 — vessel, ~5 m
+
+```bash
+gh pr view 196 --json state,mergeable --jq '"\(.state) \(.mergeable)"'      # expect: OPEN MERGEABLE
+cd /home/ghilios/src/hocus-focus
+git checkout ghilios/synthetic-af-bank-followups-wave27 && git pull
+git checkout -b ghilios/synthetic-af-bank-followups-wave28
+mkdir -p /mnt/d/hf_w28
+```
+
+Commit the design and this plan **before any measurement**, with the privacy email:
+
+```bash
+GIT_COMMITTER_NAME="George Hilios" GIT_COMMITTER_EMAIL="322725+ghilios@users.noreply.github.com" \
+  git commit --author="George Hilios <322725+ghilios@users.noreply.github.com>" \
+  -m "W28 pre-registration: item 8 is the LOWER edge of the detector's 2-4 px calibrated band"
+```
+
+**Gate:** `git log --oneline -1` shows the pre-registration commit before step 4 runs anything.
+
+---
+
+## Step 1 — `verify_derivation_w28.py`, BLOCKING, ~30 m
+
+Derive from `/mnt/d/hf_w27/verify_derivation_w27.py` (**not** the `.bak` — that is the pre-[F87](../docs/followups.md) copy).
+
+1. `sed` the wave id forward; **shape-matched** token patterns, both affixes, `_` treated as a word character.
+2. **Carry [F87](../docs/followups.md)'s repair forward and prove it did not regress.** `in_historical_block()` must not
+   treat the **definition line of `HISTORICAL_BLOCKS`** as opening a historical literal. The regression test
+   is direct: the checker must report findings **on its own file** when its own file names `w27`, and must
+   **not** report a wave-27 token inside a declared historical block.
+3. **Self-test clause `[6]` carried forward**: a real historical block is exempt · the file after it is not ·
+   the definition line opens nothing. Both ends.
+4. **Both FAIL fixtures pinned and kept:** `/mnt/d/hf_w24` **and** `/mnt/d/hf_w26`. Neither is "whatever came
+   before" ([F80](../docs/followups.md)).
+
+```bash
+python3 /mnt/d/hf_w28/verify_derivation_w28.py --self-test --out /mnt/d/hf_w28/vdrift_selftest_w28.txt
+python3 /mnt/d/hf_w28/verify_derivation_w28.py --root /mnt/d/hf_w28 --out /mnt/d/hf_w28/vdrift_w28.txt
+```
+
+**Gates — READ THE OUTPUT, NOT THE EXIT CODE:**
+- `vdrift_selftest_w28.txt` ends with `SELFTEST V28 <n> of <n>`, `n` equal on both sides, and clause `[6]`
+  present with both ends;
+- both pinned fixtures **refuse** with a non-zero finding count, each printed;
+- `vdrift_w28.txt` verdict is `V-CLEAN` **and** its banner reads `RULE V28`, not `V27`. **A `V-CLEAN` from a
+  checker printing the previous wave's rule name is exactly [F87](../docs/followups.md) and blocks the wave.**
+
+**Nothing downstream runs until this passes.**
+
+---
+
+## Step 2 — read-only fingerprint, BEFORE, ~10 m
+
+`/mnt/d/hf_w25/table18/` and `/mnt/d/SyntheticAutofocusBank/` are read-only for the whole wave.
+
+**[F91](../docs/followups.md): ONE expression, called twice.** Write `fp_w28.sh` exposing a single
+`sweep <root> <outfile>` function used for both BEFORE and AFTER. No second `find`.
+
+```bash
+find "$ROOT" -type f -print0 | sort -z | xargs -0 sha256sum
+```
+
+- `-print0 | sort -z | xargs -0` — `/mnt/d/Autofocus Bank` contains a space and plain `xargs` splits it.
+- **Assert the population size inside the file** (`POPULATION <n>`); it is the only thing that catches a
+  false `VIOLATED`.
+
+**Gate:** `fp_BEFORE.txt` exists with its asserted count printed. AFTER is step 8.
+
+---
+
+## Step 3 — ship (1): the false in-band statement, ~60 m + suite
+
+**Unconditional (design §9). Product code, no measurement.**
+
+File: `Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/Utility/DetectionBinningResolver.cs`
+
+Two defects, one cause — the recommendation is one-sided because `Clamp` floors at 1:
+
+1. `DescribeRecommendationDetail`'s else-branch (`:100-104`) asserts *"{0:0.0} px is already in that range"*
+   for **any** `recommended == 1`, including 0.7 px. Split the branch: **in band** keeps today's wording;
+   **below band** says the measurement is below the range the detector is calibrated for, that binning
+   cannot help (it only divides), and points at the axis that does — `MinHFR`
+   (cf. [F35](../docs/followups.md), [F43](../docs/followups.md): the only axis that rescues an under-sampled rig).
+2. `ShouldShowRecommendation` (`:120-121`) returns **false** below the band, so the row is hidden from
+   exactly the users who need it. It must return **true** when the measurement is below the band.
+
+Add a named boundary constant rather than a literal — the band's edges are already implied by
+`TargetHfrPixels`; make the lower edge explicit and reference it from both call sites so they cannot drift.
+
+**Tests** (`Joko.NINA.Plugins.HocusFocus.Tests/`), **three cases so the below-band case cannot pass by
+accident**:
+
+| case | HFR | expect |
+|---|---|---|
+| below band | 0.7 | detail does **not** contain "already in that range"; `ShouldShowRecommendation(1, 0.7)` is **true** |
+| in band | 3.0 | detail **does** say in-range; `ShouldShowRecommendation(1, 3.0)` is **false** |
+| above band | 6.0 | `RecommendFromHfr` is 2; detail describes the division |
+
+**Do NOT change `RecommendFromHfr`.** It is the single source of truth cited by the options page, the wizard
+and the documentation; changing what it returns changes detection behaviour on upgrade. **This step changes
+what the user is TOLD, and nothing else.** State that in the commit message.
+
+**Gate:** suite green at **≥ 3973 + 3**, verified **by COUNT out of the log** ([F37](../docs/followups.md)), never by the
+tick. Kill stragglers first; `dotnet test <sln>` does **not** build `TestApp` — build it separately.
+
+```bash
+powershell.exe -NoProfile -Command "Get-Process testhost,vstest.console -EA SilentlyContinue | %{ \$_.Kill() }"
+dotnet.exe test "$(wslpath -w Joko.NINA.Plugins/Joko.NINA.Plugins.sln)" -c Debug --nologo 2>&1 | tee /mnt/d/hf_w28/suite_AFTER_ship1.log
+```
+
+---
+
+## Step 4 — `RULE W28-S` (source), ~30 m, zero compute
+
+`score_w28s.py --out <file>`, **refusing without `--out`**. Reads `StarDetector.cs` at HEAD, records its
+**sha256** in the output, and asserts:
+
+| clause | assertion |
+|---|---|
+| `S-a` | the `ConvolveGaussian(structureMap, structureMap, …)` call's third argument is literally `p.StructureLayers * 2 + 1` |
+| `S-b` | no `StarDetectorParams` member controls the post-wavelet blur width independently |
+| `S-c` | `EffectiveStructureLayers(p)` reaches the residual (`:611`/`:619`/`:622`) and **not** the blur |
+
+**Count assertion (F68 part 5):** the scorer asserts it matched **exactly one** `ConvolveGaussian` call site
+in `BuildDetectionContextInternal` and **refuses on any other count** — a second copy must not be silently
+read past.
+
+**Self-test, both ends, captured:** run each clause against a constructed fixture where it is false. Print
+`SELFTEST W28S <n> of <n>` to the output file.
+
+**Gate:** `w28s_score.txt` prints a verdict in `{S-WELDED, S-SEPARATE, S-UNEVALUATED}` and the file sha256.
+A missing file or line is `S-UNEVALUATED`, **never a pass**.
+
+> **This is a finding, not a ship gate** (design §4/§9). It holds at the commit read during pre-registration;
+> a conjunct known-true at pre-registration must not be dressed as a gate.
+
+---
+
+## Step 5 — `RULE W28-B` (the verdict), ~75 m, ~1 min compute
+
+**The blind half. Score it before step 7.**
+
+`score_w28b.py --manifest <tsv> --rule W28-B --out <file>`:
+
+- takes its **rule label as an argument** and asserts it against the manifest ([F90](../docs/followups.md));
+- **refuses without `--out`**;
+- reads paths **through the manifest**, never a template.
+
+**Manifest** (`w28b_manifest.tsv`), built from one expression: 20 rows of
+`dataset · log path · synthetic_meta path · class`. `class` is **computed** from
+`K = max(hfrMin, hfrMinEffective)`, never typed.
+
+**Population, computed not typed:** `POP = set(all 20) − EXCLUDED`, `EXCLUDED = {D01, D02, D03}` as a named
+constant. Assert `len(POP) == 17` and print it.
+
+**Parsing gates, before any row is read:**
+- the `PER-FRAME (sorted by focuser)` header line matches exactly
+  `focuser  dsteps  golden  acc   TP   FP   FN   prec   recall   f1`; refuse otherwise;
+- **the scorer refuses to read any `OVERALL` or `ATTRIBUTION` line from the 17** — that is the blindness
+  boundary of design §6 and it is enforced in code, not by intention;
+- exactly 9 frame rows per dataset, asserted.
+
+**Statistics** (design §5.2): `Δrecall` from the `recall` column (**ALL-TIER** — the log carries
+`recall@high` only in `OVERALL`, and the results must never call `Δrecall` a high-tier statement);
+`Δacc` from the `acc` column (**detector-only, no golden**).
+
+**Clauses:** `B-1` sign agreement ≥ 13 of 14 · `B-2` prediction correct ≥ 12 of 14 with ≥ 1 per class ·
+`B-3` **all 4 LOW have `Δacc < 0`**.
+
+**Verdict tree — check total coverage at pre-registration and print `B-TREE-GAP` for any uncovered region**
+(wave 27 §8.1). Domain: `B-BANDPASS` · `B-REFUTED` · `B-SPLIT` · `B-UNDERPOWERED` · `B-TREE-GAP`.
+
+**EMPTY:** a dataset with no `PER-FRAME` block, < 3 frames, or no `truthModel.perFrame` is `CNL-NOFRAMES`,
+leaves the denominator, prints as `k of 14` with **k computed**; `k < 10` ⇒ `B-UNDERPOWERED`, never a pass.
+
+**Self-test, captured, both ends** — including at minimum: a fixture whose two routes disagree returns
+`B-SPLIT`; a fixture with one LOW dataset positive returns `B-REFUTED`; a fixture missing a `PER-FRAME`
+block returns `CNL-NOFRAMES` and a **computed** `k`; a fixture with a renamed header **refuses**. Print
+`SELFTEST W28B <n> of <n>`.
+
+**Gate:** `w28b_score.txt` carries the verdict, the computed populations (`17`, `14`, `k of 14`), the three
+MID datasets excluded **by name**, and both routes per dataset.
+
+---
+
+## Step 6 — `RULE W28-N` (the arm), ~60 m, **5–8 min compute**
+
+**No binary.** Build the arm tree by copying seedA0's optimized settings and editing **one field**.
+
+```bash
+mkdir -p /mnt/d/hf_w28/nc
+# for each of D01,D02,D03 x NC in {landed,2.0,1.0}: copy the opt-results subtree, edit
+# optimized_settings.json's NoiseClippingMultiplier only, and record the before/after sha256 of each file.
+```
+
+**[F89](../docs/followups.md): `cp -p` restores the pre-edit mtime.** `touch` every copied file after the copy; keep the
+sha256 check, which guards content and says nothing about mtime.
+
+Invocation mirrors the published `table18` one, differing **only** in `--opt-results` and a pinned
+`--profile-id`; state the pin's demonstrated inertness **with its `n`**, never assumed. Redirect
+`TestApp.exe`'s stdin: `< /dev/null`.
+
+Run **sequentially** — one `TestApp.exe` at a time, no NINA. Confirm a live `TestApp` and a `*_START` line
+before believing the arm is running; **a `*_START` line alone is not evidence**.
+
+`score_w28n.py --manifest <tsv> --rule W28-N --out <file>`:
+
+| clause | field | bar |
+|---|---|---|
+| `N-1` | `NoiseClip=` on the `key detector knobs:` line | intended value on **9 of 9** |
+| `N-2` | `NO CANDIDATE (structure gap)` **inside the `HIGH TIER ONLY` block** | ≥ 25 % fall at `NC=1.0` on **3 of 3** |
+| `N-3` | `precision` from `OVERALL` | ≥ 0.90 on **3 of 3** at `NC=1.0` |
+
+**[F68](../docs/followups.md) part 5 — which copy:** the `NO CANDIDATE (structure gap)` line appears **twice** per log, once
+in the aggregate block and once in `HIGH TIER ONLY` (`GoldenEvalRunner.cs:763` vs `:774`). **The aggregate
+copy is the wrong one.** Anchor on the block header and assert exactly one line consumed.
+
+**`N-1`'s FAIL end runs on a real cell:** one extra `golden eval` from an **unedited** copy, which must echo
+the landed `NoiseClip`. A control that cannot fail is not a control.
+
+**Verdict:** `N-RECOVERS` · `N-REFUTED` (`N-2` fails — §2.2's amplitude account is wrong, and the results say
+so plainly) · `N-COSTED` (`N-2` holds, `N-3` fails) · `N-UNDERPOWERED` (`k < 3`). Tree checked for total
+coverage.
+
+**Estimate to record against actual ([F21](../docs/followups.md)):** 9 cells at the measured `golden eval` rate of
+**6–46 s per 9-frame cell** (full 20-dataset arm 349 s) ⇒ **5–8 min**. The charter's §5 budget table has no
+`golden eval` row; **record the actual and add one.**
+
+---
+
+## Step 7 — ship (2) decision, ~30 m if owed
+
+**Read `w28b_score.txt` first.**
+
+- `B-BANDPASS` ⇒ surface the below-band condition outside the wizard. The machinery exists —
+  `HasUndersampledStars` (`StarDetectionOptimizerWizardVM.cs:237-238`), `MinHfrSeed.IsBelowGate`
+  (`MinHfrSeed.cs:113-120`) — and is wizard-only. Re-run the suite by COUNT.
+- **anything else ⇒ it does not ship**, and is recorded as a costed recommendation with its price. Do not
+  renegotiate the rule after seeing the number.
+
+---
+
+## Step 8 — AFTER fingerprint, ~10 m
+
+Call **the same `sweep` function** from step 2. Assert `BEFORE == AFTER` population size **before comparing
+any hash** — that assertion is the only reason wave 27 caught a false `VIOLATED`
+([F91](../docs/followups.md)).
+
+**Gate:** `PRESERVED`, with both counts printed. A difference forces `UNEVALUATED` on any rule reading those
+roots.
+
+---
+
+## Step 9 — record, ~45 m
+
+1. `docs/synthetic-af-bank-followups-wave28-results.md` — verdicts, both estimate and actual, what was
+   **not** run and its price, controller deviations, and a blindness statement matching design §6.
+2. `docs/followups.md` — register entries. **Owed regardless of verdict:**
+   - the **welded cutoff** (`StarDetector.cs:632`) and that it confounds
+     [F43](../docs/followups.md)'s "fewer `StructureLayers` is worse";
+   - the **one-sided band** (§7): a calibrated range enforced above and not below, with the false in-band
+     string, and ship (1);
+   - **item 8 was substantially worked** by F20/F35/F43/F44/F22 — amend those entries to cross-reference each
+     other, since their being scattered is why the backlog called it untouched;
+   - amend [F62](../docs/followups.md) — `RULE D27` and item 8 are **one band-pass phenomenon**, not two findings.
+3. `docs/synthetic-af-bank-results-table.md` — add the **in-focus kernel HFR (px)** column from
+   `truthModel`, and the note that `D01`/`D02`/`D03` are the **only three floored by the generator**
+   (`hfrMin < hfrMinEffective`). It reorders the recall column into a monotone story and costs nothing.
+4. `docs/waves29+-…` handoff — re-price the backlog. **[F82](../docs/followups.md) (`D01`'s step recommendation stalled at 3
+   against a truth of 9) is better-evidenced than item 8 was and scores goal 2**; name it item 1.
+
+---
+
+## Step 10 — close, ~20 m
+
+```bash
+git status --short   # nothing untracked left behind -- F88: git diff does NOT list untracked files
+```
+
+Commit with the privacy email, push, open the PR, and **verify CI by COUNT out of the log**, not by the
+conclusion field alone.
+
+---
+
+## Standing constraints (apply to every step)
+
+- Instruments in `/mnt/d/hf_w28/`, **LF endings**.
+- Every scorer taking `--out` **refuses without it**; `--self-test` is **never dispatched from a sourced
+  file**; every self-test prints `SELFTEST <RULE> <n> of <n>` **into a file**.
+- **Populations asserted. Ordinals computed, never typed. Paths through a manifest.**
+- `-print0 | sort -z | xargs -0`.
+- Scorers take **WSL paths** (`/mnt/d/...`); a Windows path yields UNEVALUATED and looks like a failed arm.
+- **Never rebuild an arm's directory mid-wave.** Wave 28 needs **one** build (step 3) and it is not an arm
+  binary — no `golden eval` cell runs against it.
+- Logs ASCII. Newtonsoft writes NaN/Infinity as the **strings** `"NaN"`/`"Infinity"`.
+- **Read logs, not exit codes.**
+- Never push `develop`.
+
+## Stop conditions
+
+- Steps 0–2 are blocking. If step 1 cannot be made to pass, **that is the wave's finding** — record it and
+  stop; a derivation checker that cannot certify itself is [F87](../docs/followups.md) recurring.
+- If `W28-B` returns `B-TREE-GAP`, **the rule is incomplete: report it, do not repair and re-score.**
+  ([F14](../docs/followups.md) / `RULE D20` fence.)
+- If the arm overruns, **cut step 6 first.** Steps 3, 4 and 5 carry the wave: (3) ships unconditionally,
+  (4) is free, (5) is the verdict.

--- a/plans/synthetic-af-bank-followups-wave29-plan.md
+++ b/plans/synthetic-af-bank-followups-wave29-plan.md
@@ -1,0 +1,355 @@
+# Wave 29 — implementation plan
+
+**Spec:** `docs/synthetic-af-bank-followups-wave29-design.md`. Read it first; this file only executes it.
+**The controller runs every measurement.** A subagent's background processes die with its session and its tool
+timeouts cap at 10 minutes.
+
+**Order is load-bearing, and Step 1 → Step 2 is the whole of [F95](../docs/followups.md)'s remedy.** Every
+instrument is written **before** the blocking pre-flight runs, so the pre-flight has a non-empty population.
+Wave 28 ran its pre-flight at the moment its plan said to — which was before the six instruments it guards
+existed — and certified a root of one file. **A blocking pre-flight must run BEFORE the measurement and AFTER
+the instruments.** No previous plan in this series has said so.
+
+**Step 4 (`W29-S`) and Step 5 (`W29-R`) must both be scored before anything is written about F82's fix.**
+Nothing in this wave ships (design §9); if that changes for any reason, Step 8's reversal conditions fire and
+the wave owes the suite and the 42 m gate.
+
+---
+
+## Step 0 — vessel, ~10 m
+
+```bash
+gh pr view 196 --json state,mergeable --jq '"\(.state) \(.mergeable)"'      # expect: OPEN MERGEABLE
+cd /home/ghilios/src/hocus-focus
+git checkout ghilios/synthetic-af-bank-followups-wave27 && git pull
+git checkout -b ghilios/synthetic-af-bank-followups-wave29
+mkdir -p /mnt/d/hf_w29
+date -u +%FT%H:%M:%SZ > /mnt/d/hf_w29/T0.txt
+```
+
+**A fresh branch and a fresh PR. Do not add a third section to #196** — design §0; wave 28 §13 deviation 2
+already measured what that costs.
+
+Commit the design and this plan **before any measurement**:
+
+```bash
+GIT_COMMITTER_NAME="George Hilios" GIT_COMMITTER_EMAIL="322725+ghilios@users.noreply.github.com" \
+  git commit --author="George Hilios <322725+ghilios@users.noreply.github.com>" \
+  -m "W29 pre-registration: F82's pre-registered fix has no carrier in the product, and its reversal condition has never been run"
+```
+
+**Gate:** `git log --oneline -1` shows the pre-registration commit before Step 4 runs anything.
+
+---
+
+## Step 1 — write EVERY instrument, ~60 m. Nothing runs yet
+
+Five files under `/mnt/d/hf_w29/`, **LF endings**, all derived from `/mnt/d/hf_w28/`:
+
+| file | derived from | role |
+|---|---|---|
+| `verify_derivation_w29.py` | `verify_derivation_w28.py` (**not** a `.bak`) | `RULE V29` |
+| `fp_w29.sh` | `fp_w28.sh` | `W29-FP`, one `sweep()` called twice |
+| `score_w29s.py` | `score_w28s.py` | `RULE W29-S` |
+| `score_w29r.py` | new, but reusing `score_w28n.py`'s manifest + refusal skeleton | `RULE W29-R` |
+| `w29l_arm.sh` + `score_w29l.py` | `w28n_arm_w28.sh` + `score_w28n.py` | `RULE W29-L` |
+
+Standing requirements for all of them (design §12):
+
+1. **`--out` is mandatory and the scorer REFUSES without it.** A stdout redirect puts the evidence in a
+   job-scoped temp directory that is deleted without ceremony.
+2. **`--rule` is asserted against the file's own declared rule name** ([F90](../docs/followups.md)) — a hard
+   refusal, not a warning. Wave 28's scorers caught the controller within a minute with this.
+3. **Every ordinal and count in printed output is COMPUTED**, never typed (`V29-C` will check).
+4. **Populations asserted** inside the output file. Paths reach a scorer through a **manifest**, never a
+   template ([F74](../docs/followups.md)); both drivers source **one** layout function.
+5. **Each scorer re-derives its own outcome-space enumeration in code** and prints
+   `regions enumerated: N   uncovered: 0`, against design §10's tables. A mismatch prints `<RULE>-TREE-GAP`,
+   enumerates the uncovered regions, prints what design §10 would have said, and **does not repair and
+   re-score** ([F94](../docs/followups.md)).
+6. **Every clause's FAIL end is reachable and demonstrated on real files**, and each demonstration asserts
+   **which clause fired**, not merely that something did.
+
+### 1a. `verify_derivation_w29.py` — the three repairs to carry, and the one thing to MEASURE
+
+1. `sed` the wave id forward with **shape-matched** token patterns, both affixes, `_` treated as a word
+   character. **Then grep the result for `V28`/`w28` residue** — wave 28's own controller `sed`
+   (`s/\bV27\b/V28/g`) failed to rewrite `V27_OK` because `_` is a word character, and the checker caught its
+   author. Expect the same class here with `V28_OK`.
+2. **Carry [F87](../docs/followups.md)'s `historical_ranges` repair and prove it did not regress.**
+   `in_historical_block()` must compute ranges top-down by **bracket depth**, require the opener line to
+   actually open a bracket, and exclude the **definition line of `HISTORICAL_BLOCKS`** by name
+   (`is_definition`). The regression test is direct: the checker must report findings on its own file when
+   its own file names `w28`, and must **not** report a token inside a declared historical block.
+3. **Self-test clause `[6]` carried forward, both ends**: a real historical block is exempt · the file after
+   it is not · the definition line opens nothing.
+4. **Per-clause fixture pinning `[5b]` carried forward — and the fixtures are MEASURED, not inherited.**
+   Wave 28 established that a root pinned for its `-B` findings goes silent one wave later. Run first:
+
+   ```bash
+   for R in /mnt/d/hf_w24 /mnt/d/hf_w26 /mnt/d/hf_w27 /mnt/d/hf_w28; do
+     python3 /mnt/d/hf_w29/verify_derivation_w29.py "$R" --out "/mnt/d/hf_w29/vdrift_probe_$(basename $R).txt"
+   done
+   ```
+
+   **Pin `-B` to a root that still refuses and `-C` to a root that still refuses**, from those counts.
+   `/mnt/d/hf_w27` was wave 28's `-B` fixture and `PREV` is now 28 — **assume nothing, read the four probe
+   files.** Keep every expired root pinned and **asserted silent**, so the expiry is demonstrated rather than
+   described. **A clause with no live fixture is a FAIL**, not a pass.
+
+**Nothing in Step 1 is run for its verdict.** The probe runs above are fixture selection and their outputs are
+kept.
+
+---
+
+## Step 2 — `RULE V29`, BLOCKING, over the POPULATED root, ~20 m
+
+**This step runs only after Step 1 has written all five instruments.** That ordering is the deliverable.
+
+```bash
+ls -la --time-style=full-iso /mnt/d/hf_w29/        # capture: the population must be > 1 file
+python3 /mnt/d/hf_w29/verify_derivation_w29.py --self-test --out /mnt/d/hf_w29/vdrift_selftest_w29.txt
+python3 /mnt/d/hf_w29/verify_derivation_w29.py /mnt/d/hf_w29 --out /mnt/d/hf_w29/vdrift_w29.txt
+```
+
+**Gates — READ THE OUTPUT, NOT THE EXIT CODE:**
+
+- `vdrift_selftest_w29.txt` ends `>>> SELF-TEST PASS`, with clause groups `[1] [2] [3] [4] [5] [5b] [6]` all
+  present and `[6]` showing **both** ends;
+- each pinned fixture **refuses on its own clause**, count printed;
+- the expired root is present and **asserted silent**;
+- `vdrift_w29.txt` verdict is `V-CLEAN`, **`files checked` is ≥ 5**, and its banner reads `RULE V29` — not
+  `V28`. **A `V-CLEAN` from a checker printing the previous wave's rule name is [F87](../docs/followups.md);
+  a `V-CLEAN` over a root of one file is [F95](../docs/followups.md). Both block the wave.**
+
+**Nothing downstream runs until this passes.**
+
+---
+
+## Step 3 — `W29-FP` fingerprint, BEFORE, ~8 m
+
+Read-only for the whole wave: `/mnt/d/hf_w25/{after,before,table18,exe}`, `/mnt/d/hf_w28/nc`,
+`/mnt/d/SyntheticAutofocusBank`.
+
+**[F91](../docs/followups.md): ONE `sweep <root> <outfile>` function, called twice.** No second `find`.
+
+```bash
+find "$ROOT" -type f -print0 | sort -z | xargs -0 sha256sum
+```
+
+- `-print0 | sort -z | xargs -0` — `/mnt/d/Autofocus Bank` contains a space and plain `xargs` splits it.
+- **Assert `ROOTPOPULATION` per root and `POPULATION <n>` overall inside the file.** It is the only thing that
+  catches a false `VIOLATED`.
+- Write the artifact **outside** every tree it sweeps (wave 28 §7.10).
+- **Run `fp_w29.sh --self-test` and KEEP ITS OUTPUT** — wave 28's self-test left no artifact (§7.7), and so
+  did its verdict line. Both are two minutes and both are captured here: `fp_selftest_w29.txt`.
+
+**Gate:** `fp_BEFORE.txt` exists with its asserted counts printed, and `fp_selftest_w29.txt` contains
+`SELFTEST W29FP`.
+
+---
+
+## Step 4 — `RULE W29-S` (source), ~25 m, zero compute
+
+```bash
+python3 /mnt/d/hf_w29/score_w29s.py --rule W29-S --out /mnt/d/hf_w29/w29s_score.txt
+```
+
+Reads four files at `HEAD` and **records each sha256 in the output** (design §4). Refuses if any is absent.
+
+| clause | what the scorer does |
+|---|---|
+| `S-a` | Locate `ComputeStepBehavioral` **by declaration, not first textual occurrence** — wave 28 §7.9's real bug, where the first occurrence was a call site and the "body" contained zero of the thing being counted. **An overloaded declaration REFUSES rather than picking a body.** Count `StepSizeRecommender.Recommend(` sites in the body; assert exactly 1; print the count seen and the whole-file count (**2**, at `:792` and `:1262`) so a reader can see the scoping is doing work. Then assert `ComputeStepBehavioral` is the only writer of the value serialized as `terminal.stepBehavioral` |
+| `S-b` | Enumerate **every** `Recommend(` site under `Joko.NINA.Plugins.HocusFocus/`, print the count and the list. For each, assert its enclosing round loop reloads previously-captured runs (`LoadRunStampedAsync`) rather than capturing a sweep. Then scan `OptimizedStarDetectionSettings` and `OptimizationSummary` for any member matching `(?i)halfwidth` and assert **zero** |
+| `S-c` | Assert `SweepDetectability` declares a member carrying requested focuser positions, and that it is reachable inside `Recommend` |
+
+**String literals are blanked length-preservingly before any pattern is counted**, so a decoy in a comment or
+literal cannot inflate a count and offsets stay aligned (wave 28 §7.9).
+
+**Self-test, on real files, both ends per clause:** `S-a`'s zero-site end against `StepSizeRecommender.cs`;
+its multi-site end against the whole of `SynthValidateRunner.cs` (2 sites); `S-b`'s carrier end against
+`StepSizeRecommendation`, which **does** declare `HalfWidth`; `S-c`'s absent end against the same type.
+
+**Gate:** `w29s_score.txt` ends `>>> RULE W29-S = <verdict>` with `regions enumerated: 8   uncovered: 0`,
+and `w29s_selftest.txt` ends `SELFTEST W29S <n> of <n>`.
+
+---
+
+## Step 5 — `RULE W29-R` (the verdict on wave 26's escape clause), ~25 m, zero compute
+
+```bash
+python3 /mnt/d/hf_w29/score_w29r.py --rule W29-R \
+   --root /mnt/d/hf_w25/after --out /mnt/d/hf_w29/w29r_score.txt
+```
+
+**Before any statistic, in this order:**
+
+1. Assert `MaxHalfWidthSampledHalfSpanMultiple == 1.5` **in source at both trees** — B15's tree hash read out
+   of `/mnt/d/hf_w25/binary_provenance_w25.txt` (line `tree:`), **never assumed from a previous HEAD** — and
+   at `HEAD`. A mismatch is `R-UNSATISFIABLE`; the inversion is only valid if the constant that produced the
+   artifacts is the one the scorer divides by.
+2. Assert the addressable population: **18** cells, and assert the gap against the 20 datasets is **exactly**
+   `D05_tec140_1000mm` and `D19_cygnus_deep_shed` ([F74](../docs/followups.md); wave 24's 40-vs-38).
+3. Assert every round read is `wasCapped || wasBandFloored` and `wasDetectBounded == false`. **Any round that
+   is not is a could-not-look**: named, counted, and excluded — never silently included.
+4. Assert the field copies read are the **per-round** `stepRecommendation` and `bootstrap`, exactly one
+   `stepRecommendation` per round index, and that **no value is read from `terminal`**
+   ([F68](../docs/followups.md) part 5).
+
+Then, per cell, per transition `r → r+1`:
+
+```
+impliedSearchSpan(r) = stepRecommendation.halfWidth / 0.75
+requested(r)         = 2 * bootstrap.offsetSteps * bootstrap.stepSize
+qualifies(r)         = requested(r+1) > requested(r)  AND  impliedSearchSpan(r+1) < impliedSearchSpan(r)
+```
+
+Cell qualifies if **any** transition does. Print `k`, `c` (over 18) **and** `c_blind` (over the 15 excluding
+`D01`/`D02`/`D03`), plus the names of every qualifying cell. **The verdict is taken on `c >= 2`, as wave 26
+wrote it** — not on a rate this wave invented.
+
+**Reachability of both branches, demonstrated before the population is read:** the scorer's self-test asserts
+that the identity reproduces `D01`'s published rounds (implied 16 → 12 against requested 16 → 24) **and** that
+`D02`'s published rounds (implied 16 → 24) do **not** qualify — one end each, on real published numbers.
+
+**Gate:** `w29r_score.txt` ends `>>> RULE W29-R = <verdict>` with `regions enumerated: 4   uncovered: 0`, and
+the `R-0`-false / `R-1`-true region is printed as asserted-empty.
+
+**Do not write a line of C# on either verdict.** Design §5.4 and §9.
+
+---
+
+## Step 6 — `RULE W29-L` (the one arm), ~55 m, **~25 m compute**
+
+**No build.** Binary `/mnt/d/hf_w25/exe`; assert `TestApp.dll` sha256 `2fb0c8fd…` against
+`/mnt/d/hf_w25/binary_provenance_w25.txt` before the first cell.
+
+`w29l_arm.sh` — derived from `w28n_arm_w28.sh`, keeping its structure:
+
+- copies the settings tree per cell **without `-p`** and `touch`es every copied file
+  ([F89](../docs/followups.md));
+- edits the named fields **only**, and its own self-test proves the edit is surgical (*exactly N files changed
+  and they are the settings files*; an unedited tree fingerprints identically twice);
+- writes per-cell fingerprints to `/mnt/d/hf_w29/l/fp/`, **outside** every tree they sweep
+  (wave 28 §7.10 — a fingerprint written inside the tree it sweeps makes the AFTER population one larger);
+- pins `--settings` **and** `--profile-id`;
+- gives `TestApp.exe` `< /dev/null`;
+- writes `w29l_manifest.tsv` (cell, settings path, out path, exit, seconds) **last**, and the
+  `W29L_MANIFEST_READY` marker is written **by the driver, on success only** ([F75](../docs/followups.md)) —
+  never by a controller `printf`;
+- the scorer reads paths **only** out of the manifest.
+
+Five cells, `NoiseClippingMultiplier = 1.0` throughout (design §6): `L0` baseline · `L1` `MinimumStarBoundingBoxSize`
+6 → 3 · `L2` `MaxDistortion` 0.5 → 0.9 · `L3` `Sensitivity` one notch · `L4` all three.
+
+**Budget from the measured rate, not from instinct:** wave 28 measured `D01` at `NC = 1.0` at **179 s** for a
+9-frame cell — 3.9× the previous published maximum, because lowering the threshold multiplies the candidate
+count. `L1`/`L2`/`L4` open gates *further*, so they may exceed it. **Reserve 25 m and check the manifest's
+per-cell seconds against 179 s; report the range in the results.**
+
+```bash
+python3 /mnt/d/hf_w29/score_w29l.py --rule W29-L \
+   --manifest /mnt/d/hf_w29/w29l_manifest.tsv --out /mnt/d/hf_w29/w29l_score.txt
+```
+
+The scorer anchors on the **`FALSE-NEGATIVE ATTRIBUTION, HIGH TIER ONLY`** header and asserts it consumed
+exactly one block — the same line appears twice per report and the aggregate copy appears **first**, so a
+first-match reader takes the wrong one (wave 28 self-test [3]).
+
+**`L-0` is the control and it can fail:** `L0` must reproduce wave 28's published `D01` `NC = 1.0` high-tier
+attribution block **field for field**. If it does not, every downstream number is uninterpretable and the
+verdict is `L-UNEVALUATED`.
+
+**Gate:** `w29l_score.txt` ends `>>> RULE W29-L = <verdict>` with `regions enumerated: 8   uncovered: 0`, the
+exclusive and joint shares printed, and the `L-1 ∧ L-2` region printed as asserted-empty.
+
+**No branch reads `L3` alone, and nothing this wave writes may cite `L3` as evidence for or against a
+sensitivity bound** ([F84](../docs/followups.md), `RULE S16` fence).
+
+---
+
+## Step 7 — [F83](../docs/followups.md)'s `P-D08` at `n = 3`, ~2 m
+
+*"The cheapest decision-moving measurement left in the register."* **An item under two minutes is never
+dropped** (charter §4). Run it, capture it with `--out`, record it whether it moves anything or not.
+
+---
+
+## Step 8 — fingerprint AFTER, the reversal check, and the CLOSING `V29`, ~12 m
+
+```bash
+bash /mnt/d/hf_w29/fp_w29.sh after                 # same sweep() expression, second call
+git status --short && git diff --stat              # the reversal check
+python3 /mnt/d/hf_w29/verify_derivation_w29.py /mnt/d/hf_w29 --out /mnt/d/hf_w29/vdrift_w29_FINAL.txt
+```
+
+**The reversal check, explicitly (design §8):** if **any** `.cs` file changed for any reason, or the
+`/mnt/d/hf_w25/exe` dll hashes do not match `binary_provenance_w25.txt`, or the arm proved non-deterministic —
+then **the unit suite is owed by COUNT** ([F37](../docs/followups.md), baseline **3997**, not the charter's
+stale 3973) **and the 42 m `optimize` gate becomes owed** and the wave stops until both are run.
+
+**The closing `V29` run is not optional at any budget.** It is [F95](../docs/followups.md)'s entire remedy:
+the first run proves the checker works, the closing run proves the wave is clean, and this series has been
+conflating them. **Keep `vdrift_w29.txt` beside `vdrift_w29_FINAL.txt`** so both states are on the record.
+**Capture the `W29-FP` verdict LINE to a file** — wave 28's existed only in a terminal.
+
+**Gate:** `W29-FP = PRESERVED`, populations asserted equal, and `vdrift_w29_FINAL.txt` reads `V-CLEAN` over a
+root of every instrument the wave wrote.
+
+---
+
+## Step 9 — record, ~75 m
+
+**First action of the results document is `ls -la --time-style=full-iso /mnt/d/hf_w29/`, with the timestamp
+PRINTED at the top.** Any row still open at that instant is marked open **in place**, not reported as done.
+Wave 19's document was falsified by an artifact written 33 seconds before its own commit.
+
+1. `docs/synthetic-af-bank-followups-wave29-results.md` — every verdict quoted from an artifact and cited;
+   the pre-registered rules **applied as written**; an unsatisfiable or under-specified clause reported as a
+   **finding**, not repaired and not re-scored. Estimate **and** actual per step
+   ([F21](../docs/followups.md)). What was not run, and its price.
+2. `docs/followups.md` — the entries design §14 names: **F96** (conditional on `W29-S`), **F97**, **F98**, and
+   the amendments to **F82** (in place: the *"truth of 9"* is a product-derived fixed point; name which
+   caller; add the third candidate), **F81**, **F94**, **F95**, **F21**.
+3. `docs/synthetic-af-bank-results-table.md` — wave 28's owed `K` column from `truthModel`
+   (`max(hfrMin, hfrMinEffective)`) and the note that `D01`/`D02`/`D03` are the only three floored by the
+   generator. **No 2–4 px band claim below the band** — `W28-B` is `B-SPLIT`.
+4. `docs/waves30+-…` handoff, **or** design §11's cut 4: fold it into the results file's §12 and say so.
+
+---
+
+## Step 10 — close, ~20 m
+
+```bash
+git add -A && GIT_COMMITTER_NAME="George Hilios" \
+  GIT_COMMITTER_EMAIL="322725+ghilios@users.noreply.github.com" \
+  git commit --author="George Hilios <322725+ghilios@users.noreply.github.com>" -m "W29 results: ..."
+git push -u origin ghilios/synthetic-af-bank-followups-wave29
+gh pr create --base develop --head ghilios/synthetic-af-bank-followups-wave29 --title "Wave 29: ..." --body "..."
+```
+
+**Never push `develop`.** Verify CI by **COUNT read out of the log**, never by the tick. Delete the status
+cron.
+
+---
+
+## Standing constraints (apply to every step)
+
+- **Only one `TestApp.exe` at a time.** Never run NINA during the arm. No fan-out.
+- **Never rebuild any directory mid-wave** — every instrument is written at Step 1.
+- **Pass scorers WSL paths** (`/mnt/d/...`). A Windows path yields `UNEVALUATED` and looks like a failed arm.
+- **Read the output, not the exit code.** A background job reporting `exit 0` has repeatedly meant a driver
+  aborted in one second; a `*_START` line alone is not evidence.
+- **A `--self-test` dispatcher in a SOURCED file sees the parent's `$1`** — wave 26's fired inside its
+  caller's `source` line, terminated it, and printed a clean PASS.
+- Newtonsoft writes NaN/Infinity as the **strings** `"NaN"`/`"Infinity"`. Every `table18` log carries **CRLF**;
+  strip `\r` before any comparison. Wave roots at or before 23 carry a `0xE5` — read old logs on bytes.
+- Commit with the privacy email, both author and committer.
+
+## Stop conditions
+
+- `RULE V29` not `V-CLEAN`, or its population ≤ 1 file → **stop**; nothing downstream runs.
+- `W29-FP` not `PRESERVED` → **stop**; a read-only root was written.
+- Any `.cs` file changed → Step 8's reversal fires: suite by COUNT **and** the 42 m gate, or stop.
+- Two consecutive waves producing no finding worth a register entry → **stop and say so.** *"There is nothing
+  left worth a wave"* is an acceptable and welcome answer.

--- a/plans/synthetic-af-bank-followups-wave30-plan.md
+++ b/plans/synthetic-af-bank-followups-wave30-plan.md
@@ -1,0 +1,416 @@
+# Wave 30 — implementation plan
+
+**Executes `docs/synthetic-af-bank-followups-wave30-design.md`.** Nothing in this plan changes what the design
+pre-registers. Where a step and the design disagree, **the design wins and the disagreement is a deviation to
+be recorded**, not a silent fix.
+
+**Hard stop `2026-08-14T00:45:17Z`.** Anchor `T0` with `date -u '+%Y-%m-%dT%H:%M:%SZ'` **and write it to
+`/mnt/d/hf_w30/T0.txt`** — wave 29's plan named `T0.txt` and never wrote it, so its `RULE F21` table has no
+in-band start stamp.
+
+---
+
+## 0. COMMAND-LINE CONVENTIONS — checked against the instruments, not invented here
+
+Wave 29's controller deviation (ii) was that *"the plan's command lines were not checked against the
+instruments the plan itself commissioned"*. **Step 1's exit gate is that every command line below is grepped
+out of the instrument's own `usage:` line before any of them runs.**
+
+The forms, inherited from `/mnt/d/hf_w29/`'s headers (verified at pre-registration):
+
+```
+bash  <driver>.sh   --self-test        --out <file>  [--rule <RULE>]
+bash  <driver>.sh   --run              --out <file>  [--rule <RULE>]
+bash  fp_w30.sh     [--self-test|before|after]  --out <file>  [--rule W30-FP]
+python3 <scorer>.py --manifest <tsv>   --rule <RULE>  --out <file>
+python3 <scorer>.py --self-test        --out <file>
+python3 verify_derivation_w30.py <root>  --out <file>  [--rule V30]
+```
+
+- **`--out` is mandatory on every instrument and every instrument REFUSES without it.** No step in this plan
+  uses a stdout redirect in place of `--out`.
+- **`--rule` is asserted against the file's own declared rule name** ([F90](../docs/followups.md)) and is a
+  hard refusal on mismatch. `verify_derivation_w29.py` declares `--rule` at its `argparse` line `:748`; `V30`
+  keeps it.
+- **All paths passed to scorers are WSL paths.** A Windows path yields `UNEVALUATED` and looks like a failed
+  arm. The one exception is `TestApp.exe`'s own `--runs` / `--opt-results` / `--out`, which take Windows paths
+  and are built by the arm driver, never typed here.
+- Every `TestApp.exe` invocation gets `< /dev/null`. **One `TestApp.exe` at a time.**
+
+---
+
+## Step 0 — the vessel, and the pre-registration commit (12 m)
+
+1. Confirm the current state before branching:
+   ```
+   git branch --show-current                       # expect ghilios/synthetic-af-bank-followups-wave29
+   git log --oneline -1                            # expect 59e27ab (or later on that branch)
+   git status --short                              # expect clean apart from the two wave-30 documents
+   gh pr view 197 --json number,state,baseRefName,headRefName,title
+   ```
+2. **Branch and commit:**
+   ```
+   git checkout -b ghilios/synthetic-af-bank-followups-wave30
+   git add docs/synthetic-af-bank-followups-wave30-design.md \
+           plans/synthetic-af-bank-followups-wave30-plan.md
+   GIT_COMMITTER_NAME="George Hilios" GIT_COMMITTER_EMAIL="322725+ghilios@users.noreply.github.com" \
+     git commit --author="George Hilios <322725+ghilios@users.noreply.github.com>" \
+     -m "W30 pre-registration: which gate binds on D01, measured as a FLOW with an exact conservation identity"
+   git push -u origin ghilios/synthetic-af-bank-followups-wave30
+   ```
+3. **Open the PR with the base that makes its diff one wave** (design §0, the finding):
+   ```
+   gh pr create --base ghilios/synthetic-af-bank-followups-wave29 \
+     --title "Wave 30: which gate actually binds on D01 — the per-gate FLOW, and a conservation identity that can fail" \
+     --body-file <a body naming the product question in one sentence, the two differing predictions, and what ships (nothing)>
+   ```
+4. **Verify the base took and the diff is one wave** — this is the step's gate:
+   ```
+   gh pr view <n> --json number,baseRefName,files | \
+     python3 -c "import json,sys; d=json.load(sys.stdin); print(d['number'], d['baseRefName'], len(d['files']))"
+   ```
+   **Expect `<n> ghilios/synthetic-af-bank-followups-wave29 2`.** Any base of `develop`, or any file count
+   above 2, means the vessel finding of design §0 has just repeated itself and **the step is not done**.
+5. **Do NOT** edit #196's or #197's base. Design §0 recommends it to the owner and wave 30 does not do it.
+6. **Never push `develop`.** Author **and** committer email `322725+ghilios@users.noreply.github.com`; if a
+   commit slips through with `ghilios@gmail.com`, amend before pushing.
+
+**Gate:** the PR exists, its base is the wave-29 branch, its diff is 2 files, `T0.txt` is written.
+
+---
+
+## Step 1 — write ALL SEVEN instruments, before any of them runs (60 m)
+
+`mkdir -p /mnt/d/hf_w30`. **LF line endings, ASCII only.** Nothing under `/mnt/d/hf_w30/` is rebuilt after this
+step ([F95](../docs/followups.md); design §14).
+
+| # | file | derived from | must contain |
+|---|---|---|---|
+| 1 | `layout_w30.sh` | `/mnt/d/hf_w29/layout_w29.sh` | the `(root, predicate)` array (design §6) defined **once**; `w30_sweep` taking that array and emitting `ROOT` / `ROOTPOPULATION` / `POPULATION`; `w30_fp_population`; `w30_fp_changed`; the shared self-test counter (`W30_N_OK` / `W30_N_ALL`) so **every ordinal in a `SELFTEST` line is computed** |
+| 2 | `fp_w30.sh` | `fp_w29.sh` | `before` / `after` / `--self-test`; both sides call `w30_sweep` with the **same** array ([F91](../docs/followups.md)); population size asserted **equal** before any hash is compared; `realpath` dedup for the D01 overlap between rows 1 and 2; written **outside** every tree it sweeps |
+| 3 | `verify_derivation_w30.py` | `verify_derivation_w29.py` | design §7 — all three `historical_ranges` generations with self-test `[6]` asserting **all four ends**; the widened `PRINTS` selector; **per-clause populations with the `N = 0` refusal**; the 12-region tree with `A = None`; the **realized-tuple membership assertion** |
+| 4 | `w30g_arm_w30.sh` | `w29l_arm_w29.sh` | design §4.3 — five cells, JSON keys **resolved not typed**, the four defocus preconditions asserted, the gate order extracted from source at **both** trees, dll sha256 asserted against `binary_provenance_w25.txt`, `cp` without `-p` + `touch`, per-cell BEFORE/AFTER fingerprints, the manifest, and the `READY` marker written **last** and only on full success |
+| 5 | `score_w30g.py` | `score_w29l.py` | design §4.4 / §4.5 / §11 — the flow statistic, the conservation identity, the 36-region tree, the `Sensitivity` fence, the F22 caveat printed beside every recall number |
+| 6 | `score_w30d.py` | new | design §5 — parses wave 29's §11 table out of the committed document, resolves each row, searches the declared set, the 6-region tree |
+| 7 | `kcol_w30.py` | new | design §2.6 — `truthModel.max(hfrMin, hfrMinEffective)` per dataset from `/mnt/d/SyntheticAutofocusBank/<ds>/synthetic_meta.json`, emitting the `K` column rows |
+
+**Three things the arm driver must get right, each of which cost a previous wave:**
+
+- **The knob edits.** Seed tree: the same source wave 29's arm used. Edited keys **resolved** from the tree's
+  own declared key set against a candidate list, refusing on zero or >1 match. Expected resolutions:
+  `MaxDistortion`, `BrightnessSensitivity`, `MinStarBoundingBoxSize`. `EffectiveSensitivityGate` is **left
+  alone** and each cell asserts its `key detector knobs:` echo shows the intended sensitivity (design §4.3).
+- **The `Sensitivity` value is computed, never typed.** `landed − 4 × step`, with `step` read at run time from
+  `OptimizerVariable.cs`'s own `Continuous(nameof(StarDetectorParams.Sensitivity), …)` declaration. Print the
+  declaration line and the arithmetic.
+- **The `FALSE-NEGATIVE ATTRIBUTION, HIGH TIER ONLY` block is anchored on its header**
+  ([F68](../docs/followups.md) part 5) — the line appears twice per report and a first-match reader takes the
+  wrong one. Wave 28's self-test proved this; wave 30's must too.
+
+**Self-tests, all written now and all captured at their own steps:** `w30g_arm_w30.sh --self-test`,
+`fp_w30.sh --self-test`, `score_w30g.py --self-test`, `score_w30d.py --self-test`,
+`verify_derivation_w30.py --self-test`. **`score_w30g.py`'s self-test uses wave 29's `L0/L1` and `L0/L3` pairs
+as live fixtures with known answers** — the two exact balances in design §4.2 — not synthetic mutants, and it
+must demonstrate **both** ends: a conserving pair passes, and a deliberately perturbed copy of one FAILS.
+
+**Gate for Step 1 (both halves, both blocking):**
+
+1. **Every command line in §0 and in Steps 2–8 is grepped out of the corresponding instrument's own `usage:`
+   line.** Print the grep output. A mismatch is fixed **in the plan**, not worked around at run time.
+2. `wc -l` and `file` on all seven, confirming LF and ASCII; then `ls -la --time-style=full-iso /mnt/d/hf_w30/`
+   captured, so the "last instrument written" timestamp exists for the `F21` table.
+
+---
+
+## Step 2 — `W30-FP` BEFORE. The first thing any instrument does (5 m)
+
+**Nothing else may read a declared root before this completes** — not `V30`'s fixture probes, not the arm.
+
+```
+bash /mnt/d/hf_w30/fp_w30.sh --self-test --out /mnt/d/hf_w30/fp_selftest_w30.txt
+bash /mnt/d/hf_w30/fp_w30.sh before --out /mnt/d/hf_w30/fp_BEFORE.txt --rule W30-FP
+```
+
+**Gate:** `fp_BEFORE.txt` exists, prints a `ROOTPOPULATION` line for each of the six rows in design §6, and a
+`POPULATION` total. **Capture the wall time** — design §6 predicts ~40 s at wave 29's measured 61 MB/s and
+prices it at 3 m; the measured number goes in the `F21` table either way.
+
+**If a declared root is absent**, `w30_sweep` writes `COULD-NOT-LOOK <root> absent` and the root **leaves the
+denominator** rather than scoring zero. Do not substitute another root.
+
+---
+
+## Step 3 — `RULE V30` pre-flight over the POPULATED root, and the fixture measurement (15 m)
+
+```
+python3 /mnt/d/hf_w30/verify_derivation_w30.py --self-test --out /mnt/d/hf_w30/vdrift_selftest_w30.txt
+
+for R in /mnt/d/hf_w24 /mnt/d/hf_w26 /mnt/d/hf_w27 /mnt/d/hf_w28 /mnt/d/hf_w29; do
+  python3 /mnt/d/hf_w30/verify_derivation_w30.py "$R" \
+    --out "/mnt/d/hf_w30/vdrift_probe_$(basename "$R").txt" --rule V30
+done
+
+python3 /mnt/d/hf_w30/verify_derivation_w30.py /mnt/d/hf_w30 \
+  --out /mnt/d/hf_w30/vdrift_w30.txt --rule V30
+```
+
+**Pin the per-clause fixtures FROM the five probes, never inherit them** ([F103](../docs/followups.md)).
+
+**Design §7's forward prediction, to be scored here and reported whichever way it lands:**
+
+| root | predicted `-B` | predicted role at wave 30 |
+|---|---|---|
+| `hf_w24` | 0 (`-C` = 2) | durable `-C` fixture, fourth wave |
+| `hf_w26` | 0 | asserted silent |
+| `hf_w27` | 0 | asserted silent |
+| `hf_w28` | **0 — EXPIRES**, from 100 at wave 29 | asserted silent |
+| `hf_w29` | **large, non-zero** | the new live `-B` fixture |
+
+**A clause with no live fixture is a FAIL, not a pass.**
+
+**Gate:** `vdrift_w30.txt` reports **`files checked: 7`** (all seven instruments — wave 29's plan said five and
+its verifier found seven), `SELFTEST V30 <n> of <n>` with every clause group present, every clause's
+`candidates: N` printed and non-zero where a population is declared, `regions enumerated: 12   uncovered: 0`,
+the realized tuple printed and asserted a member, and **`>>> V-CLEAN`**.
+
+**`V-DRIFT` blocks the wave.** Fix the instrument, re-run this step, and record it as a deviation. **Do not
+proceed to Step 4 on a `V-DRIFT`.**
+
+---
+
+## Step 4 — `RULE W30-G`, the arm (25 m wall, ~15 m compute)
+
+```
+bash /mnt/d/hf_w30/w30g_arm_w30.sh --self-test --out /mnt/d/hf_w30/w30g_arm_selftest.txt
+bash /mnt/d/hf_w30/w30g_arm_w30.sh --run       --out /mnt/d/hf_w30/w30g_arm.log --rule W30-G
+```
+
+The driver, in order, and it refuses at the first failure rather than continuing:
+
+1. asserts the dll sha256 of `/mnt/d/hf_w25/exe` against `/mnt/d/hf_w25/binary_provenance_w25.txt`;
+2. extracts the gate order from `StarDetector.cs` at `HEAD` **and** at the B15 tree `29665a62e4f8`
+   (`git show 29665a62e4f8:…/StarDetector.cs`) and **refuses if they differ**;
+3. asserts `DefocusAwareGates`, `DefocusAwareDonutDetection`, `DefocusAwareStructure` are all `false` and
+   `DonutMaxStreakEccentricity` is `1.0` in the seed tree (design §4.1(b));
+4. resolves each edited key and prints the resolution;
+5. per cell: `cp` without `-p`, `touch`, edit, BEFORE fingerprint, run, AFTER fingerprint, assert exactly one
+   file changed and every unnamed field unchanged, assert the `key detector knobs:` echo;
+6. writes `w30g_manifest.tsv` and, **last and only on full success**, `W30G_MANIFEST_READY`.
+
+**The five cells (design §4.3):**
+
+| cell | `MaxDistortion` | `BrightnessSensitivity` | `MinStarBoundingBoxSize` |
+|---|---|---|---|
+| `M0` | 0.5 | 36.333… | 6 |
+| `M1` | **0.3** | 36.333… | 6 |
+| `M2` | 0.5 | **landed − 4 × step** | 6 |
+| `M3` | **0.3** | **landed − 4 × step** | 6 |
+| `M4` | **0.2** | 36.333… | 6 |
+
+`NoiseClippingMultiplier` = **1.0** on all five.
+
+**Gate:** all five `exit=0`; `W30G_MANIFEST_READY` present; the arm's wall time inside the pre-registered band
+**725–1 600 s** (predicted ~950 s) — a time outside the band is **reported, not silently accepted**;
+`SELFTEST W30G-ARM <n> of <n>`.
+
+**If the arm exceeds ~30 m wall**, kill it, record it, and go to the cut list (§ Step 9's cut order). Do not
+restart cells piecemeal — `M0` is the control and a partial arm has no licence for the imports.
+
+---
+
+## Step 5 — `RULE W30-G`, scoring (12 m)
+
+```
+python3 /mnt/d/hf_w30/score_w30g.py --self-test --out /mnt/d/hf_w30/w30g_selftest.txt
+python3 /mnt/d/hf_w30/score_w30g.py --manifest /mnt/d/hf_w30/w30g_manifest.tsv \
+  --rule W30-G --out /mnt/d/hf_w30/w30g_score.txt
+```
+
+The scorer reads **every** artifact path out of the manifest ([F74](../docs/followups.md)) and rebuilds none,
+including the two wave-29 imports `/mnt/d/hf_w29/l/out/L{1,3}/attempt01/golden_eval.txt`.
+
+It must print, in this order:
+
+1. **the population lines** — cells scored, fields compared for the `M0`/`L0` control, gates ordered, single-
+   knob cells checked — each as `candidates: N   findings: M`, **refusing on an unexpected `N = 0`**;
+2. **`G-0`'s seven sub-assertions**, each with its own result;
+3. **the conservation check per single-knob cell** — every upstream Δ, the release, every downstream Δ, the
+   three terminals, and the balance as an integer equality;
+4. **the capture matrix** `C_{g→h}` in full;
+5. `Σ R_g`, `recapture`, `survive_g` per gate, `ΔTP(M3)`, and the **computed** material bar
+   `0.01 × FN_total(M0)`;
+6. the **realized clause tuple** and its membership assertion, then
+   `regions enumerated: 36   uncovered: 0`;
+7. the verdict, and the [F22](../docs/followups.md) caveat beside every recall number.
+
+**The `Sensitivity` fence is enforced in code:** the scorer refuses to name `Sensitivity` in any verdict string
+even if it carries the largest release, and prints the fence text ([F84](../docs/followups.md), `RULE S16`).
+
+**Gate:** a verdict from design §11's table; `uncovered: 0`; the realized tuple asserted a member. **An
+unsatisfiable clause is a FINDING and is not repaired.** A `G-TREE-GAP` is reported with what the design's tree
+would have said, and **is not re-scored after a repair**.
+
+---
+
+## Step 6 — `RULE W30-D` and the two retrospective captures (15 m, ~2 m compute)
+
+```
+python3 /mnt/d/hf_w30/score_w30d.py --self-test --out /mnt/d/hf_w30/w30d_selftest.txt
+python3 /mnt/d/hf_w30/score_w30d.py --manifest /mnt/d/hf_w30/w30d_manifest.tsv \
+  --rule W30-D --out /mnt/d/hf_w30/w30d_score.txt
+```
+
+Then the **retrospective** capture of wave 29's three missing scorer self-tests — labelled as retrospective
+everywhere they are quoted, because a self-test run now is weaker than the gate the wave-29 plan wrote:
+
+```
+python3 /mnt/d/hf_w29/score_w29s.py --self-test --out /mnt/d/hf_w30/w29s_selftest_RETRO.txt
+python3 /mnt/d/hf_w29/score_w29r.py --self-test --out /mnt/d/hf_w30/w29r_selftest_RETRO.txt
+python3 /mnt/d/hf_w29/score_w29l.py --self-test --out /mnt/d/hf_w30/w29l_selftest_RETRO.txt
+```
+
+**Write them under `/mnt/d/hf_w30/`, never under `/mnt/d/hf_w29/`** — wave 29's root is a declared read-only
+root of this wave's fingerprint and writing into it would produce a self-inflicted `VIOLATED` at Step 8.
+
+**Gate:** a `W30-D` verdict with `uncovered: 0`; three `RETRO` captures on disk, each with its own
+`SELFTEST … <n> of <n>` line; `P-D08`'s row named in the `D-STALE` output with the artifact path
+`/mnt/d/hf_w26/pd08/` and the commit `e42e2df` if the rule finds it, or a recorded disagreement with design
+§2.1 if it does not.
+
+---
+
+## Step 7 — the results-table `K` column (12 m)
+
+```
+python3 /mnt/d/hf_w30/kcol_w30.py --out /mnt/d/hf_w30/kcol_w30.txt --rule W30-K
+```
+
+Reads `truthModel.hfrMin` and `truthModel.hfrMinEffective` from each
+`/mnt/d/SyntheticAutofocusBank/<dataset>/synthetic_meta.json` (20 of 20 confirmed present at pre-registration,
+key names only), emits `K = max(hfrMin, hfrMinEffective)` per row, and asserts **20 rows** before emitting any.
+
+Then edit `docs/synthetic-af-bank-results-table.md`:
+
+1. add the **`K` column**, values pasted from `kcol_w30.txt` and never retyped;
+2. add the note that **`D01` / `D02` / `D03` are the only three floored by the generator**;
+3. **remove any 2–4 px band claim below the band** (`W28-B` = `B-SPLIT`).
+
+**Gate:** the three edits are present and the `K` values in the document match `kcol_w30.txt` byte for byte on
+a `diff` of the extracted column.
+
+**This is the first cut after `M4`** (design §13). If it is cut, §16's register entry must say **withdrawn**,
+not "still owed" — it has now been carried by waves 28, 29 and 30.
+
+---
+
+## Step 8 — `W30-FP` AFTER, the closing `V30`, and the three reversal checks (8 m)
+
+**Order matters and the reversal checks come first**, so that a C# change discovered here stops the wave before
+it writes a clean-looking close.
+
+```
+git diff --name-only <base> HEAD -- '*.cs'
+git ls-files --others --exclude-standard -- '*.cs'
+```
+
+**Union must be EMPTY.** If it is not, the 42 m `optimize` gate becomes owed and the unit suite runs by count
+against baseline **3997** ([F37](../docs/followups.md)) — design §9. Also re-assert the arm binary's dll sha256
+against `binary_provenance_w25.txt`, and confirm the arm's per-cell BEFORE/AFTER fingerprints showed exactly
+one changed file per cell.
+
+Then:
+
+```
+bash /mnt/d/hf_w30/fp_w30.sh after --out /mnt/d/hf_w30/fp_AFTER.txt --rule W30-FP
+python3 /mnt/d/hf_w30/verify_derivation_w30.py /mnt/d/hf_w30 \
+  --out /mnt/d/hf_w30/vdrift_w30_CLOSING.txt --rule V30
+```
+
+**Gate:** BEFORE and AFTER populations asserted **equal** before any hash is compared; a `PRESERVED` /
+`VIOLATED` / `UNEVALUATED` verdict per design §11; the closing `V30` is **`V-CLEAN`** over the now-fully-
+populated root. **Neither of these is cut at any budget.**
+
+**Take the roll call here**, not at the end of the write-up:
+
+```
+date -u '+%Y-%m-%dT%H:%M:%SZ'; ls -la --time-style=full-iso /mnt/d/hf_w30/
+```
+
+**Any artifact whose mtime is within a few seconds of the roll call must be checked for being mid-write**
+(`stat` it twice, two seconds apart) and **reported as open at the timestamp AND as a completed artifact** if
+it closes afterwards. Wave 19's document was falsified by an artifact written 33 s before its own commit; wave
+29's fix for that was to say both things, and it is now standing practice.
+
+---
+
+## Step 9 — results, register, handoff (80 m)
+
+Write `docs/synthetic-af-bank-followups-wave30-results.md`. It must contain, and the order is the order a
+reader needs:
+
+1. **THE TIMESTAMP** — the roll call table from Step 8, with each row's state at that instant.
+2. **§0 What this document is allowed to say** — every number quoted from a cited artifact; the design's rules
+   **applied as written**; a rule that turned out unsatisfiable, under-specified or directionally wrong is a
+   **finding**, not a repair; **everything is synthetic-only and `W30-G` is one dataset, `D01`**.
+3. **The verdict table** — `W30-G`, `W30-D`, `V30`, `W30-FP`, each with its population and artifact.
+4. **The headline**, whichever of design §4.6's two predictions survived, **naming which document predicted
+   which** and stating plainly if both were wrong.
+5. **The capture matrix in full**, and the conservation identity's result per cell.
+6. **The [F22](../docs/followups.md) caveat, inline, before any recall number** — and no recall gain quoted as
+   a product benefit anywhere in the document (design §2.7).
+7. **What is still unknown about `D01`, said plainly**, in the shape wave 29 §3.3 used.
+8. **Instrument findings** — populations that printed `0` and refused, `None` regions entered, tuple-membership
+   assertions that fired.
+9. **Controller deviations**, named, with what each cost.
+10. **Under-specified in the plan**, per the instrument agent.
+11. **[F21](../docs/followups.md): estimate vs actual per step**, plus the measured sweep constant for the
+    **trimmed** 2.4 GB root set against wave 29's 41.8 GB / 61 MB/s.
+12. **What was not run and what it costs.**
+13. **Register entries** F104–F107 and the amendments, per design §16, **ready to paste** — and append them to
+    `docs/followups.md` in the same commit.
+14. **Wave 31, priced and goal-scored**, plus **the stop question answered** per design §17.
+15. **Handoff**, folded here rather than written separately.
+
+Commit with the privacy email, push, and **watch nothing further** — wave 30 ships no code, so there is no
+release run to follow.
+
+---
+
+## THE CUT ORDER, decided before the clock is short
+
+1. **`M4`** — fenced out of every verdict branch by construction, so cutting it changes no verdict and no
+   register entry. −3 m compute, −3 m wall.
+2. **Step 7, the `K` column** — −12 m, and if cut it is **withdrawn**, not re-listed a fourth time.
+3. **The three retrospective self-test captures** in Step 6 — −6 m. `RULE W30-D` itself is **not** cut with
+   them; it is the step's substance.
+4. **Step 9's handoff document**, folded into the results file.
+
+**NOT cut at any budget:**
+
+- **the closing `V30`** (Step 8, ~2 m) — [F95](../docs/followups.md)'s remedy is both halves or neither;
+- **the `W30-FP` BEFORE sweep** (Step 2, ~3 m) — it cannot be recovered retroactively, and wave 29 paid the
+  full cost of learning that;
+- **`RULE W30-D`** — design §2.1 measured the ledger already rotting.
+
+**If the arm cannot run at all** (binary missing, provenance mismatch, seed tree absent), the wave does **not**
+substitute a different binary or rebuild one. It records `G-UNEVALUATED`, keeps `W30-D`, `V30` and the `K`
+column, and says in §12 exactly what the arm would have cost.
+
+---
+
+## STANDING CONSTRAINTS — every one of them earned
+
+- **Never push `develop`.** Feature branch, PR, and for wave 30 a **PR base that is the wave-29 branch**.
+- Author **and** committer email `322725+ghilios@users.noreply.github.com`.
+- Specs in `docs/`, plans in `plans/` — both already written.
+- **Pass scorers WSL paths.**
+- **`--out` mandatory**; **`--rule` asserted** against the file's own declared name.
+- Populations asserted; **ordinals and counts computed, never typed** — including the gate order, the axis step
+  and the material bar.
+- Paths through a **manifest**; BEFORE/AFTER from **one** expression called twice.
+- `cp` without `-p`; `touch` after every copy or restore.
+- `find … -print0 | sort -z | xargs -0` — `/mnt/d/Autofocus Bank` contains a space.
+- **One `TestApp.exe` at a time**; `< /dev/null` on every invocation; **no directory rebuilt mid-wave.**
+- **Read-only for the whole wave:** every root in design §6's table. Nothing wave 30 writes goes anywhere but
+  `/mnt/d/hf_w30/` and the repository.
+- **An unsatisfiable clause is a FINDING. Do not repair it.**


### PR DESCRIPTION
Wave 27 of the synthetic-AF-bank followup series. **PR #195 merged, so this branch is cut fresh off `develop @ e19a779`.**

## The wave's assigned item was already done, and the register contradicted itself

The charter's top backlog item was *"re-measure precision against `*.truth.json`, not `*.golden.json`"*. **It shipped on 2026-08-03** (`aaf26e8`) as `TestApp/SynthBank/TruthProtection.cs`, wired into **both** `GoldenEvalRunner` and `BankVerifyRunner` — and `followups.md`'s **F31** records it `Done` about 1,600 lines above the F84 entry that asked for it.

Wave 26's *"150 false positives, 137 real, 91.3 % reference omission"* counted a **pre-repair** quantity. Its 150 decompose as **50 excluded by the golden's own `unresolved` boxes + 89 truth-protected + 11 surviving**, and `golden eval` reported **`FP = 11`**. Confirmed independently: the wave's scorer run with `--protection off` moves D08's FP from 11 to 100, i.e. **+89**, matching the separately-derived count exactly.

So wave 27 **audits the correction instead of repeating it**.

## What it did

| half | result |
|---|---|
| **(A) ship** | `golden eval` carried **none** of `bank-verify`'s four truth disclosures. Ported via a shared `TruthDisclosure.cs`, plus `protectedDetections` (protection *exercised*), which `bank-verify` does not report and is the number a reader needs |
| **(B) `RULE T27`** | **`T-SOUND-WITH-NAMED-EXCEPTIONS`** — the precision column is honest on **18 of 19** blind datasets. `D18_m24_deep_shed` is `SATURATED-BY-NULL` (`precisionNull` 0.2820, `A_all` 0.2372) at 1,043 stars/Mpx. `D01` is the near-miss at 0.2182 |
| **(C) the record** | the results table's *"READ THE PRECISION COLUMN AS A LOWER BOUND"* banner **withdrawn** — the column is truth-corrected and `1.000` is a ceiling. 8 documents corrected in place, historical records annotated not rewritten |
| **(D) `RULE D27`** | **`D-MOVED`, 6 of 6.** Seven published rows were scored at detection binning 1 while `optimize` uses the derived 2. `D14_cdk14_2563mm_e47` `recall@all` **0.641 → 0.937** |

## Controls

- **`S27-4` do-no-harm, proved at byte level:** 360/360 detection artifacts byte-identical to the published run, TP/FP/FN unchanged on 20/20, and 20/20 report sinks changed (so the port is not inert).
- **`RULE R27` = `R-IDENTICAL`:** B15 regenerates the entire published population — 20 cells, 420 files, 0 differences.
- **`Q27-V1` = GATE DISCHARGED:** the B15→B16 change set does not intersect the `optimize` gate's reachable set; the FAIL end was **run** against the B14 tree and refuses.
- **`RULE V27` = `V-CLEAN`**, after closing a fourth gap in the F80 derivation checker that had **disabled** it (see below).
- Mutants `M-S1`/`M-S2a`/`M-S2b`/`M-S3` all shown red; `M-S3` re-verified independently by the controller.

## Suite

**3992** by COUNT (`Failed: 0, Passed: 3992, Total: 3992`, `SUITE_EXIT=0`), up from **3973**. The **+19** are the 19 tests in `TruthDisclosureTests.cs`.

## Instrument defects found and reported (not repaired with data in hand)

- **The F80 derivation checker had a fourth gap that had switched it off.** `in_historical_block()` treated the *definition line* of `HISTORICAL_BLOCKS` as opening a historical literal, so its `-B` clause was inert from that line to EOF. It reported `V-CLEAN` on its own file over **53** surviving previous-wave tokens while printing the **previous wave's rule name**. After the repair: 32 findings on itself, and 204 → **255** on the pinned prior-wave fixture. The class is new — *a rule that describes itself must exclude itself from its own population*.
- **`git diff --name-only <tree>` does not list untracked files**, so a two-binary provenance diff can silently omit an entire new source file.
- **A mutation harness restoring with `cp -p` restores the pre-mutation mtime**, so MSBuild skips the recompile and the next run silently re-measures the mutant.
- **`S27-1` names four fields; there are five** — `protectedDetections` is single-routed and ships unchecked by that clause. Stated, not repaired.
- **The `T27` verdict tree has a gap** (`SAT=3, CHANCE=3` disjoint matches no clause). Emitted as `T-TREE-GAP`; did not fire.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QTNWdSNar6g3Nj5wXnLZc6
