### PR TITLE
Wave 29: F82 IS a product defect (its own rule refuted the pre-registration), and the step-size truth is a fixed point of the recommender

### DIFF
--- a/docs/followups.md
+++ b/docs/followups.md
@@ -791,8 +791,32 @@ attributable to the one edited field.
 
 ### F94 — Verdict trees keep shipping with uncovered regions, and the standing rule against it did not stop the second one
 
-**Status:** **Open — a class, now on its second consecutive wave** (2026-08-13, wave 28) · generalises wave 27
-§8.1 · belongs beside [F68](#f68) part 5
+**Status:** **Open — a class, now on its THIRD consecutive wave, and wave 29 found the reason the fix does not
+work** (2026-08-13, waves 27–29) · generalises wave 27 §8.1 · belongs beside [F68](#f68) part 5
+
+> #### APPEND, wave 29 — the coverage PROOF is the thing that is wrong, not just the tree
+>
+> Wave 29 answered F94 by **enumerating every tree and printing `uncovered: 0`** on all five instruments. It
+> was not enough, and the failure is instructive.
+>
+> `RULE W29-L` printed `regions enumerated: 8   uncovered: 0` and then ran to the clause state
+> **`(L-0=True, L-1=None, L-2=None)`** — a triple its own enumeration **never visits**, because the
+> enumeration ranges over `{True, False}` and the clauses are three-valued: `L-1` and `L-2` are `None` when
+> `joint` is not positive, which is a could-not-look and not a `False`.
+>
+> **A tree proved total over `{True, False}` is not total over `{True, False, None}`**, and every rule in this
+> series that has a could-not-look state has three-valued clauses. So the remedy waves 28 and 29 adopted —
+> enumerate and assert `uncovered: 0` — **proves the wrong totality** and will keep printing a clean coverage
+> line beside an uncovered state.
+>
+> **The corrected remedy: enumerate over the clause's ACTUAL value domain, `None` included, and assert that
+> the verdict function is total over THAT product.** A cheap check that would have caught it: assert the run's
+> own observed clause tuple is a member of the enumerated set, which costs one line and cannot be satisfied by
+> a proof of the wrong thing.
+>
+> Wave 29's `w29l_score.txt` also shipped a **false explanatory sentence** on the same run — *"the control did
+> not hold"* when `L-0` **held** (8 fields, 0 disagreeing). The verdict `L-UNEVALUATED` is correct on the
+> numbers; only the prose was wrong. It is annotated in place on the artifact rather than edited out.
 
 Wave 27's `RULE T27` tree left `3 ≤ union ≤ 9` with neither set at 5 uncovered, and the scorer printed
 `T-TREE-GAP` rather than papering over it. Wave 28's design §12 turned that into a standing rule — *"every

--- a/docs/followups.md
+++ b/docs/followups.md
@@ -429,6 +429,293 @@ shape for this space.
 > three where the search **also** drove `StarClippingMultiplier` down, twice to the axis's own 0.25 floor.
 > Reproduce: `/mnt/d/hf_w26/q26_score.txt`; `docs/synthetic-af-bank-followups-wave26-results.md` §4.3, §7.
 
+### F96 — The harness's `stepBehavioral` "truth" is a fixed point of the recommender it scores, so every goal-2 conclusion is denominated in a bar the code under test produces
+
+**Status:** Open (diagnosed to a line; no fix priced) · found 2026-08-13, wave 29, `RULE W29-S` clause `S-a`
+= HOLDS · `/mnt/d/hf_w29/w29s_score.txt`
+
+`SynthValidateRunner.ComputeStepBehavioral` (`:1213–1270`) builds an analytic curve, fits it, calls
+`StepSizeRecommender.Recommend` at **`:1262`**, and loops until `rec.StepSize == step`. `RULE W29-S` asserts
+from source, at `HEAD`, by sha256, that the method is **declared once**, contains **exactly one** `Recommend(`
+call site inside its body (whole-file count 2, at `:792` and `:1262`, printed so the scoping is visibly doing
+work), and is the **only writer** over 70 harness files of the value serialized as `terminal.stepBehavioral`.
+
+**Consequence.** A change to `Recommend` moves the bar **and** the measurement together. This is the mechanism
+behind [F82](#f82)'s observation that `stepBehavioral` moved 8.0 → 9.0 across wave 25's two arms while it was
+identical on the other 17 cells: wave 25 changed `Recommend`. **Assertion `A3`, and every goal-2 statement in
+waves 20–29 that quotes `stepBehavioral` as truth, is a self-consistency check and not an accuracy measurement.**
+
+**What it does NOT say.** It does not say the recommender is wrong; a fixed point can be correct. It says the
+harness cannot tell. **The remedy is a spec-derived truth model** — backlog item 4's `A4` gap, priced at 20 m
+of code **+ 42 m of gate** because it rebuilds `TestApp`.
+
+**Note on scope.** Design §14 pre-registered F96 as a two-part entry — the truth-model coupling **and** "F82's
+fix has no product carrier" — to be **withdrawn in place** on `S-CARRIER-EXISTS`. The verdict was
+`S-CARRIER-EXISTS`, so **the carrier half is withdrawn and is not registered.** The coupling half is `S-a`,
+which held, and stands.
+
+---
+
+### F97 — F82's shrink-while-widening transition occurs on exactly ONE cell in the bank, and on ZERO of the fifteen that were blind
+
+**Status:** Open (measured; F82's fix choice unchanged) · found 2026-08-13, wave 29, `RULE W29-R` =
+**`R-STANDS`** · `/mnt/d/hf_w29/w29r_score.txt`
+
+Wave 26 pre-registered a reversal condition on its choice between F82's two fixes — *"if a later wave measures
+that `SearchSpan` … shrinks on more than a single cell while the requested sweep widens, then … (2) becomes
+correct."* **Three waves quoted it; none ran it.** Wave 29 ran it at zero compute over the 18 addressable
+paired S1 cells under `/mnt/d/hf_w25/after`, via the exact inversion
+`impliedSearchSpan = stepRecommendation.halfWidth / (1.5 × 0.5)`, with the multiple asserted `= 1.5` at **both**
+the B15 tree `29665a62e4f8` and `HEAD`, and with all 37 rounds confirmed capped-or-floored and none
+detect-bounded before any statistic was taken.
+
+```
+k = 18   c = 1   c_blind = 0   qualifying cells: ['D01_ultrawide_40mm']
+```
+
+**`c = 1`, and the one cell is `D01`, which was already burned.** `D05_tec140_1000mm` and
+`D19_cygnus_deep_shed` produced no report and **left the denominator** as named `CNL-NOREPORT`, never as zeros.
+
+**What this changes.** F82 is real and (per [F98's sibling finding in `RULE W29-S`](#f96)) reaches a real
+product path — but it is **rare, not general**: one cell in eighteen, zero in fifteen blind. On all 17 other
+cells the implied and requested spans move together on every transition. **Anyone pricing a fix should price it
+against 1 of 18, not against the 37-of-37 capped-or-floored population.** Wave 26's choice of fix (1) stands on
+wave 26's own grounds; the reversal condition is now **evaluated** rather than merely unexamined.
+
+**Blindness spent.** Producing this verdict required publishing the per-cell table for all 18 cells, so the 15
+formerly-blind cells' `halfWidth`/`bootstrap`/implied-span values are now read. See F100.
+
+---
+
+### F98 — `MaxDistortion` is a MINIMUM fill-ratio despite its name, and 0.9 is above the ~0.79 ceiling of a perfect disk, so a whole arm cell was dead before it ran
+
+**Status:** Open — **candidate goal-3 product finding** · found 2026-08-13, wave 29, `RULE W29-L` =
+**`L-UNEVALUATED`** · `/mnt/d/hf_w29/w29l_score.txt`, `/mnt/d/hf_w29/l/out/L{0,2,4}.log`
+
+`StarDetector.cs:1804` rejects a candidate as `TooDistorted` when `fillRatio < effectiveMaxDistortion`. The
+parameter is a **lower bound on bounding-box fill ratio**; **raising it tightens the gate.** The file's own
+comment at `:1786` states the ceiling: *"a perfect disk fills ~PI/4 ≈ 0.79."* With `DefocusAwareGates: false`
+in `D01`'s landed tree, `ComputeEffectiveMaxDistortion` returns `p.MaxDistortion` verbatim.
+
+Wave 29's design §6 pre-registered `MaxDistortion` **0.5 → 0.9** under the heading *"one knob relaxed per
+cell"*. Measured result on `D01`, 9 frames: **`TP=0 FP=0 FN=110384`, `recall@high = 0.000 (0/62 411)`** on
+both `L2` and `L4` — total detection collapse. Corroborated by wall clock: `L2` (152 s) and `L4` (145 s) were
+the two **fastest** cells in a five-cell arm, because nothing survived the gate to do downstream work.
+
+**Two findings, and they are separable.**
+
+1. **The instrument finding.** A pre-registration can specify a knob edit whose *direction* no clause reads.
+   The arm's self-test proved the edit was **surgical** (`33 of 33`, *"exactly 1 file changed"*, *"an unnamed
+   field is UNCHANGED"*) — surgical is not correctly signed. `RULE W29-L`'s verdict is
+   **`L-UNEVALUATED`** and it stands; the cell was not re-run at a corrected value and scored.
+2. **The product finding.** `OptimizerVariable.cs:176` declares the searchable axis
+   `Continuous(nameof(StarDetectorParams.MaxDistortion), 0.1, 1.0, 0.1)`. **The upper ~21 % of that axis
+   (> π/4 ≈ 0.785) is provably detection-killing for round stars** — any value above the perfect-disk fill
+   ratio rejects every candidate. A searchable range whose top fifth returns zero detections is a parameter
+   space that wastes optimizer evaluations, and the name `MaxDistortion` reads as the opposite of what it
+   gates. **Worth ~20 m to bound the axis at π/4 and rename or document the field; owes the 42 m gate because
+   it touches plugin code.**
+
+---
+
+### F99 — Relaxing the bounding-box floor on `D01` releases 9 537 candidates and three survive: the binding gates are downstream, and the pre-registered statistic could not see it
+
+**Status:** Open — the hypothesis wave 30 should pre-register · found 2026-08-13, wave 29 ·
+`/mnt/d/hf_w29/l/out/L{0,1}/attempt01/golden_eval.txt`
+
+`RULE W29-L`'s pre-registered statistic is the difference in `FN_total`. On `D01`, lowering
+`MinStarBoundingBoxSize` 6 → 3 gives `FN_total` 50 249 → 50 246, i.e. **−3**, which reads as "this gate does
+almost nothing". The per-gate blocks in the same artifact say otherwise:
+
+| gate | `L0` | `L1` (MinBox 6→3) | Δ |
+|---|---|---|---|
+| `REJECTED:TooSmall` | 11 372 | 1 835 | **−9 537** |
+| `REJECTED:TooDistorted` | 14 876 | 20 573 | **+5 697** |
+| `REJECTED:LowSensitivity` | 13 612 | 17 426 | **+3 814** |
+| others | | | +23 |
+
+**9 537 high-tier candidates were released from the bounding-box floor and 99.97 % of them were immediately
+re-caught by `TooDistorted` and `LowSensitivity`. Three reached acceptance.** The gate is not inert; its entire
+yield is absorbed one and two gates downstream.
+
+**The lesson is about the statistic, not the detector.** A first-rejection-wins attribution differenced only at
+the *total* cannot distinguish a gate that never fires from a gate whose output is fully captured downstream.
+**Wave 30's rule over sequential gates must read the per-gate flow, not the net.** And the substantive
+hypothesis this generates, stated so it can be wrong: **`D01`'s binding constraint is `TooDistorted`, jointly
+with `LowSensitivity`, and no single-knob change recovers it** — which is `L-JOINTLY-BOUND`'s claim arrived at
+by a different route than the rule that could not evaluate it.
+
+---
+
+### F100 — A blindness ledger that promises a quantity will stay unread, beside an instrument that must read it, burns the population at pre-registration time
+
+**Status:** Recorded (the burn is spent; the structural fix is cheap) · found 2026-08-13, wave 29 ·
+design §7 vs `/mnt/d/hf_w29/w29r_score.txt`
+
+Wave 29's design §7 wrote: *"the requested-vs-implied comparison has **never** been computed on any other
+cell"*, and named the 15 non-burned cells as **BLIND, and carrying `W29-R`'s verdict**. The same document's
+§5.3 pre-registered a scorer that computes exactly that comparison over all 18 addressable cells and prints
+`c` and `c_blind`. **`w29r_score.txt` publishes the full 18-row table.** The ledger's claim is now false, and
+the instrument that falsified it was commissioned by the document that made the claim.
+
+**The rule was not tuned** — `W29-R` is implemented exactly as §5.3 writes it, and its verdict was taken on the
+first computation of the statistic, which is what blindness protects. **But it is the last verdict on this
+population that can claim blindness.** Any future rule over `SearchSpan` persistence on `/mnt/d/hf_w25/after`
+has no blind cells left.
+
+**Fix, ~5 m per wave:** the design's blindness ledger must be checked against the design's own instrument
+specifications before the pre-registration commit — every quantity the ledger promises stays unread must not
+appear in any clause's per-member output. Nothing does this today.
+
+---
+
+### F101 — The derivation checker's `historical_ranges` has now failed THREE generations, each time with a passing self-test
+
+**Status:** Repaired in wave 29's checker; the pattern is the entry · found 2026-08-13, wave 29 ·
+`/mnt/d/hf_w28/verify_derivation_w28.py:579`, `/mnt/d/hf_w29/verify_derivation_w29.py:224–238`
+
+[F87](followups.md) recorded this function eating its own file; wave 27 repaired it; wave 28's design required
+the repair be carried forward and demonstrated, and wave 28's self-test clause `[6]` did demonstrate both ends
+it knew about. **It was still broken.** Wave 28 counted brackets on the **raw** line, so an unbalanced `[` or
+`{` inside a **string literal** opened a phantom block that ran to EOF. Measured on wave 28's own 599-line
+file:
+
+```
+ranges computed by WAVE 28's own function: [(93, 120), (557, 565), (579, 598)]
+  range 579 -> 598   opener: defonly = ['HISTORICAL_BLOCKS = ("PRIOR_BUILD_IDS", "ALLOW = [")',  ...
+   *** RUNS TO EOF ***
+```
+
+**29 of 599 lines of wave 28's own checker, including its tail, were exempt from `V28-B` and `V28-C` for the
+whole of wave 28.** It concealed nothing — every token in the exempt span is wave 28's own wave id — and that
+is luck, not design. Wave 29 blanks string literals length-preservingly before counting and asserts all four
+ends in clause `[6]`, including *"a token INSIDE the declared historical literal is NOT reported"*.
+
+**The durable finding is the pattern:** three generations, three passing self-tests, because each generation's
+self-test tested the ends the previous generation broke. **A self-test that only covers the last bug found is a
+regression test, not a specification.**
+
+---
+
+### F102 — `V28-C` returned zero because its population was almost empty: 124 of 126 printing lines in wave 28's scorers were never scanned
+
+**Status:** Repaired in wave 29's checker; the vacuity class is the entry · found 2026-08-13, wave 29 ·
+`/mnt/d/hf_w28/verify_derivation_w28.py:170`, `/mnt/d/hf_w29/verify_derivation_w29.py:160`
+
+`V*-C` forbids typed ordinals and counts in an instrument's printed output. Wave 28's line-selector was
+`\b(print|log|echo|printf|Prog|tee)\b`; wave 28's three scorers emit through `out.write(`, which matches none
+of it. Measured over `score_w28b.py` (36), `score_w28n.py` (52), `score_w28s.py` (38):
+
+```
+out.write( lines total : 126
+matched by w28 PRINTS  : 2      (incidentally -- the string being WRITTEN contained a keyword)
+matched by w29 PRINTS  : 126
+```
+
+**Wave 28's `V28-C: 0` was vacuous.** Wave 29 widened the selector to
+`\b(?:\w*[._])?(?:printf|print|echo|log|write|emit|say|tee|Prog)\b` and **demonstrated** the widening rather
+than asserting it — self-test `[3]` carries *"V29-C via `out.write` fired on its own mutant"* and *"V29-C via
+an underscored helper fired on its own mutant"*.
+
+**The class, which is the same as F101's and should be read with it:** a clause can pass for three waves
+because it has no candidates, and **no verdict tree in this series distinguishes "zero findings" from "zero
+candidates".** [F94](followups.md) made trees total over their *outcomes*; nothing makes a clause report its
+*population*. **~10 m to make every clause print `candidates: N   findings: M` and refuse on `N = 0` where a
+population is expected.**
+
+---
+
+### F103 — A pinned per-clause fixture goes silent exactly one wave later, as predicted in an instrument's own header and confirmed by measurement
+
+**Status:** Closed as a mechanism; standing obligation to re-measure each wave · found 2026-08-13, wave 29 ·
+`/mnt/d/hf_w29/vdrift_selftest_w29.txt` `[5b]`, `vdrift_probe_hf_w2{4,6,7,8}.txt`
+
+Wave 28 pinned `/mnt/d/hf_w27` as its live `V28-B` fixture and wrote into its own instrument's header that such
+a pin expires one wave later, because `PREV` advances and last wave's tokens stop being "previous-wave". Wave
+29 measured all four candidate roots before pinning anything:
+
+| root | `-A` resolving | `-B` findings | `-C` findings | role |
+|---|---|---|---|---|
+| `hf_w24` | 1 of 1 | 0 | **2** | durable `-C` fixture, third wave running |
+| `hf_w26` | 2 of 6 | **0** | 1 | expired at wave 28; kept and **asserted silent** |
+| `hf_w27` | 1 of 5 | **0** | 1 | **EXPIRED as predicted** — wave 28's live `-B` |
+| `hf_w28` | 0 of 5 | **100** | 1 | the new live `-B` |
+
+**This is the strongest evidence class this series has produced**, and the reason is structural: it is a
+**falsifiable forward claim about the instruments, written before the measurement, with a stated mechanism, and
+checked one wave later.** Everything else in the series is a rule scored against artifacts that already
+existed. **`hf_w28` is next to expire; wave 30 must re-measure and must treat a clause with no live fixture as
+a FAIL, not a pass.**
+
+---
+
+### AMENDMENTS TO EXISTING ENTRIES
+
+**[F82](followups.md) — AMEND IN PLACE. Its fix choice stands; its scope, its generality and its truth
+model are now measured.** Append:
+
+> **Amended 2026-08-13, wave 29.** Three things about this entry were unmeasured when it was written.
+>
+> 1. **The "truth of 9" is a PRODUCT-DERIVED FIXED POINT, not a spec-derived truth.** `terminal.stepBehavioral`
+>    is `StepSizeRecommender.Recommend` iterated to a fixed point by
+>    `SynthValidateRunner.ComputeStepBehavioral:1262` — see **F96**. `D01`'s stall is measured against a bar the
+>    recommender itself produces, and wave 25 moved both together.
+> 2. **"Confined to the recommender's caller state" names a caller, and it is
+>    `StarDetectionOptimizerWizardVM.CaptureNewSweepAsync` (`:5012`).** `RULE W29-S` clause `S-b` returned
+>    **FALSE**: of `BuildSummaryAsync`'s five callers, `CaptureNewSweepAsync` takes a **fresh sweep**
+>    (`RunLiveAttemptAsync`, `:5071`), calls `BuildSummaryAsync` at `:5098`, and carries the previous round's
+>    recommended geometry forward through the instance field `recaptureStepSize` (`:2608`, assigned `:5037`,
+>    consumed `:3236`). **F82 is a real product defect on a real product path**, and the wave-29
+>    pre-registration's claim that it "reaches no user" and "scores goal 2 zero" is **withdrawn**.
+> 3. **Its generality is one cell in eighteen.** `RULE W29-R` = `R-STANDS`: `k = 18`, `c = 1`, `c_blind = 0`.
+>    The only qualifying cell is `D01` itself. See **F97**. Wave 26's choice of fix (1) stands, on wave 26's
+>    own grounds, with the escape clause now **evaluated** rather than unexamined.
+> 4. **A third candidate fix is registered and deliberately NOT chosen** (wave 29 design §4.4): bound
+>    `maxHalfWidth` below by the span the sweep actually **requested**, guarded by
+>    `BandDemonstrablyUnsampled(sampledHfrRange)`. `RULE W29-S` clause `S-c` **HOLDS** — the requested positions
+>    are in `SweepDetectability.FrameFocuserPositions`, reachable inside `Recommend` via
+>    `MeasureMaxUsefulHalfSpan`. It needs **no cross-round state and no `A3` re-derivation**, which makes it the
+>    cheapest of the three (~45 m + a 3-cell re-run + the 42 m gate) and is precisely why the wave that thought
+>    of it did not select it. **The next wave pre-registers the choice among three.**
+
+**[F81](followups.md)** — append: the floor F81 shipped **is** reached in the product on a re-swept round, not
+only at round 0 of a session. `CaptureNewSweepAsync` (`:5012`) re-captures and carries `recaptureStepSize`
+forward, so the wizard's `Capture new sweep` path has genuine cross-round sweep state. The `Continue` and
+`Re-optimize` paths do not — they call `LoadRunStampedAsync` and re-optimize already-captured frames — so on
+those two the floor is inert after round 0, and that half of the original claim stands.
+
+**[F94](followups.md)** — append: wave 29's design §10 is the first in the series to publish its own outcome
+space as a table, and **every scorer re-derived it in code and agreed with the published counts**: `W29-S`
+**8 / 0 uncovered**, `W29-R` **4 / 0**, `W29-L` **8 / 0** — matching design §10's three tables exactly — and
+`V29`, which §10 declared as inheriting wave 28's tree without a count, re-derived **12 / 0** including the
+`A=None` empty-population region. The two logically-unreachable regions (`R-INCOHERENT`, `L-INCOHERENT`) are
+present, asserted empty, and checked against the measured numbers (`c = 1 ≤ k = 18 is True`; `L-1 ∧ L-2 =
+False`). **The remedy works for outcome coverage.** It does **not** cover two adjacent failures found this wave: a clause whose *population* is
+empty (**F102**) and a clause whose realized value is **neither `True` nor `False`** — `W29-L` ended at
+`L-0 = True, L-1 = None, L-2 = None`, a state outside the enumerated boolean cube, yet the scorer still printed
+`uncovered: 0` and appended a canned `READING:` line saying *"the control did not hold"* **when `L-0` in fact
+HELD**. The tree was total over booleans and the run was not a boolean. **Trees must enumerate `None` as a
+clause value, and a verdict's explanatory text must be derived from the clause values rather than templated per
+verdict name.**
+
+**[F95](followups.md)** — append: **the remedy's first half works and was proved this wave.** Wave 29's plan
+ordered instruments (Step 1) before the blocking pre-flight (Step 2); the last instrument was written at
+`17:01:28Z`, the pre-flight ran at `17:35:55Z` over a **populated root of 7 files**, and returned `V-CLEAN`
+with `SELFTEST V29 27 of 27`. Wave 28's equivalent certified **one file**. **The second half did not run** —
+the closing `V29` (`vdrift_w29_FINAL.txt`) has no artifact, against design §11's *"NOT cut, at any budget."*
+Both halves are needed and the series has now demonstrated one of them.
+
+**[F21](followups.md)** — append wave 29's per-step estimate vs actual (§10). Steps 1, 2, 4, 5 and 6 all landed
+**under**; the only two that overran were the two priced from instinct rather than from a measured rate
+(fingerprint sweeps, §10). Measured constant for future waves: **the six declared read-only roots are ~41.8 GB
+/ 2 452 files and hash at ~61 MB/s, i.e. ~12 m per sweep, ~24 m for a two-sided fingerprint.**
+
+**`docs/synthetic-af-bank-results-table.md`** — still owed from wave 28: the `K` column from `truthModel`
+(`max(hfrMin, hfrMinEffective)`), the note that `D01`/`D02`/`D03` are the only three floored by the generator,
+and **no 2–4 px band claim below the band** (`W28-B` = `B-SPLIT`). **Not paid this wave.** ~10 m.
+
+---
+
 ### F92 — The post-wavelet blur is WELDED to `StructureLayers`, so one knob sets two opposing scale cutoffs
 
 **Status:** **Open — source-derived, zero compute, and it re-opens [F43](#f43)** (2026-08-13, wave 28,
@@ -1479,7 +1766,38 @@ Reproduce: `StepSizeRecommender.cs` (the `BandDemonstrablyUnsampled` guard, the 
 
 ### F82 — The half-width floor is not sticky across rounds, and the cap recomputed from a shrunken fit pulls it back down
 **Status:** Open (diagnosed to a line, two candidate fixes, priced) · found 2026-08-13, wave 25, on the one
-labelled control that missed its pre-registered bar
+labelled control that missed its pre-registered bar · **SCOPE AND GENERALITY MEASURED, wave 29 — see below**
+
+> #### AMENDMENT, wave 29, 2026-08-13 — the fix choice stands; the scope and the generality are now measured
+>
+> **1. It IS a product defect, on a real product path.** Wave 29's own pre-registration argued the opposite —
+> that no caller had anywhere to put a cross-round half-width, so the fix would reach no user — and **its own
+> rule refuted it**: `RULE W29-S` = **`S-CARRIER-EXISTS`**. The design's caller table named two of
+> `BuildSummaryAsync`'s **five** callers; **`CaptureNewSweepAsync`** (`StarDetectionOptimizerWizardVM.cs:5012`)
+> takes a **fresh sweep** via `RunLiveAttemptAsync`, calls `BuildSummaryAsync` at `:5098`, and carries the
+> previous round's recommended geometry forward in `recaptureStepSize`. So `SearchSpan` **can** change between
+> wizard rounds and the defect **can** occur there.
+>
+> **2. But it is far rarer than this entry implies.** `RULE W29-R` ran wave 26's own reversal condition, which
+> three waves had quoted and none had executed: over **18 addressable paired S1 cells**, the
+> shrink-while-widening transition occurs on **`c = 1`** — and that one cell is `D01`, which is burned.
+> **`c_blind = 0` over the fifteen cells that were blind.** See [F97](#f97).
+>
+> **3. The reversal condition is NOT met, so fix (1) stands — now on evidence rather than on caution.**
+> Wave 29 deliberately did **not** flip the choice, and did not choose the third candidate it registered:
+> choosing a fix in the same wave that discovers a new reason to prefer it is the [F14](#f14) / `RULE D20`
+> fence in a new costume.
+>
+> **4. The bar this entry is scored against is produced by the code under test** — `SynthValidateRunner
+> .ComputeStepBehavioral:1262` iterates `StepSizeRecommender.Recommend` to a fixed point. That is
+> [F96](#f96), and it is why `stepBehavioral` moved 8.0 → 9.0 across wave 25's two arms while staying
+> identical on the other seventeen cells: wave 25 changed `Recommend`, so it moved the bar as well as the
+> measurement. **Any future scoring of this entry must say which side of that loop it is standing on.**
+>
+> **5. The price in the handoff (~45 m) is for the HARNESS change.** The product carrier needs new persisted
+> session state surviving between wizard sessions, with the `Continue`/`Re-optimize` paths excluded where it is
+> inert, plus migration and the question of whether it is an option (and therefore owes a control in
+> `Resources/OptionsDataTemplates.xaml`). That is a ~2–4 h band and nobody has priced it.
 
 [F81](#f81--maxhalfwidthsampledhalfspanmultiple-has-been-a-ceiling-with-no-floor-and-the-half-width-unresolved-exit-returned-before-the-ceiling-was-consulted-at-all)'s
 floor engaged on **all three** published stall cells at round 0 and handed off to the cap at round 1 exactly as

--- a/docs/synthetic-af-bank-followups-wave29-design.md
+++ b/docs/synthetic-af-bank-followups-wave29-design.md
@@ -1,0 +1,645 @@
+# Wave 29 — backlog item 1 ([F82](followups.md)): the step-size floor, and what source says about its fix
+
+**Pre-registration. Written before any wave-29 statistic is computed.** §2 records where the controller's
+framing is wrong; there are six such places and **three of them change what the wave does**. One of them
+removes the wave's ship.
+
+---
+
+## 0. THE VESSEL — decided in writing, before any measurement
+
+**Wave 29 opens a fresh branch off `ghilios/synthetic-af-bank-followups-wave27`, named
+`ghilios/synthetic-af-bank-followups-wave29`, and opens its own PR. PR #196 is left to be reviewed and merged
+as what it is.**
+
+- PR #195 (`…wave23`, waves 23–26) is **MERGED**.
+- PR #196 (`…wave27`) is **OPEN / MERGEABLE** at `6ffa498`, and already carries **two** waves (27 and 28) plus a
+  user-visible product change, under a title naming only wave 27's truth-protection audit.
+
+**Reason.** Wave 28's design §0 pre-registered exactly this and the wave did the opposite; wave 28 §13 recorded
+it as a deviation and named the cost — *"#196 now carries two waves and a user-visible product change under a
+title about wave 27's truth-protection audit."* Repeating it would make #196 carry three. The charter's §1a
+warning against silent accretion has now been ignored once with the cost measured; **a third section is the
+accretion, not a step toward it.**
+
+**Wave 29 changes no C# and builds no binary** (§9), so nothing about this choice is load-bearing for a
+verdict. It is load-bearing for whether the previous wave's declared deviation gets repeated.
+
+---
+
+## 1. THE HEADLINE: the pre-registered fix has no carrier in the product, and the "truth" it is scored against is produced by the code under test
+
+Two facts, both decidable from source at zero compute, both verified in this document against shipping files:
+
+**(a) `terminal.stepBehavioral` — the number [F82](followups.md) calls "a truth of 9" — is
+`StepSizeRecommender.Recommend` iterated to a fixed point.** `SynthValidateRunner.ComputeStepBehavioral`
+(`:1213-1270`) builds an analytic curve, fits it, and calls `StepSizeRecommender.Recommend` at **`:1262`**,
+looping until `rec.StepSize == step`. Its own XML doc says so in the file: *"the fixed point A3 compares
+against is produced by the same rule as the landing it scores."* **The harness scores the recommender against
+a fixed point of the recommender.** That is why F82 observed `stepBehavioral` moving 8.0 → 9.0 across wave
+25's two arms while it was identical on the other 17 cells: wave 25 changed `Recommend`, so it changed the
+bar as well as the measurement. F82 recorded the symptom and called it *"an assumption this series can no
+longer make for free"*; **the cause is one line and nobody has looked at it.**
+
+**(b) No caller in the product has anywhere to put a previous round's floored half-width.** The pre-registered
+fix (wave 26 design §14) is *(1) the monotone floor — carry the previous round's floored half-width forward as
+a lower bound on the next round's `maxHalfWidth`*, chosen partly because it is *"confined to the caller's round
+state, which is where a cross-round property belongs."* The callers, enumerated:
+
+| caller | file:line | has cross-round sweep state? |
+|---|---|---|
+| `StarDetectionOptimizerWizardVM.BuildSummaryAsync` | `:4117` | **No.** `Continue` (`:4850`) and `Re-optimize` (`:4740`) both call `LoadRunStampedAsync(folder, …)` and re-optimize **the frames already captured**. No new sweep is taken between wizard rounds, so `SearchSpan` cannot change between them and the defect cannot occur there at all |
+| `OptimizationDiagnosticRunner` (`optimize`) ×4 | `:1102`, `:1134`, `:1262`, `:1702` | **No.** Single-pass, all four strictly after `OptimizeAsync` returns at `:916` |
+| `TiltCalibrationRunner` | `:479` | **No.** Single-pass |
+| `SynthValidateRunner.RunRoundAsync` | `:792` | **YES** — `ScenarioRunState` (`:360-371`), and it is a **test harness** |
+| `SynthValidateRunner.ComputeStepBehavioral` | `:1262` | the truth model, per (a) |
+
+And nothing persists a half-width across sessions: `OptimizedStarDetectionSettings` carries
+`RecommendedStepSize` (`:69`) and no half-width; `OptimizationSummary` carries `RecommendedStepSize`,
+`StepSizeWasCapped`, `StepSizeWasBandFloored`, `StepSizeSampledHfrRange`, `StepSizeCappedGrowthRatio`,
+`StepSizeDegenerateReason` — **and no `HalfWidth` at all.**
+
+**So the real product's "next round" is the next SESSION**, and the only carrier for a monotone floor across
+sessions would be new persisted state. **Fix (1), implemented as pre-registered, is a change to
+`SynthValidateRunner.ScenarioRunState` and reaches no user.**
+
+**What this does and does not do to wave 26's pre-registered choice.** It impeaches reason (iii) —
+*"confined to the caller's round state"* — because the caller with round state is the harness. It leaves
+reason (i) — blast radius — standing and **quantified for the first time**: §5.1 measures that **37 of 37
+rounds across 18 paired cells are capped-or-floored**, so fix (2) moves every round of every cell in the
+population, not merely "every capped round". And fact (a) supplies a **fourth reason wave 26 never had**:
+fix (2) changes `SearchSpan`, which `ComputeStepBehavioral` also consumes, so **fix (2) moves the truth model
+as well as the landing**, while fix (1) — a new parameter defaulting to `NaN` — does not.
+
+**Two of wave 26's three reasons for (1) are impeached; the third is confirmed and a fourth is added. That is
+not a licence to flip, and wave 29 does not flip it.** What it is, is a demonstration that the choice was made
+without knowing where the state would live — and that is a finding, registered rather than repaired.
+
+### 1.1 The sentence this wave is not allowed to write
+
+**Wave 29 does not ship a fix to F82 and does not decide between (1) and (2) on new grounds.** It executes
+what wave 26 already pre-registered and nobody has run — the **reversal condition** (§5) — publishes the
+source rule above as a rule (§4), and hands the item forward re-priced with a third candidate registered but
+**not chosen** (§4.4). Choosing a fix in the same wave that discovers a new reason to prefer it is the
+[F14](followups.md) / `RULE D20` fence in a new costume.
+
+---
+
+## 2. WHERE THE CONTROLLER'S FRAMING IS WRONG
+
+### 2.1 "F82 … scores goal 2 ✓✓✓" — **not as pre-registered, it scores goal 2 ZERO**
+
+Goal 2 is *accuracy of step-size recommendations* — the recommendation a **user** receives. Fix (1) lands in
+`SynthValidateRunner`, which no user runs. Worse: shipping it there alone would make the harness model a
+product that does not have the fix, so `synth-validate` would stop reproducing the product's own stall.
+**A harness that diverges from the product in the direction of the product being better is not an
+improvement, it is a broken instrument.** Wave 28 §12 scored this item `2 ✓✓✓`; on the code as it stands the
+honest score is **0 until a product carrier is chosen and priced**, and choosing one is a design question, not
+an execution question.
+
+### 2.2 "Priced in the handoff at ~45 m code + tests, ~10 m 3-cell re-run" — **the price is for the wrong thing**
+
+45 m is the price of the harness change. The product change is a new persisted value on the optimizer's
+recommendation, surviving between wizard sessions, with the `Continue`/`Re-optimize` paths (where it is inert)
+explicitly excluded, plus the migration and — per `CLAUDE.md` — the question of whether it is an *option* and
+therefore owes a control in `Resources/OptionsDataTemplates.xaml`. **That is not 45 m and nobody has
+priced it.** §11 prices it as a band and says it is a band.
+
+### 2.3 "F82's fix touches `StepSizeRecommender`, which IS plugin code, so the intersection is probably non-empty and the gate probably IS owed" — **not "probably". CERTAINLY, and it is already on disk by name**
+
+`Q27-V1`'s FAIL end was not a hypothetical. It was **run**, against the B14 tree, and
+`/mnt/d/hf_w27/q27_v1.txt` records the two files that made the intersection non-empty:
+
+```
+intersection is NON-EMPTY (2 files), e.g.:
+Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/StarDetectionOptimizerWizardVM.cs
+Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/StepSizeRecommender.cs
+>>> FAIL END DEMONSTRATED: the same predicate REFUSES on a diff that reaches the gate.
+```
+
+**Wave 27 used F82's own two files as its canonical example of a diff that reaches the gate.** The reachable
+set is the literal ERE `^Joko\.NINA\.Plugins/Joko\.NINA\.Plugins\.HocusFocus/|^Joko\.NINA\.Plugins/TestApp/(OptimizationDiagnosticRunner|HarnessSettingsStore|OptimizationRunDiscovery|ParamsDump|StubBehaviorSelectors|DiagnosticUtil|Program)\.cs$`
+— a **directory prefix over the whole plugin assembly**, not a call graph. `StepSizeRecommender.cs` sits under
+it. **Any wave that ships F82 in the product owes the full 42 m gate, and there is no argument left to have.**
+
+**And the argument a later wave will be tempted to make must be refused in advance.** `StepSizeRecommender` is
+genuinely *not* reachable from `optimize`'s objective — the evaluator handed to `OptimizeAsync` is built by
+`RunEvaluationData.CreateEvaluator` (`:929-953`), whose body is `results.Add(await run.EvaluateAsync(p,
+token))`, and every one of the seven `Recommend` call sites is strictly downstream of `OptimizeAsync`
+returning. Wave 25 *measured* this: it shipped a change to `StepSizeRecommender.cs` and the gate returned
+`FinalJ` bit-identical to K8, **8 of 8 at sixteen digits**. **None of that licenses narrowing a pre-registered
+reachable set after seeing which files your own change touches.** It licenses one thing only: the gate becomes
+**a rule with a predicted answer** — predict `G-PASS`, 8 of 8 bit-identical, on wave 25's measurement — which
+the charter calls a virtue (`RULE R24`) because it is the only kind of rule that can be wrong.
+
+### 2.4 "Item 2 … needs no product change and reuses wave 28's arm shape … say whether it can reach a verdict at all, or whether it can only rank" — **it can reach a verdict, if it runs one more cell than the controller specified**
+
+Opening one gate at a time and differencing gives, per gate, the number of stars that gate **exclusively**
+blocked — the ones that pass every other gate. It does not decompose the multiply-blocked set, so a
+one-at-a-time design **ranks and lower-bounds, and cannot attribute.** Adding a single cell with **all three
+gates opened together** measures the total recoverable set, and then
+
+> joint (multiply-blocked) share = total − Σ(exclusive shares)
+
+**exactly.** Four intervention cells plus a baseline turn a ranking into a decomposition. §6 pre-registers it
+that way, with the prediction that the singles will sum to well under the joint total — because a 0.7 px blob
+on a 19.4″/px rig is simultaneously too small, too distorted and low-signal, and the gates are not
+independent.
+
+### 2.5 "[F22](followups.md) bounds the payoff … weigh whether recall is even the right objective there" — **agreed, and it is why item 2 is re-framed rather than dropped**
+
+The controller is right and the consequence is larger than the controller drew. `D01` reaches `BestJ`
+0.994825 from a `BaselineJ` of 0.000000; below ~1.1 px the measured HFR over-reads by up to **+234 %**; its
+0.231 px optical vertex measures 0.77 px. **Recovering `D01`'s recall cannot be justified as a focus
+improvement and wave 29 does not justify it that way.** What survives F22 untouched is the **goal-3** question:
+`MinimumStarBoundingBoxSize` landed at **6** on the rigs with the smallest stars, against a shipped default of
+**5** (`IStarDetector.cs:435`) and a `WideField` preset that *lowers* it. That is a parameter pinned against
+the physics, and *"avoiding parameters pinned to extreme values"* is goal 3 verbatim. **Item 2 runs as an
+attribution of which gate binds — a goal-3 question — and its results section is forbidden from quoting a
+recall gain as a benefit.**
+
+### 2.6 "Two waves running, the verdict tree shipped with uncovered regions ([F94](followups.md))" — **agreed, and a sentence is again not the remedy**
+
+Wave 28's design §12 wrote the standing rule and wave 28 shipped a tree with 4 of 135 regions uncovered.
+Writing the sentence a third time will not work either. §10 of this document **enumerates every region of
+every tree in a table, in this document**, and every scorer re-derives that enumeration in code and prints
+`regions enumerated: N  uncovered: 0`. **Where a region is logically unreachable, it is named, asserted empty,
+and given a refusal verdict** — the failure mode F94 describes is a region silently absent, and a region that
+is present-and-impossible is a different, checkable thing.
+
+---
+
+## 3. THE ITEM, AND WHY THE OTHERS LOSE
+
+**Chosen: item 1 ([F82](followups.md)), re-scoped from "ship the fix" to "execute the pre-registration nobody
+ran, and publish what source says about the choice" — plus item 2 as a co-equal second half.**
+
+| candidate | verdict | why |
+|---|---|---|
+| **1 — F82** | **TAKEN, re-scoped** | Its pre-registered **reversal condition has never been evaluated** and can be evaluated at zero compute on 15 blind cells. Writing the code before checking the escape clause is executing a pre-registration with its own reversal ignored. And §1 says the fix as written does not reach a user, which the wave must publish before anyone spends 45 m on it |
+| **2 — localise `D01`'s residual loss** | **TAKEN**, re-framed to goal 3 | Cheap (no build, one binary already on disk, ~25 m), finishes wave 28's named biggest open question, and with a fifth cell it **attributes** rather than ranks. Re-framed per §2.5: the deliverable is which gate binds, not a recall gain |
+| **3 — re-register the band's lower edge** | **REJECTED** | It produces a *rule*, not a *finding*. `B-SPLIT` already delivered the substantive answer — the lower edge is not where the design drew it, `Δacc > 0` on all 17. Re-scoring buys a boundary number on a synthetic-only population with **no real under-sampled dataset** ([F35](followups.md), [F43](followups.md)). It is worth ~10 m as a note on `docs/synthetic-af-bank-results-table.md`, and that note is owed anyway (wave 28 §9.5). It is not worth a rule |
+| **4 — a `NoiseClippingMultiplier` default change** | **REJECTED for wave 29** | [F93](followups.md) says plainly it is not licensed by `N-RECOVERS`; it is explicitly behind item 2; it owes a fresh **~1.7 h** `optimize` baseline because the optimizer *chose* the landed values; and its measured payoff on `D01` is **+0.012**, which is exactly the number item 2 exists to explain. Running it before item 2 is proposing a default change on the strength of a dataset where the change does almost nothing |
+
+**Is there nothing here worth a wave?** That answer was seriously considered and is rejected, but narrowly.
+The wave produces: a source rule that changes what F82 is (§4), the execution of a two-wave-old
+pre-registration on a blind population of 15 (§5), and a decomposition that closes wave 28's largest open
+question (§6). **Three register entries, no product risk, ~25 minutes of compute.** What it does *not*
+produce is a ship, and the honest reading of §1 is that **a wave that shipped fix (1) this afternoon would
+have shipped it into a test harness and scored it against a bar computed by the code it changed.**
+
+---
+
+## 4. `RULE W29-S` — the carrier and the truth model, decided from source. Zero compute
+
+**Population:** four source files at `HEAD`, each recorded by **sha256** in the scorer's output:
+`TestApp/SynthValidateRunner.cs`, `HocusFocus/StarDetection/Optimization/StepSizeRecommender.cs`,
+`HocusFocus/StarDetection/Optimization/StarDetectionOptimizerWizardVM.cs`,
+`HocusFocus/StarDetection/Optimization/OptimizedStarDetectionSettings.cs`.
+**Wave 28 §7.5's lesson applied in advance:** design §4 of that wave named one artifact where its clause
+needed two, and the scorer had to say so. Here the population is named as four and the scorer **refuses** if
+any is absent.
+
+| clause | statement | refusal condition |
+|---|---|---|
+| **`S-a`** *(validity, and it is IN the tree)* | `ComputeStepBehavioral`'s body contains **exactly one** `StepSizeRecommender.Recommend(` call site, **and** `ComputeStepBehavioral` is the **only** writer of the value serialized as `terminal.stepBehavioral` | any count ≠ 1; more than one writer; the method cannot be located by **declaration** (not first textual occurrence — wave 28 §7.9) |
+| **`S-b`** | Over every `Recommend(` call site under `Joko.NINA.Plugins.HocusFocus/`: **none** sits in a method whose enclosing round loop captures a new sweep, **and** neither `OptimizedStarDetectionSettings` nor `OptimizationSummary` declares a member matching `(?i)halfwidth` | a product caller with a re-capturing round loop; any `halfwidth` member on either type |
+| **`S-c`** | `SweepDetectability` declares a member carrying the **requested** focuser positions, and it is reachable inside `Recommend` | no such member |
+
+**Verdicts.** `S-a` false ⇒ `S-UNEVALUATED` (the coupling could not be established; nothing downstream in this
+rule is quoted). `S-a` ∧ ¬`S-b` ⇒ `S-CARRIER-EXISTS` — a product carrier was found, wave 26 reason (iii)
+stands, and §1's headline is **withdrawn in the results document, in place.** `S-a` ∧ `S-b` ∧ `S-c` ⇒
+`S-NO-CARRIER`. `S-a` ∧ `S-b` ∧ ¬`S-c` ⇒ `S-NO-CARRIER-NO-ALT`.
+
+**Both branches of every clause are reachable and the FAIL ends are demonstrated on real files**, not
+fixtures: `S-a`'s zero-site end on `StepSizeRecommender.cs` itself (which contains no such call), its
+multi-site end on `SynthValidateRunner.cs` scoped to the whole file (**two** sites, `:792` and `:1262`);
+`S-b`'s carrier end on `StepSizeRecommendation`, which **does** declare `HalfWidth`; `S-c`'s absent end on
+`StepSizeRecommendation`, which declares no focuser positions.
+
+### 4.4 The third candidate — REGISTERED, PRICED, AND NOT CHOSEN
+
+If `S-c` holds, a fix exists that wave 26 never considered, because it needs no cross-round state at all:
+**bound `maxHalfWidth` below by the span the sweep actually REQUESTED, and only on a round where
+`BandDemonstrablyUnsampled(sampledHfrRange)` is already true.** The requested positions are in
+`SweepDetectability.FrameFocuserPositions`; the guard is the same predicate F81 already ships; and it is inert
+on every round that reached the band, which is where the cap is *the* convergence mechanism.
+
+**It is proposed from source and it is NOT chosen in this wave.** Wave 26 pre-registered a binary choice
+before anyone looked; introducing a third option after reading the diagnosis and then selecting it in the same
+breath is exactly the shape the `RULE D20` fence forbids. It is registered with its price (§11) and the
+**next** wave pre-registers the choice among three.
+
+---
+
+## 5. `RULE W29-R` — wave 26's reversal condition, executed. Blind on 15 cells, zero compute
+
+Wave 26 design §14, quoted, and this is the whole of what the rule tests:
+
+> **And the condition that would reverse it**, stated now: if a later wave measures that `SearchSpan` over
+> `bestFit.Inputs` **shrinks on more than a single cell** while the requested sweep widens, then the defect is
+> in the quantity and not in its persistence, and (2) becomes correct.
+
+**Nobody has run it.** Three waves have quoted the pre-registered choice and none has evaluated its escape
+clause. It costs nothing.
+
+### 5.1 The instrument — exact, on data already on disk, needing no field that is not serialized
+
+`maxHalfWidth = MaxHalfWidthSampledHalfSpanMultiple × 0.5 × SearchSpan` (`StepSizeRecommender.cs:320`), and
+`maxHalfWidth` is **not** serialized. It does not need to be. On any round where the cap bound
+(`:347-349`, `halfWidth = maxHalfWidth`) **or** the floor engaged (`:332`, `:364-365`, `halfWidth =
+maxHalfWidth`), the serialized `stepRecommendation.halfWidth` **is** `maxHalfWidth` exactly, so
+
+```
+implied SearchSpan(round)  =  halfWidth / (MaxHalfWidthSampledHalfSpanMultiple × 0.5)   =  halfWidth / 0.75
+requested span(round)      =  2 × bootstrap.offsetSteps × bootstrap.stepSize
+```
+
+Validated against the one burned cell before the instrument was written: `D01` r0 floored `halfWidth` 12.0 ⇒
+implied 16, requested 2×4×2 = 16; r1 capped `halfWidth` 9.0 ⇒ implied 12, requested 2×4×3 = 24. **F82's
+published table reads *"requested 16 → 24, fitted 16 → 12"*. The identity reproduces on the nose.**
+
+**The trap that must not be silent, and it is checked before any statistic:** there is a **third** bound.
+`WasDetectBounded` / `MaxUsefulHalfSpan` (`:368-379`) can also set `halfWidth`, in which case
+`halfWidth ≠ maxHalfWidth` and the inversion is wrong. **A round with `wasDetectBounded == true` is a
+could-not-look**, named and counted, never silently included. A round that is neither capped nor floored is
+likewise a could-not-look. Measured at pre-registration over the 18 addressable cells: **37 rounds, 37
+capped-or-floored, 0 detect-bounded.** The instrument is applicable everywhere.
+
+**And `MaxHalfWidthSampledHalfSpanMultiple = 1.5` is asserted from source at BOTH trees** — wave 25's B15 tree
+(`29665a62…`, read out of `/mnt/d/hf_w25/binary_provenance_w25.txt`, never assumed) and `HEAD` — because the
+inversion is only valid if the constant that produced the artifacts is the constant the scorer divides by.
+A mismatch is `R-UNSATISFIABLE`, not a silently rescaled number.
+
+### 5.2 Population, and what is already known about three of its members
+
+**Population: the 18 addressable paired S1 cells under `/mnt/d/hf_w25/after/`.** 20 datasets less
+`D05_tec140_1000mm` and `D19_cygnus_deep_shed`, which time out at `timeout 600` on **every** S1 arm — four in
+a row, structural, not flaky. **The count is asserted and the gap is asserted to be exactly those two names**
+([F74](followups.md); wave 24's `40` vs `38`). Every cell has ≥ 2 rounds; `D08` has 3.
+
+`D01`, `D02` and `D03` are **burned** — their rounds are published in F82's own table — and they are **kept in
+the denominator and computed anyway**, because dropping a member because you know its answer is how a
+denominator becomes a choice. Their contribution is therefore **predicted here, before the scorer runs**:
+
+| burned cell | published `halfWidth` r0 → r1 | implied `SearchSpan` | qualifies? |
+|---|---|---|---|
+| `D01_ultrawide_40mm` | 12.0 → 9.0 | 16 → 12, **shrank** | **YES** (it is the cell the condition was written from) |
+| `D02_rich_135mm` | 12.0 → 18.0 | 16 → 24, grew | no |
+| `D03_redcat_250mm` | 24.0 → 42.0 | 32 → 56, grew | no |
+
+**So `c ≥ 2` holds if and only if at least one of the 15 BLIND cells qualifies**, and the rule is a clean
+binary question on a population nobody has computed this statistic over. The scorer **prints both** `c` (over
+18, as the condition is written) and `c_blind` (over 15), so no reader has to do that arithmetic — and the
+verdict is taken on `c ≥ 2` **as pre-registered by wave 26**, not on a rate this wave invented.
+
+### 5.3 The clauses
+
+| clause | statement | bar |
+|---|---|---|
+| **`R-0`** *(validity, IN the tree)* | addressable cells `k`, each with ≥ 2 rounds and every read round capped-or-floored and not detect-bounded; **and** `MaxHalfWidthSampledHalfSpanMultiple == 1.5` at both trees | `k ≥ 2` |
+| **`R-1`** | `c` = distinct cells with ≥ 1 round transition `r → r+1` where `requested(r+1) > requested(r)` **and** `impliedSearchSpan(r+1) < impliedSearchSpan(r)` | `c ≥ 2` |
+
+**`R-0` false ⇒ `R-UNSATISFIABLE`, and that is a FINDING, not something to repair and re-score.** The
+pre-registered default then stands: fix (1) remains the choice, because wave 26 named `n = 1` as insufficient
+and an unevaluable condition does not become an evaluated one.
+
+**Aggregation, stated because [F68](followups.md) has five parts.** Population = the report file
+`synth_validate_report.json` per cell; field = `datasets[0].scenarios[0].rounds[i].stepRecommendation.halfWidth`
+and `.bootstrap.{offsetSteps,stepSize}` — **the per-round copies, never the `terminal` block**, and the scorer
+asserts it consumed exactly one `stepRecommendation` per round index. Statistic = per transition. Aggregation
+= **any transition qualifies the cell; cells are counted, not transitions**, because wave 26 wrote "cells".
+Empty-set answer = `R-UNSATISFIABLE` per `R-0`.
+
+### 5.4 What each verdict costs, fixed before the data
+
+- **`R-STANDS`** — fix (1) remains correct **on wave 26's grounds**, and §1's finding stands beside it
+  unchanged: it still has no product carrier. F82 is re-priced and handed forward with three candidates.
+- **`R-REVERSE`** — fix (2) becomes correct by wave 26's own pre-registration, **and wave 29 does not ship it.**
+  It moves `maxHalfWidth` on **37 of 37 rounds**, and — per §1(a) — it also moves `ComputeStepBehavioral`, so
+  it moves assertion `A3`'s bar as well as `A3`'s measurement. Its price is a full paired 18-cell arm
+  (~2 h 40 m), the **42 m gate** (§8), and an `A3` re-derivation. **That is not a wave-29 ship and saying so is
+  the rule working**, in the same way wave 28's ship (2) did not ship.
+
+---
+
+## 6. `RULE W29-L` — which of `D01`'s three downstream gates actually binds. One arm, no build
+
+Wave 28 converted 34 060 `NO CANDIDATE` into 33 298 gate rejections at `NC = 1.0` and **said, correctly, that
+it had not localised them**: the gates fire in sequence — `TooSmall` (`StarDetector.cs:1757`) → `OnBorder`
+(`:1766`) → `TooDistorted` (`:1807`) → `Degenerate` (`:1823`) → `LowSensitivity` (`:1854`) — so the published
+counts are **first-rejection-wins** and are an ordering, not shares.
+
+**Design: five cells on `D01` alone, `NoiseClippingMultiplier` held at 1.0 throughout, one knob relaxed per
+cell plus one cell with all three relaxed.** No build. Binary: `/mnt/d/hf_w25/exe`, `TestApp.dll` sha256
+`2fb0c8fd…` — the same B15 that produced `table18` and wave 28's arm. Settings tree copied per cell from the
+same source wave 28's arm used, one field edited, `cp` **without** `-p` and `touch` after every copy
+([F89](followups.md)).
+
+| cell | edit, against the landed tree with `NoiseClippingMultiplier = 1.0` |
+|---|---|
+| `L0` **baseline** | `NC = 1.0` only — **must reproduce wave 28's published `D01` high-tier block exactly** |
+| `L1` | + `MinimumStarBoundingBoxSize` 6 → **3** |
+| `L2` | + `MaxDistortion` 0.5 → **0.9** |
+| `L3` | + `Sensitivity` relaxed one notch — **diagnostic only, see below** |
+| `L4` | + all three of `L1`/`L2`/`L3` together |
+
+**`L3` is diagnostic and proposes nothing on the Sensitivity axis.** [F84](followups.md) is re-affirmed, not
+touched: *"a floor on the Sensitivity axis alone is dead"*, `RULE S16` is a permanent fence, and wave 28
+already recorded that `D01`'s `LowSensitivity` rise is a **downstream consequence** of more candidates
+existing. You cannot attribute three sequential gates by opening two, so the third cell is necessary and its
+role is bounded here, in writing: **no verdict branch reads `L3` alone, and no register entry produced by this
+wave may cite it as evidence for or against a sensitivity bound.**
+
+### 6.1 The statistic and the decomposition
+
+Read **only** the `FALSE-NEGATIVE ATTRIBUTION, HIGH TIER ONLY` block, anchored on that header
+([F68](followups.md) part 5 — the same line appears twice per report and wave 28's self-test [3] proved a
+first-match reader takes the wrong one). For each cell, `FN_total` = the block's total high-tier false
+negatives.
+
+```
+exclusive(g)  =  FN_total(L0) − FN_total(L_g)                for g in {MinBox, MaxDistortion, Sensitivity}
+joint         =  FN_total(L0) − FN_total(L4)
+```
+
+`exclusive(g)` is the count of stars that gate `g` blocked **and no other opened gate did**; `joint` is the
+total recoverable across all three. `joint − Σ exclusive(g)` is the multiply-blocked residual, **exactly**.
+
+| clause | statement | bar |
+|---|---|---|
+| **`L-0`** *(validity, IN the tree)* | all 5 cells `exit=0`; each echoes its intended knob values on the `key detector knobs:` line; **and `L0` reproduces wave 28's published `D01` `NC = 1.0` high-tier attribution block field-for-field** | all |
+| **`L-1`** | `Σ exclusive(g) < 0.60 × joint` | — |
+| **`L-2`** | `Σ exclusive(g) ≥ 0.90 × joint` | — |
+
+`L-1` and `L-2` are mutually exclusive by construction and the scorer **asserts** it.
+
+**Verdicts.** ¬`L-0` ⇒ `L-UNEVALUATED`. `L-0` ∧ `L-1` ⇒ **`L-JOINTLY-BOUND`** — no single gate binds; `D01`'s
+residual loss is multiply-gated and **no single-knob change can recover it**. `L-0` ∧ `L-2` ⇒ `L-SEPARABLE` —
+the gates are near-independent and the largest `exclusive(g)` names the binding one. Otherwise ⇒ `L-PARTIAL`,
+with the shares published and no gate named.
+
+**The prediction, stated before the data so the rule can be wrong: `L-JOINTLY-BOUND`.** A 0.7 px kernel on a
+19.4″/px rig produces a candidate that is simultaneously below the bounding-box floor, noisy enough in its
+second moments to read as distorted, and marginal in signal. If instead `L-SEPARABLE` comes back naming
+`MinimumStarBoundingBoxSize`, that is a **goal-3 product finding** — a knob landed at 6 against a shipped
+default of 5 on the rig with the smallest stars, with a `WideField` preset that lowers it — and it is worth
+its own wave.
+
+**`L0` is a control that can fail, and its failure end is real:** it re-runs a cell whose numbers are
+published to the digit. Wave 28's §4.3 found the equivalent control *"a stronger control for this arm than
+the `--profile-id` inertness probe"*, and unlike that probe it is pre-registered here rather than
+opportunistic.
+
+---
+
+## 7. BLINDNESS LEDGER — stated once, exactly, before any wave-29 statistic
+
+**READ, and by whom:**
+
+| what | by whom | scope of the burn |
+|---|---|---|
+| `D01`/`D02`/`D03` per-round `halfWidth`, `stepSize`, `wasCapped`, `wasBandFloored` | [F82](followups.md)'s published table, and §5.2 above | those 3 cells, `W29-R`'s statistic |
+| `roundIndex`, round count, `wasCapped`, `wasBandFloored`, `wasDetectBounded` — **all 18 cells** | **this document**, §5.1's applicability count | **none of `W29-R`'s statistic** — see below |
+| `D01`'s full `golden eval` block at `NC` landed and `NC = 1.0`, incl. the high-tier attribution | wave 28 §1.1, and §6 above | `W29-L`'s **baseline half** |
+| the `synth_validate_report.json` **schema** (key names only, `D01`) | this document | none |
+
+**Why reading the three flags on all 18 costs no blindness.** `wasCapped` / `wasBandFloored` were already
+published as aggregates by wave 25 (`RULE N25` `A4` **18 of 18**; `RULE W25` `W-UNEXERCISED`, no blind cell
+floored), so they were burned two waves ago. They are `W29-R`'s **applicability filter**, not its statistic:
+they decide *whether a round can be read*, and `halfWidth` / `bootstrap` decide *what it says*. **Reading which
+rounds are addressable is how a population is asserted; reading the values is how a rule is pre-empted.** This
+table exists so a later reader can check that the wave did not blur them. **`halfWidth`,
+`bootstrap.offsetSteps` and `bootstrap.stepSize` have been read on `D01` only** (published), and the
+requested-vs-implied comparison has **never** been computed on any other cell.
+
+**BLIND, and carrying `W29-R`'s verdict: the 15 paired S1 cells other than `D01`/`D02`/`D03`.**
+
+**`W29-L` has no blind population and this is said plainly.** Its baseline is published to the digit and its
+verdict is a **difference** against it; the four intervention cells do not exist yet. The honesty mechanism is
+therefore not blindness but **prediction**: §6 fixes `L-JOINTLY-BOUND` as the expected answer, with its
+mechanism, before the arm runs. **Wave 28 had to relocate its verdict to the frame level because the bank
+could not supply a blind wide-field dataset; wave 29 cannot relocate `W29-L` anywhere, so it says so instead
+of claiming a blindness it does not have.**
+
+---
+
+## 8. THE GATE — answered in both directions, and it is NOT owed this wave
+
+**Wave 29 changes no C# and builds no binary.** Wave 26's four conditions for an honest skip therefore all
+hold: nothing is compiled; `G25` already answered what a re-gate asks; a re-gate does not reach this wave's
+risk (which is a source reading and two artifact re-reads); and **no clause in any verdict tree in this
+document reads a gate landing.** *A control that no clause consumes is a ritual.*
+
+**The three conditions that reverse it are checked at Step 8 and any one of them stops the wave:** a single
+line of C# changing for any reason; a hash or `BuildId` mismatch on the binary the `W29-L` arm uses; or that
+arm's own instrument proving non-deterministic. The replacement control is `Q26-V0`'s shape — dll sha256
+identity of `/mnt/d/hf_w25/exe` against `/mnt/d/hf_w25/binary_provenance_w25.txt`, with `L0`'s exact
+reproduction of a published population as the arm-level control that *can* fail.
+
+**And the answer the controller asked for, for the record and for the next wave: if wave 29 had shipped
+F82's fix, the gate would be owed, certainly and not probably.** §2.3 has the artifact. The intersection is
+non-empty by a directory prefix over the whole plugin assembly, `Q27-V1`'s own FAIL end names
+`StepSizeRecommender.cs` by path, and **`Q27-V1` does not discharge it.** Price when it comes due: **42 m**
+measured (wave 25: 42 m 43 s, ~5.2 m/run, seven consecutive waves), predicted verdict `G-PASS` 8 of 8
+bit-identical to K8.
+
+---
+
+## 9. WHAT SHIPS — nothing, fixed here, before the data
+
+**No product code changes in wave 29.** This is not a gated ship that failed its gate; it is a scope decision
+made in the pre-registration on the strength of §1, and it is recorded so that no later reader mistakes it for
+a verdict.
+
+| candidate ship | status |
+|---|---|
+| F82 fix (1), harness | **DOES NOT SHIP.** §1: it reaches no user, and shipping it would make `synth-validate` stop reproducing the product's own stall |
+| F82 fix (1), product | **DOES NOT SHIP.** Needs new persisted state; unpriced by anyone; §11 gives a band |
+| F82 fix (2) | **DOES NOT SHIP**, on either verdict of `RULE W29-R`. §5.4 |
+| F82 fix (3), the scoped requested-span bound | **DOES NOT SHIP.** Proposed from source in §4.4, deliberately not chosen in the wave that proposed it |
+| anything on the `NoiseClippingMultiplier` or `Sensitivity` axes | **DOES NOT SHIP.** §3, §6 |
+
+**Consequence:** no C# changes, so **the unit suite is not run**, and that is stated rather than skipped
+silently. `CLAUDE.md`'s *"run the suite after every code change"* is satisfied vacuously and the condition that
+reverses it is written into the plan: **if a single line of C# changes for any reason, the suite runs by COUNT
+([F37](followups.md)) and the gate becomes owed (§8).** The baseline to compare against is **3997** — wave 28's
+measured close — **not the charter's stale 3973** (wave 28 §7.8: the design quoted a figure two waves old and
+would have hidden a 19-test regression).
+
+---
+
+## 10. VERDICT TREES, ENUMERATED — [F94](followups.md)'s remedy, executed rather than restated
+
+Every clause appears in its own tree, **including every validity clause**. Every scorer re-derives these
+enumerations in code and prints `regions enumerated: N   uncovered: 0`; a gap prints `<RULE>-TREE-GAP`,
+enumerates the uncovered regions, prints what this document's tree would have said, and **does not repair and
+re-score**.
+
+**`RULE W29-S` — 3 clauses, 8 regions, 0 uncovered**
+
+| `S-a` | `S-b` | `S-c` | verdict |
+|---|---|---|---|
+| F | * | * | `S-UNEVALUATED` (4 regions) |
+| T | F | * | `S-CARRIER-EXISTS` (2 regions) |
+| T | T | T | `S-NO-CARRIER` (1) |
+| T | T | F | `S-NO-CARRIER-NO-ALT` (1) |
+
+**`RULE W29-R` — 2 clauses, 4 regions, 0 uncovered**
+
+| `R-0` | `R-1` | verdict |
+|---|---|---|
+| F | F | `R-UNSATISFIABLE` — a FINDING; wave 26's choice stands by default |
+| F | T | **logically unreachable** (`c ≥ 2` ⇒ `k ≥ 2`). Present, asserted empty, and entering it is `R-INCOHERENT` — a refusal |
+| T | F | `R-STANDS` |
+| T | T | `R-REVERSE` |
+
+**`RULE W29-L` — 3 clauses, 8 regions, 0 uncovered**
+
+| `L-0` | `L-1` | `L-2` | verdict |
+|---|---|---|---|
+| F | * | * | `L-UNEVALUATED` (4 regions) |
+| T | T | T | **unreachable by construction** — asserted empty; entering it is `L-INCOHERENT` (1) |
+| T | T | F | `L-JOINTLY-BOUND` — **the prediction** (1) |
+| T | F | T | `L-SEPARABLE` (1) |
+| T | F | F | `L-PARTIAL` (1) |
+
+**`RULE V29` (pre-flight) and `W29-FP` (fingerprint)** inherit wave 28's trees unchanged:
+`V-CLEAN` / `V-DRIFT` / `V-UNEVALUATED`, and `PRESERVED` / `VIOLATED` / `UNEVALUATED` on differing membership.
+
+**Why the pattern F94 identified does not recur here.** F94's diagnosis was specific: *"the uncovered region
+is always the VALIDITY clause"* — `N-1` was expected to hold, so it fell out of the tree. `S-a`, `R-0` and
+`L-0` are all validity clauses and **all three are the first column of their own table.**
+
+---
+
+## 11. PRICE, per half, scored against the owner's three goals, and what is cut first
+
+Goals (charter §8): **(1)** optimization + autofocus across a wide range of setups; **(2)** accuracy of
+step-size recommendations; **(3)** appropriate exposure adjustments, no parameters pinned to extremes.
+
+| step | est | compute | goals |
+|---|---|---|---|
+| 0 vessel + pre-registration commit | 10 m | — | — |
+| 1 write **all** instruments (5 files) before any of them runs | 60 m | — | — |
+| 2 `RULE V29` pre-flight, **over the populated root** ([F95](followups.md)) | 20 m | — | instrument |
+| 3 `W29-FP` fingerprint BEFORE | 8 m | — | instrument |
+| 4 `RULE W29-S` | 25 m | — | **2** ✓✓ (it decides what F82 *is*) |
+| 5 `RULE W29-R` | 25 m | — | **2** ✓✓ |
+| 6 `RULE W29-L` arm + scoring | 55 m | **~25 m** | **3** ✓✓, **1** ✓ |
+| 7 [F83](followups.md)'s `P-D08` at `n = 3` | 2 m | ~2 m | **3** ✓ |
+| 8 fingerprint AFTER + **closing** `V29` | 12 m | — | instrument |
+| 9 results, register, handoff | 75 m | — | — |
+| **total** | **~5 h** | **~27 m** | |
+
+Comfortably inside both the ~8 h wall clock and the ~6 h compute ceiling. **Slack is deliberate**, because
+this is the fourth consecutive wave in which the analysis halves are over-priced — wave 28 came in **~59 %
+under**, wave 27 ~36 % under, and the lesson is now specific: *price compute from the measured rate and price
+analysis at a third of instinct.* The one figure here priced from a measured rate is step 6: wave 28 measured
+`D01` at `NC = 1.0` at **179 s per 9-frame cell**, the top of the bank's range, and 5 cells is ~15 m plus
+copies and fingerprints — reserved at 25 m.
+
+**What is cut first, in order:**
+
+1. **`L3` and `L4`** — the Sensitivity cell and the joint cell. The arm degrades from a decomposition to a
+   ranking with lower bounds, saving ~10 m of compute. **This is the cut, and it is the one that costs the
+   most per minute saved**, so it is named first to be honest, not because it is cheap.
+2. **The whole of `RULE W29-L`.** Wave 29 still delivers `W29-S` and `W29-R`, which are the two halves that
+   decide F82's fate. `W29-L` finishes someone else's question.
+3. **Step 7** — no. **An item under two minutes is never dropped** (charter §4); wave 19 finished at 1 h 35 m
+   of a 6 h ceiling with a one-minute item undone and it cost `RULE C19` its verdict.
+4. **Step 9's handoff document**, folded into the results file's §12 rather than written separately.
+
+**What is NOT cut, at any budget:** the closing `V29` run (step 8). It is two minutes and it is
+[F95](followups.md)'s entire remedy.
+
+**Prices this wave hands forward rather than paying:**
+
+| item | price |
+|---|---|
+| F82 fix (1) **in the harness** | ~45 m + tests. **Not recommended** — §1, §9 |
+| F82 fix (1) **in the product** | **a BAND, and it is one**: ~2–4 h. New persisted half-width surviving between wizard sessions; the `Continue`/`Re-optimize` paths excluded where it is inert; migration; a `CLAUDE.md` decision on whether it is an *option* and therefore owes a control in the options templates; **+ 42 m gate** (§8) |
+| F82 fix (2) | ~45 m code **+ a full paired 18-cell arm ~2 h 40 m + 42 m gate + an `A3` re-derivation**, because it moves `ComputeStepBehavioral` |
+| F82 fix (3), the scoped requested-span bound (§4.4) | ~45 m code + a 3-cell re-run + **42 m gate**. Needs no new state and no `A3` re-derivation if the guard holds — **cheapest of the three, and precisely why it must not be chosen by the wave that thought of it** |
+| the `A4` truth-model gap (backlog item 4, "~20 m") | **the 20 m is the code. It rebuilds `TestApp`, which trips §8's first reversal condition and adds 42 m of gate.** Naming that is itself a finding: the cheapest item on the backlog is not cheap |
+
+---
+
+## 12. INSTRUMENTS AND CONSTRAINTS
+
+All under `/mnt/d/hf_w29/`, **LF**, derived from `/mnt/d/hf_w28/`.
+
+- `verify_derivation_w29.py` — derived from `verify_derivation_w28.py`, **not** any `.bak`. **Carry forward,
+  and demonstrate, all three of wave 28's repairs:** [F87](followups.md)'s `historical_ranges` fix (the
+  definition line of `HISTORICAL_BLOCKS` opens nothing — bracket-depth, top-down, `is_definition` excluded);
+  self-test clause **`[6]`** in both directions; and wave 28's **per-clause fixture pinning** `[5b]`.
+- **Per-clause fixtures: MEASURE which roots still refuse; do not inherit wave 28's choices.** Wave 28
+  established that a root pinned for its `-B` findings **goes silent exactly one wave later**, because `PREV`
+  moves: `/mnt/d/hf_w26` yielded 0 `-B` at wave 28. `/mnt/d/hf_w27` was wave 28's live `-B` fixture and
+  **`PREV` is now 28**, so it is a candidate to have expired in exactly the same way. **The plan measures
+  `-A`/`-B`/`-C` finding counts across `/mnt/d/hf_w{24,26,27,28}` and pins from the measurement**, keeps the
+  expired root asserted-silent so the expiry is demonstrated rather than described, and treats **a clause with
+  no live fixture as a FAIL**. Wave 28 assumed and got lucky; wave 29 measures.
+- **`--out` mandatory and REFUSING without it** on every scorer.
+- **`--rule` asserted against the file's own declared rule name** ([F90](followups.md)) — a hard refusal.
+  Wave 28's scorers made this a refusal and it caught the controller within a minute.
+- Populations **asserted**; ordinals and counts **computed, never typed** (`V29-C`); paths handed to scorers
+  through a **manifest**, never rebuilt from a template ([F74](followups.md)); one shared layout function.
+- `find … -print0 | sort -z | xargs -0` — `/mnt/d/Autofocus Bank` contains a space.
+- **BEFORE/AFTER built from ONE expression called twice** ([F91](followups.md)), population size asserted
+  **equal** before any hash is compared, and the fingerprint written **outside** every tree it sweeps
+  (wave 28 §7.10).
+- `touch` after every mutant or settings restore ([F89](followups.md)); `cp` **without** `-p`.
+- Provenance: `git diff --name-only <tree> -- '*.cs'` **unioned with** `git ls-files --others
+  --exclude-standard -- '*.cs'` ([F88](followups.md)), and the BEFORE tree hash read out of
+  `/mnt/d/hf_w25/binary_provenance_w25.txt`, **never assumed from a previous HEAD**.
+- **Pass scorers WSL paths.** A Windows path yields `UNEVALUATED` and looks like a failed arm.
+- `TestApp.exe` gets `< /dev/null`; `--settings` **and** `--profile-id` pinned on the arm; one `TestApp.exe`
+  at a time; **no directory rebuilt mid-wave** — every instrument is written at Step 1.
+- **Read-only for the whole wave:** `/mnt/d/hf_w25/{after,before,table18,exe}`, `/mnt/d/hf_w28/nc`,
+  `/mnt/d/SyntheticAutofocusBank`.
+
+**Every conclusion in this wave is synthetic-only.** The bank has no real under-sampled dataset
+([F35](followups.md), [F43](followups.md)) and `W29-L` is one dataset, `D01`, named as one dataset everywhere
+it is quoted.
+
+---
+
+## 13. WHAT WAVE 29 WILL NOT RUN, AND WHAT IT COSTS
+
+| not run | price | why |
+|---|---|---|
+| any F82 fix | see §11 | §1, §9 — none of the three reaches a user at wave-29 cost |
+| the 42 m `optimize` gate | 42 m | **Not owed** — no C# changes (§8). Owed, certainly, by the wave that ships F82 |
+| the unit suite | ~4 m | No C# changes (§9). Reverses on one line of C# |
+| a full paired 18-cell S1 arm | ~2 h 40 m | `W-UNEXERCISED`: 13 blind cells moved by exactly zero across a real product change. A second full arm buys a second `SAME 13` |
+| wave 28's `M1`–`M6` mutant records | ~10 m | **Not applicable** — wave 29 ships nothing and writes no test. Wave 28's debt stays wave 28's, named in its §11 |
+| `S27-1` and wave 27's three mutants | ~20 m | **STILL OPEN, two waves running.** Cut for budget; named so it is not lost a third time |
+| new datasets between 1.4 and 19.4 ″/px | ≥ 1 h render | The only route to a **blind** wide-field dataset. The bank's coverage hole is unchanged |
+| the blur/layer decoupling build ([F92](followups.md)) | ~45 m + 10 m (+42 m to ship) | Better-motivated than at its pre-registration, and it is a detector change owing a baseline |
+| the `A4` truth-model gap | 20 m code **+ 42 m gate** | §11's last row |
+| anything on real frames | — | The bank has no real under-sampled dataset |
+
+---
+
+## 14. REGISTER ENTRIES OWED, whatever the verdicts
+
+- **F96** — the harness's `stepBehavioral` is `StepSizeRecommender.Recommend` iterated to a fixed point, so a
+  change to the recommender moves the bar that scores it; and no product caller carries cross-round sweep
+  state, so F82's pre-registered fix has no product carrier. Owed on `S-NO-CARRIER` **or**
+  `S-NO-CARRIER-NO-ALT`; **withdrawn in place** on `S-CARRIER-EXISTS`.
+- **F97** — `RULE W29-R`'s verdict, whichever it is, with `c`, `c_blind`, `k` and the named qualifying cells.
+- **F98** — `RULE W29-L`'s decomposition, with the exclusive and joint shares, framed per §2.5 as goal 3.
+- **[F82](followups.md) — AMEND IN PLACE.** Its *"truth of 9"* must be labelled as a **product-derived fixed
+  point**, not a spec-derived truth; its *"confined to the recommender's caller state"* must name **which**
+  caller; and the third candidate (§4.4) must be added beside the two.
+- **[F81](followups.md)** — append that the floor it shipped is reached in the product only at round 0 of a
+  session, because the wizard's rounds do not re-sweep.
+- **[F94](followups.md)** — append §10's enumeration as the first design to publish its own outcome space,
+  and whether the scorers' re-derivations agreed with it.
+- **[F95](followups.md)** — append whether the ordering in the plan (instruments **then** pre-flight **then**
+  measurement, plus a closing run) produced a non-empty population at the first run. **This is the wave that
+  tests the remedy.**
+- **[F21](followups.md)** — estimate vs actual for every step, per §11.
+- **`docs/synthetic-af-bank-results-table.md`** — wave 28's owed `K` column, and **no 2–4 px band claim below
+  the band** (`B-SPLIT`).

--- a/docs/synthetic-af-bank-followups-wave29-design.md
+++ b/docs/synthetic-af-bank-followups-wave29-design.md
@@ -27,6 +27,36 @@ verdict. It is load-bearing for whether the previous wave's declared deviation g
 
 ---
 
+> ## CORRECTION, added after the measurement — §1(b) IS FALSE AT HEAD, and `RULE W29-S` says so
+>
+> **This design's headline is half wrong, the wave's own rule refuted it, and the pre-registration text below
+> is left EXACTLY as written so the error is visible rather than tidied away.**
+>
+> **`RULE W29-S` = `S-CARRIER-EXISTS`** (`/mnt/d/hf_w29/w29s_score.txt`): `S-a` **HOLDS**, `S-c` **HOLDS**,
+> **`S-b` is FALSE**. A product carrier *does* exist.
+>
+> §1(b)'s caller table names **two** of `BuildSummaryAsync`'s **five** callers. The full set, discovered by the
+> instrument rather than typed: `StartAsync`, `ReOptimizeWithLabelsAsync`, `ContinueOptimizationAsync`,
+> `OptimizeAgainAtRecommendedBinningAsync`, and — the one that matters —
+> **`CaptureNewSweepAsync`** (`StarDetectionOptimizerWizardVM.cs:5012`), which takes a **fresh sweep**
+> (`RunLiveAttemptAsync` per run), calls `BuildSummaryAsync` at `:5098`, and **carries the previous round's
+> recommended geometry into the next sweep** through the instance field `recaptureStepSize`.
+>
+> So the sentence *"No new sweep is taken between wizard rounds, so `SearchSpan` cannot change between them and
+> the defect cannot occur there at all"* is **false**, and with it the claims that fix (1) *"reaches no user"*
+> and that F82 *"scores goal 2 zero"*. **F82 is a real product defect on a real product path.**
+>
+> **The controller repeated the false claim in the wave-29 pre-registration commit message** (`544f2b2`), which
+> cannot be edited; it is corrected here, in the PR, and in the results document.
+>
+> **What survives, and it is the larger half:** §1(a) — the truth-model coupling — is `S-a`, and it **HOLDS**.
+> The harness still scores the recommender against a fixed point of the recommender. And the wave's refusal to
+> flip wave 26's choice still stands, now for a better reason than it was written for: `RULE W29-R` =
+> **`R-STANDS`**, so the reversal condition is not met on evidence, not merely unexamined.
+>
+> **The instrument was written to the pre-registration and NOT tuned to this result.** `S-b` was implemented
+> exactly as §4 fixes it; it returned FALSE on its own terms. That is a pre-registration working.
+
 ## 1. THE HEADLINE: the pre-registered fix has no carrier in the product, and the "truth" it is scored against is produced by the code under test
 
 Two facts, both decidable from source at zero compute, both verified in this document against shipping files:

--- a/docs/synthetic-af-bank-followups-wave29-results.md
+++ b/docs/synthetic-af-bank-followups-wave29-results.md
@@ -1,0 +1,941 @@
+# Wave 29 — results
+
+## THE TIMESTAMP — the roll call, taken at an instant
+
+```
+$ date -u '+%Y-%m-%dT%H:%M:%SZ'; ls -la --time-style=full-iso /mnt/d/hf_w29/
+2026-08-13T18:03:36Z
+drwxrwxrwx  ...  2026-08-13 13:52:45.735921200 -0400 .
+```
+
+**One row was OPEN at that instant and is marked open in place.** `fp_AFTER.txt` had mtime
+`13:52:45 → 14:03:36.461` (`= 18:03:36Z`) — **the same second as the timestamp**. Three `stat` calls two
+seconds apart returned `373637 → 377044 → 380971` bytes: it was **mid-write**, the 42 GB sweep still running.
+It closed at `14:04:27.954 -0400` (`= 18:04:27Z`), **51 seconds after the roll call**, at 398 023 bytes and
+`POPULATION 2452`. It is reported below as a completed artifact **and** as having been open at the timestamp,
+because wave 19's document was falsified by an artifact written 33 seconds before its own commit and the fix
+for that is to say both things.
+
+| row | state at **18:03:36Z** | artifact |
+|---|---|---|
+| `RULE W29-S` | **CLOSED** 17:36:08Z | `w29s_score.txt` |
+| `RULE W29-R` | **CLOSED** 17:36:19Z | `w29r_score.txt` |
+| `RULE W29-L` arm | **CLOSED** — `W29L_ARM_END 17:51:23Z`, 5 of 5 cells `exit=0`, interlock written by the driver | `w29l_arm.txt`, `w29l_manifest.tsv`, `W29L_MANIFEST_READY`, `l/out/L{0..4}.log` |
+| `RULE W29-L` scoring | **CLOSED** 17:52:13Z | `w29l_score.txt` |
+| `RULE V29` (pre-flight) | **CLOSED** 17:35:55Z, over a root of **7 files**; self-test 17:35:39Z `27 of 27`; four fixture probes 17:20:58–17:21:32Z | `vdrift_w29.txt`, `vdrift_selftest_w29.txt`, `vdrift_probe_hf_w2{4,6,7,8}.txt`, `vdrift_instrumentcheck_w29.txt` |
+| `W29-FP` AFTER sweep | **OPEN AT THE TIMESTAMP** — mid-write, closed 18:04:27Z (11 m 42 s, 2 452 files) | `fp_AFTER.txt`, `fp_after_run.txt` |
+| cross-wave integrity check | **NOT YET WRITTEN** at the timestamp — appeared 18:05:04Z | `fp_crosswave_check.txt` |
+| `W29-FP` **BEFORE** sweep | **NEVER RUN** — controller deviation (i), §8 | — |
+| the **closing** `V29` (`vdrift_w29_FINAL.txt`) | **NOT RUN** — design §11 called it the one thing not cut at any budget | — |
+| Step 7, [F83](followups.md)'s `P-D08` at `n = 3` | **NOT RUN** — no artifact under the root | — |
+| the three scorers' `--self-test` captures | **NO ARTIFACT** — `w29s_selftest.txt` / `w29r_selftest.txt` / `w29l_selftest.txt` are absent; the two drivers' self-tests **are** on disk (`27 of 27`, `33 of 33`) | — |
+| `fp_w29.sh --self-test` capture, `T0.txt` | **NO ARTIFACT** — both named by the plan, neither on disk | — |
+
+**Vessel.** Wave 29 ran on its own branch `ghilios/synthetic-af-bank-followups-wave29`, with commits `544f2b2`
+(pre-registration) and `80e42c5` (the CORRECTION), on **PR #197**, verified `OPEN`, stacked on #196. **Design
+§0 was executed rather than reversed** — wave 28's declared deviation was not repeated, and #196 does not carry
+a third section.
+
+**But the PR's own title still carries the withdrawn claim** — *"Wave 29: F82's fix has no product carrier, and
+the step-size truth is produced by the code under test"*. The second half is `S-a` and holds. **The first half
+is `S-b` and is FALSE** (§1). The title is editable where the pre-registration commit message is not, and
+correcting it is owed before merge.
+
+---
+
+## §0 — What this document is allowed to say
+
+Every number below is quoted from an artifact under `/mnt/d/hf_w29/`, from `/mnt/d/hf_w28/`, from
+`/mnt/d/hf_w25/`, or from a file in the repository at `HEAD`, and each is cited. The pre-registered rules in
+`docs/synthetic-af-bank-followups-wave29-design.md` are **applied as written**. Where a rule turned out to be
+unsatisfiable, under-specified or directionally wrong, that is reported as a **finding** (§6, §7, §8, §9) — it
+is not repaired, and no repaired version is scored.
+
+**Everything below is synthetic-only.** The bank has no real under-sampled dataset
+([F35](followups.md), [F43](followups.md)), and `RULE W29-L` is **one dataset, `D01_ultrawide_40mm`**, named as
+one dataset everywhere it is quoted.
+
+**Verdicts, in one table.**
+
+| rule | verdict | population | artifact |
+|---|---|---|---|
+| **`RULE W29-S`** | **`S-CARRIER-EXISTS`** — `S-a` HOLDS, `S-c` HOLDS, **`S-b` FALSE** | 4 source files at `HEAD`, by sha256 | `w29s_score.txt` |
+| **`RULE W29-R`** | **`R-STANDS`** — `k = 18`, **`c = 1`**, **`c_blind = 0`** | 18 addressable paired S1 cells under `/mnt/d/hf_w25/after` | `w29r_score.txt` |
+| **`RULE W29-L`** | **`L-UNEVALUATED`** — `joint = −12162`, not positive; shares undefined | 5 cells × 9 frames on `D01` | `w29l_score.txt` |
+| **`RULE V29`** | **`V-CLEAN`** over **7** instrument files; self-test **27 of 27**; tree **12 regions / 0 uncovered** | 7 files | `vdrift_w29.txt` |
+| **`W29-FP`** | **NO WAVE-29 BEFORE.** Cross-wave overlap `PRESERVED`, 1 080 of 1 080, 0 moved; **four roots have no baseline in this run and are NOT claimed preserved** | 2 452 files AFTER | `fp_AFTER.txt`, `fp_crosswave_check.txt` |
+
+---
+
+## §1 — THE HEADLINE: the design's own headline was HALF WRONG, and the wave's own rule refuted it
+
+**`S-b` is FALSE. A product carrier exists.**
+
+Design §1(b)'s caller table named **two** of `BuildSummaryAsync`'s **five** callers. The scorer discovered the
+full set rather than being handed it — `StartAsync` (`:3022`), `ReOptimizeWithLabelsAsync` (`:4741`),
+`ContinueOptimizationAsync` (`:4853`), `OptimizeAgainAtRecommendedBinningAsync` (`:4946`), and the one that
+matters, **`CaptureNewSweepAsync` (`StarDetectionOptimizerWizardVM.cs:5012`)**, which calls `BuildSummaryAsync`
+at **`:5098`**. `w29s_score.txt` prints the discrimination directly:
+
+```
+      driver                                                         reloads  captures               prior-round state (REPORTED)
+      StarDetectionOptimizerWizardVM.cs:CaptureNewSweepAsync         yes      RunLiveAttemptAsync    RecommendedStepSize,SelectedSummary
+      StarDetectionOptimizerWizardVM.cs:ContinueOptimizationAsync    yes      NO                     -
+      StarDetectionOptimizerWizardVM.cs:OptimizeAgainAtRecommendedBinningAsync yes      NO                     SelectedSummary
+      StarDetectionOptimizerWizardVM.cs:ReOptimizeWithLabelsAsync    yes      NO                     -
+      StarDetectionOptimizerWizardVM.cs:StartAsync                   NO       AcquireAsync           -
+    S-b(i) -> FALSE
+```
+
+And the cross-round carrier is on the instance, verified at `HEAD`: `recaptureStepSize` is declared at
+`:2608`, **assigned from the previous round's recommendation** at `:5037`
+(`recaptureStepSize = geometry != null && geometry.RecommendedStepSize != …`), the fresh sweep is taken at
+`:5071` (`RunLiveAttemptAsync`), and that sweep consumes it at `:3236`
+(`ApplyRecaptureGeometry(options, recaptureStepSize)`).
+
+**So design §1(b)'s sentence — *"No new sweep is taken between wizard rounds, so `SearchSpan` cannot change
+between them and the defect cannot occur there at all"* — is FALSE**, and with it the two claims that hang off
+it: that fix (1) *"reaches no user"*, and that F82 *"scores goal 2 zero"*. **F82 is a real product defect on a
+real product path.** The controller repeated the false claim in the pre-registration commit message
+(`544f2b2`), which cannot be edited; it is corrected in the design's CORRECTION block, in commit `80e42c5`, in
+PR #197, and here.
+
+**The instrument was written to the pre-registration and was NOT tuned.** `S-b` was implemented exactly as
+design §4 fixes it — enumerate every `Recommend(` site under the plugin assembly, resolve each site's enclosing
+recommendation builder, resolve each builder's own callers, and ask of each whether it re-captures. It returned
+**FALSE on its own terms**, against the document that commissioned it. **That is a pre-registration working**,
+and it is the only mechanism in this series that can produce this outcome: a rule written to confirm a claim
+and allowed to refute it instead.
+
+**What survives, and it is the larger half.** `S-a` **HOLDS**, and it is the finding this wave was worth
+running for:
+
+```
+ComputeStepBehavioral is DECLARED once, at source lines 1213 to 1270
+StepSizeRecommender.Recommend( call sites INSIDE that body : 1 at lines [1262]
+StepSizeRecommender.Recommend( call sites in the WHOLE file: 2 at lines [792, 1262]
+writers of the value serialized as terminal.stepBehavioral, over 70 harness file(s): 1
+S-a -> HOLDS
+```
+
+At `HEAD`, `SynthValidateRunner.ComputeStepBehavioral` is a `for (var iter = 0; iter < MaxIterations; iter++)`
+loop that calls `StepSizeRecommender.Recommend` at `:1262` and returns when `rec.StepSize == step`. **The
+harness scores the recommender against a fixed point of the recommender.** Every goal-2 conclusion in this
+series — including F82's *"a truth of 9"* — is denominated in a bar that the code under test produces. That is
+why `stepBehavioral` moved 8.0 → 9.0 across wave 25's two arms while it was identical on the other 17 cells:
+wave 25 changed `Recommend`, so it moved the bar and the measurement together. F82 recorded the symptom and
+called it *"an assumption this series can no longer make for free"*. **The cause is one line, it has been in
+the file the whole time, and nobody had looked at it.**
+
+`S-c` also **HOLDS**: `SweepDetectability` declares `FrameFocuserPositions`, reachable inside `Recommend` via
+`Recommend → MeasureMaxUsefulHalfSpan`. So the third candidate fix registered in design §4.4 remains available
+and remains **not chosen** — a wave that reads a diagnosis and picks the fix it just invented is the
+[F14](followups.md) / `RULE D20` fence in a new costume.
+
+---
+
+## §2 — `RULE W29-R` = `R-STANDS`, on evidence and not on caution
+
+Wave 26 wrote the escape clause — *"if a later wave measures that `SearchSpan` over `bestFit.Inputs`
+**shrinks on more than a single cell** while the requested sweep widens, then the defect is in the quantity and
+not in its persistence, and (2) becomes correct"* — and **three waves quoted it and none executed it.** Wave 29
+executed it, at zero compute, on artifacts already on disk.
+
+**Validity first, and it is the first column of its own tree.** The divisor was asserted at **both** trees, not
+assumed: `MaxHalfWidthSampledHalfSpanMultiple` reads `1.5` at `HEAD` **and** at the B15 tree
+`29665a62e4f8`, read out of `/mnt/d/hf_w25/binary_provenance_w25.txt` rather than typed. The population
+asserted 20 dataset directories, **18** addressable, and the gap matched **by name** — `D05_tec140_1000mm`,
+`D19_cygnus_deep_shed`. The applicability census, run before any statistic: `rounds seen 37;
+capped-or-floored and not detect-bounded 37; detect-bounded 0; neither capped nor floored 0`. The
+`wasDetectBounded` trap design §5.1 named never fired. And the reader asserted it consumed the **per-round**
+`stepRecommendation`/`bootstrap` copies and read nothing from `terminal` ([F68](followups.md) part 5), proved
+by inspecting its own source for the token.
+
+**The result.**
+
+```
+k  = 18 addressable cells (bar: k >= 2)
+c  = 1 cells with at least one qualifying transition, over the 18 addressable (bar: c >= 2)
+c_blind = 0 over the 15 cells excluding the burned ['D01_ultrawide_40mm', 'D02_rich_135mm', 'D03_redcat_250mm']
+qualifying cells, by name: ['D01_ultrawide_40mm']
+```
+
+**The one qualifying cell is `D01`, and `D01` is burned** — its rounds were published in F82's own table, and
+design §5.2 predicted its contribution before the scorer ran. Over the **15 blind cells nobody had computed
+this statistic on, `c_blind = 0`.** The identity reproduced F82's published table on the nose — `D01` r0
+`halfWidth` 12.0 ⇒ implied 16 against requested 16; r1 `halfWidth` 9.0 ⇒ implied 12 against requested 24 — and
+on all 17 other cells implied and requested moved **together, in the same direction, on every transition.**
+
+**What that does to F82's apparent generality, said plainly.** The shrink-while-widening transition that
+F82 diagnosed occurs on **exactly one cell out of 18 in the bank, and on zero of the 15 that were blind.**
+F82 is real — §1 establishes it reaches a real product path — but it is **not general**. Wave 26 named `n = 1`
+as insufficient to reverse its choice; wave 29 measured `n = 1` on a population 6× larger and blind on 15 of
+it. **The defect is not being suppressed by a lack of looking. It is rare.** Anyone pricing a fix for it should
+price it against one cell in eighteen, not against the 37-of-37 capped-or-floored population that design §1
+quantified.
+
+**Two `COULD-NOT-LOOK` cells, named, each having LEFT the denominator rather than scoring zero:**
+
+```
+  [CNL-NOREPORT] D05_tec140_1000mm      no synth_validate_report.json -- the cell produced no report
+  [CNL-NOREPORT] D19_cygnus_deep_shed   no synth_validate_report.json -- the cell produced no report
+```
+
+These are [F74](followups.md)'s two structural timeouts. They left the denominator; `k = 18`, not 20, and the
+gap was asserted by name before any statistic was taken.
+
+**On this verdict, wave 26's pre-registered choice stands: fix (1) remains correct on wave 26's grounds.** And
+§1's finding stands beside it, **changed**: it does now reach a user. Nothing ships (design §9).
+
+---
+
+## §3 — `RULE W29-L` = `L-UNEVALUATED`, and it is a control working
+
+`L-0`, the control that **can** fail, **HELD**. `L0` reproduced wave 28's published `D01` `NC = 1.0` high-tier
+attribution block **field for field, 8 fields compared, 0 disagreeing**, against
+`/mnt/d/hf_w28/nc/D01_ultrawide_40mm_nc1.0/attempt01/golden_eval.txt`. All five cells `exit=0`, all five echoed
+their intended knobs, per-cell wall times 177 / 198 / 152 / 168 / 145 s against wave 28's measured 179 s
+reference, **874 s actual against a 900–1500 s pre-registered band.**
+
+**And then opening gates made the counted misses go UP.**
+
+| cell | gate | `FN_total` (high tier) | `exclusive` | `recall@high` |
+|---|---|---|---|---|
+| `L0` | (baseline) | **50 249** | — | 0.195 (12 162 / 62 411) |
+| `L1` | `MinimumStarBoundingBoxSize` 6 → 3 | 50 246 | **3** | 0.195 (12 165 / 62 411) |
+| `L2` | `MaxDistortion` 0.5 → 0.9 | **62 411** | **−12 162** | **0.000 (0 / 62 411)** |
+| `L3` | `Sensitivity` 36.333 → 35.333 | 50 148 | **101** | 0.196 (12 263 / 62 411) |
+| `L4` | all three | **62 411** | — | **0.000 (0 / 62 411)** |
+
+```
+joint (total recoverable across all three)      : -12162
+sum of the exclusive shares                     : -12058
+COULD-NOT-LOOK: joint is -12162, which is not positive; the shares are undefined and a
+  ratio against it would be an artefact rather than a measurement.
+```
+
+**`62 411` is `D01`'s entire high-tier golden population.** `L2` and `L4` returned `TP=0 FP=0 FN=110384
+precision=NaN recall=0.000`. Every high-tier star became a false negative. The scorer refused rather than
+divide by a negative denominator, and `L-1` / `L-2` are `UNEVALUATED`.
+
+### 3.1 WHY — and it is a directional error in the pre-registration, verified from source
+
+Design §6 headed its table *"one knob relaxed per cell"* and pre-registered `L2` as `MaxDistortion` **0.5 → 0.9**.
+**That is not a relaxation. It is the strictest setting the axis can nearly express.**
+
+`StarDetector.cs:1804`:
+
+```csharp
+var effectiveMaxDistortion = ComputeEffectiveMaxDistortion(p, d);
+if (fillRatio < effectiveMaxDistortion) {   // ⇒ RecordRejection(..., RejectionGate.TooDistorted, ...)
+```
+
+`MaxDistortion` is compared as a **lower bound on the bounding-box fill ratio**. Raising it **tightens** the
+gate. `DefocusAwareGates` is `false` in `D01`'s landed tree (`optimized_settings.json`), so
+`ComputeEffectiveMaxDistortion` returns `p.MaxDistortion` verbatim and the effective threshold was exactly
+`0.9`. And the file's own comment at `:1786` gives the ceiling: *"a perfect disk fills ~PI/4 ≈ 0.79."*
+
+**`MaxDistortion = 0.9` is above the fill ratio of a perfect disk. `L2` and `L4` were guaranteed to return zero
+detections before they were run.** The corroboration is in the wall clock: `L2` (152 s) and `L4` (145 s) were
+the **two fastest** cells in the arm, because nothing survived the distortion gate to do downstream work.
+
+**This is reported, not repaired.** No clause in design §6's tree reads the *direction* of a knob edit, so the
+pre-registration could not catch it; the arm's own self-test checked that the edit was **surgical** (`33 of 33`,
+including *"exactly 1 file changed"* and *"an unnamed field is UNCHANGED"*) but surgical is not the same as
+correctly signed. The verdict stands at `L-UNEVALUATED`. The wave does not re-run `L2` at `0.1` and score that.
+
+### 3.2 What the arm DID measure, which the pre-registered statistic threw away
+
+The design's statistic is `FN_total` differences. The same artifacts carry the **per-gate** blocks, and those
+answer the question the rule was written to ask. Differencing `L0` → `L1` gate by gate:
+
+| gate | `L0` | `L1` | Δ |
+|---|---|---|---|
+| `REJECTED:TooSmall` | 11 372 | 1 835 | **−9 537** |
+| `REJECTED:TooDistorted` | 14 876 | 20 573 | **+5 697** |
+| `REJECTED:LowSensitivity` | 13 612 | 17 426 | **+3 814** |
+| `REJECTED:NotCentered` | 147 | 154 | +7 |
+| `REJECTED:OnBorder` | 77 | 87 | +10 |
+| `REJECTED:Degenerate` / `TooFlat` | — | 5 / 1 | +6 |
+| `NO CANDIDATE`, `Contaminated`, `ACCEPTED-elsewhere` | 8 931 / 533 / 701 | 8 931 / 533 / 701 | 0 |
+| **net** | | | **−3** ✓ |
+
+**Lowering the bounding-box floor from 6 to 3 released 9 537 high-tier candidates from `TooSmall`, and 99.97 %
+of them were immediately re-caught by `TooDistorted` (+5 697) and `LowSensitivity` (+3 814). Three reached
+acceptance.** That is a direct measurement of which gates bind, on real artifacts, and it is far stronger
+evidence than the subtraction the rule pre-registered — which sees only the net `−3` and cannot tell a gate
+that never fired from a gate whose entire yield was captured downstream.
+
+The `L3` difference decomposes the same way and is quoted **only** as arithmetic, per design §6's fence:
+`LowSensitivity` −122, `ACCEPTED-elsewhere` +5, `Contaminated` +4, `NotCentered` +12, net −101. **Nothing in
+this document cites `L3` as evidence for or against a bound on the sensitivity axis**
+([F84](followups.md), `RULE S16` is a permanent fence).
+
+### 3.3 What is still unknown about `D01`, said plainly
+
+**`D01` remains unlocalised.** Wave 28 converted 34 060 `NO CANDIDATE` into 33 298 gate rejections and said,
+correctly, that it had not localised them. Wave 29 has now **measured** that:
+
+- relaxing `MinimumStarBoundingBoxSize` 6 → 3 recovers **3 stars of 50 249** — **0.006 %**;
+- relaxing `Sensitivity` by one notch recovers **101 of 50 249** — **0.20 %**;
+- the third candidate gate was **never opened**, because the cell that was supposed to open it closed it
+  instead.
+
+So two of the three candidate gates move `D01` by a fifth of a percent between them, and the third is
+unmeasured. **The binding constraint on `D01` has not been found, and the two cheapest candidates for it are
+now excluded to within 0.2 %.** The gate-flow numbers in §3.2 say where to look next — `TooDistorted` and
+`LowSensitivity` jointly absorb everything the bounding-box floor releases — but that is a hypothesis this wave
+generated, not one it tested, and it is handed forward as such.
+
+---
+
+## §4 — `RULE V29` = `V-CLEAN`, and [F95](followups.md)'s remedy worked at its first half
+
+```
+=== RULE V29 -- --verify-derivation over /mnt/d/hf_w29 ===
+  files checked: 7
+  V29-A: sibling targets resolving on disk: 11 of 11 = 1.0000
+  V29-B: unlicensed previous-wave tokens: 0
+  V29-C: typed ordinals/counts in printed output: 0
+regions enumerated: 12   uncovered: 0
+>>> V-CLEAN
+```
+
+Self-test **`SELFTEST V29 27 of 27`**, clause groups `[1] [2] [3] [4] [5] [5b] [5c] [6]` all present, `[6]`
+showing both ends. **The plan's Step 1 → Step 2 ordering was executed**: the last instrument was written at
+`17:01:28Z` and the pre-flight ran at `17:35:55Z`, over a populated root of **7**. Wave 28 certified a root of
+**one file**; wave 29 did not. **That is F95's remedy and it worked.**
+
+**The remedy's second half did not run.** Design §11 named the closing `V29` as the one thing *not cut at any
+budget* — *"the first run proves the checker works, the closing run proves the wave is clean, and this series
+has been conflating them."* `vdrift_w29_FINAL.txt` is not on disk. `vdrift_instrumentcheck_w29.txt` (17:23:07Z)
+and `vdrift_w29.txt` (17:35:55Z) are byte-identical in content and **both pre-date the arm**. The remedy is
+therefore **half-executed, and the half that was cut is the half its own design said could not be cut.**
+Price to close: **~2 m.**
+
+---
+
+## §5 — `W29-FP`: what is proved, and what is NOT
+
+**There is no wave-29 BEFORE fingerprint**, because the controller ran `W29-S`, `W29-R` and the `W29-L` arm
+before Step 3 (§8, deviation (i)). What exists is an AFTER sweep of the six declared read-only roots
+(`POPULATION 2452`) and a cross-wave check against wave 28's `fp_BEFORE.txt` (mtime `2026-08-13 11:13:39 -0400`
+= `15:13:39Z`; the check's own header rounds it to `~15:36Z`).
+
+**PROVED:**
+
+```
+overlapping population, by root:
+   /mnt/d/SyntheticAutofocusBank      640
+   /mnt/d/hf_w25/table18              440
+compared 1080   MOVED 0   in BEFORE but absent from AFTER 0
+>>> CROSS-WAVE INTEGRITY = PRESERVED on the overlap (1080 files, 0 moved)
+```
+
+1 080 files across the two roots wave 28 also swept are **byte-identical from 15:13:39Z to 18:04:27Z**, i.e.
+across the whole of waves 28 and 29. That is a real and useful integrity statement.
+
+**NOT PROVED, and named as such by the artifact itself rather than left to a reader:**
+
+```
+roots in the AFTER sweep with NO baseline in this run (NOT claimed preserved):
+    /mnt/d/hf_w25/after
+    /mnt/d/hf_w25/before
+    /mnt/d/hf_w25/exe
+    /mnt/d/hf_w28/nc
+```
+
+**`/mnt/d/hf_w25/after` is the population `RULE W29-R` read, and `/mnt/d/hf_w28/nc` is the published baseline
+`L-0` scored against.** Neither has an earlier fingerprint in this run. The wave cannot claim they were
+unmodified; it can only claim that its own instruments opened them read-only, that `L-0` reproduced its
+published block field-for-field (which is itself strong indirect evidence that `/mnt/d/hf_w28/nc` is intact),
+and that the `/mnt/d/hf_w25/exe` dll sha256 matched `binary_provenance_w25.txt` before the arm's first cell.
+**`W29-FP` is not `PRESERVED`, because the rule it was written for could not be evaluated. It is recorded as
+what it is.**
+
+---
+
+## §6 — INSTRUMENT DEFECTS FOUND IN PREVIOUS WAVES' CHECKERS — report, do not repair
+
+### 6.1 `historical_ranges` was STILL broken after wave 27 fixed it and wave 28 carried it forward — the THIRD generation
+
+[F87](followups.md) is the record of this function eating its own file. Wave 27 repaired it; wave 28's design
+§12 required the repair be carried forward and demonstrated, and wave 28's self-test clause `[6]` did
+demonstrate it. **It was still broken, in a way clause `[6]` cannot see.**
+
+Wave 28's function counts brackets on the **raw** line:
+
+```python
+opens = sum(line.count(c) for c in "[{(") - sum(line.count(c) for c in "]})")
+```
+
+An unbalanced `[` or `{` **inside a string literal** therefore opens a phantom block, and the depth never
+returns to zero. Running wave 28's own function over wave 28's own file (599 lines) — measured, at analysis
+time:
+
+```
+ranges computed by WAVE 28's own function: [(93, 120), (557, 565), (579, 598)]
+  range 579 -> 598   opener line:     defonly = ['HISTORICAL_BLOCKS = ("PRIOR_BUILD_IDS", "ALLOW = [")',   # V28-OK: ...
+   *** RUNS TO EOF ***
+```
+
+The opener at line 579 is a **test fixture string** containing the literal text `"ALLOW = ["`. The raw count
+sees one unmatched `[`; the block runs to end of file. **Lines 579–598 of wave 28's own checker were exempt
+from `V28-B` and `V28-C` for the whole of wave 28**, plus 557–565 by the same mechanism — 29 of 599 lines, and
+the exempt span includes the file's tail.
+
+**Whether it hid a live drift in wave 28: it did not, and that is luck rather than design.** Wave 29's probe
+over `/mnt/d/hf_w28` reports lines 553, 558, 580 and 597, and every token in that span is **wave 28's own wave
+id**, not a foreign residue. The finding is the defect, not a concealed drift.
+
+**Wave 29's repair** blanks string literals length-preservingly before counting (`code_of`, `verify_derivation_w29.py:224`;
+`historical_ranges`, `:229–238`), keeps `is_definition`, and keeps the `opens > 0` requirement. Its self-test
+clause `[6]` now asserts all four ends, including *"a token INSIDE the declared historical literal is NOT
+reported — the exemption survives the repair, which is the half a bare 'it reports findings now' would miss."*
+
+**The register entry that matters is not the fix. It is that this function has now failed three times, each
+time with a passing self-test, because each generation's self-test tested the ends the previous generation
+broke.**
+
+### 6.2 `V28-C`'s population was effectively EMPTY on every wave-28 scorer — measured
+
+`V29-C` / `V28-C` is *"typed ordinals or counts in printed output"*. The clause finds a printing line with this
+regex. Wave 28's:
+
+```python
+PRINTS = re.compile(r"\b(print|log|echo|printf|Prog|tee)\b")
+```
+
+Wave 28's three scorers emit through `out.write(`, which matches none of those tokens. Measured over
+`score_w28b.py`, `score_w28n.py`, `score_w28s.py`:
+
+```
+out.write( lines total : 126        (36 + 52 + 38)
+matched by w28 PRINTS  : 2
+matched by w29 PRINTS  : 126
+```
+
+**124 of 126 printing lines in wave 28's three scorers were never scanned for a typed ordinal.** The two that
+did match matched incidentally — the *string being written* happened to contain one of the keywords. **Wave
+28's `V28-C: 0` was vacuous**: the clause returned zero because its population was almost empty, not because
+the scorers were clean.
+
+Wave 29's regex is widened to reach the method-call form:
+
+```python
+PRINTS = re.compile(r"\b(?:\w*[._])?(?:printf|print|echo|log|write|emit|say|tee|Prog)\b")
+```
+
+and the widening is **demonstrated**, not asserted — self-test clause `[3]` carries
+*"ok: V29-C via out.write fired on its own mutant"* and *"ok: V29-C via an underscored helper fired on its own
+mutant"*. On the wave-29 root, `V29-C: 0` over 7 files with the population now real.
+
+**This is the same shape as §6.1 and it should be read as one finding in two places: a clause can pass for
+three waves because its population is empty, and nothing in the verdict tree distinguishes "zero findings" from
+"zero candidates".**
+
+### 6.3 The per-clause fixture expiry REPEATED EXACTLY AS PREDICTED — the strongest evidence class this series has
+
+Wave 28 pinned `/mnt/d/hf_w27` as its live `-B` fixture and wrote into its own instrument's header that such a
+pin **goes silent exactly one wave later**, because `PREV` moves. Wave 29's plan §1a therefore forbade
+inheriting the choice and required measuring it. The four probes, run 17:20:58–17:21:32Z:
+
+| root | `V29-A` | `V29-B` | `V29-C` | role at wave 29 |
+|---|---|---|---|---|
+| `/mnt/d/hf_w24` | 1 of 1 | **0** | **2** | the durable **`-C`** fixture, third wave running |
+| `/mnt/d/hf_w26` | 2 of 6 | **0** | 1 | expired at wave 28, **still asserted silent** |
+| `/mnt/d/hf_w27` | 1 of 5 | **0** | 1 | **EXPIRED — wave 28's live `-B` fixture, now silent** |
+| `/mnt/d/hf_w28` | 0 of 5 | **100** | 1 | the new live **`-B`** fixture |
+
+Self-test `[5b]` records all four, including *"ok: `/mnt/d/hf_w27` yields ZERO `V29-B` findings — THE EXPIRY IS
+DEMONSTRATED, which is why the `-B` fixture is pinned separately and re-measured every wave."*
+
+**Why this is the strongest evidence class available here.** It is a **prediction written into an instrument's
+own header one wave before the measurement**, with a stated mechanism (`PREV` advances, so last wave's tokens
+stop being "previous-wave"), and it was confirmed by a measurement designed before the answer was known.
+Everything else in this series is a rule scored against artifacts that already existed. This is the one place
+where the series made a falsifiable forward claim about its own instruments and then checked it. **`hf_w27`
+went from 100-class `-B` findings to zero in exactly one wave, as written.** Wave 30 must re-measure again;
+`/mnt/d/hf_w28` will be the next to expire.
+
+---
+
+## §7 — A BLINDNESS BURN, caused by the instrument, recorded as a wave-29 deviation
+
+Design §7's ledger says, verbatim: *"`halfWidth`, `bootstrap.offsetSteps` and `bootstrap.stepSize` have been
+read on `D01` only (published), and the requested-vs-implied comparison has **never** been computed on any
+other cell."*
+
+**That claim is now false, and wave 29 made it false.** While validating `RULE W29-R`'s identity, the
+instrument agent computed the requested-vs-implied comparison on **all 18 addressable cells, including the 15
+blind ones**, and `w29r_score.txt` prints all 18 rows in full — `halfWidth`, implied span, requested span and
+the qualification for every cell from `D01` to `D20`.
+
+**The rule was NOT tuned.** `W29-R` was implemented exactly as design §5.3 writes it: `c` over 18, `c_blind`
+over 15, the verdict taken on `c ≥ 2` as wave 26 wrote it, both printed so no reader has to do the arithmetic.
+The burn is not a change to the statistic — it is that **computing the statistic and publishing the per-cell
+table are the same act**, and design §7 wrote a blindness claim that the design's own §5.3 instrument was
+guaranteed to violate.
+
+**Scope of the burn, stated for whoever inherits it.** The 15 blind cells' per-round `halfWidth`,
+`bootstrap.offsetSteps`, `bootstrap.stepSize`, implied span and requested span are **now published**. Any
+future rule over `SearchSpan` persistence on `/mnt/d/hf_w25/after` has **no blind population left in this
+bank.** `W29-R`'s own verdict is unaffected — it was taken on the first computation of the statistic, which is
+what blindness protects — but it is the **last** verdict on this population that can claim it.
+
+**The structural lesson, and it belongs in the register:** a blindness ledger that promises a quantity will
+stay unread, while the same document pre-registers an instrument that must read it to produce its verdict, is
+internally inconsistent at pre-registration time. Nothing checked the ledger against the instruments.
+
+---
+
+## §8 — CONTROLLER DEVIATIONS
+
+**(i) The BEFORE fingerprint was never taken, and three measurements ran ahead of it.** The plan's Step 3
+places `W29-FP` BEFORE ahead of Steps 4–6. The controller ran `RULE W29-S` (17:36:08Z), `RULE W29-R`
+(17:36:19Z) and the whole `W29-L` arm (17:36:49–17:51:23Z) **first**, and only then swept
+(17:52:45 → 18:04:27Z). `fp_BEFORE.txt` does not exist.
+
+**What that costs, exactly.** `fp_AFTER.txt` is an integrity check with no wave-29 BEFORE. The two roots that
+overlap wave 28's sweep — `/mnt/d/hf_w25/table18` (440) and `/mnt/d/SyntheticAutofocusBank` (640) — do have a
+usable earlier baseline in wave 28's `fp_BEFORE.txt` (15:13:39Z), and across it **1 080 of 1 080 are
+byte-identical, 0 moved**. The other four roots — `/mnt/d/hf_w25/{after,before,exe}` and `/mnt/d/hf_w28/nc` —
+**have no baseline in this run at all**, and the cross-wave artifact names them rather than reporting them
+preserved. `W29-FP` did not reach `PRESERVED` and is not claimed to have. §5 states what is and is not proved.
+
+**(ii) The `--out` and `--rule` conventions in the plan's own command lines were wrong**, and the controller
+used the instrument headers' forms instead. The instance verifiable from artifacts: `fp_w29.sh`'s own header
+documents `bash fp_w29.sh before --out <file> [--rule W29-FP]` and `bash fp_w29.sh after --out <file>
+[--rule W29-FP]`, while the plan's Steps 3 and 8 write `bash /mnt/d/hf_w29/fp_w29.sh after` with no `--out` —
+against a standing constraint (design §12) that **`--out` is mandatory and every instrument refuses without
+it**. The plan's Step 1a probe loop likewise omits `--rule`, which the three scorers require and the verifier
+does not accept. **The plan's command lines were not checked against the instruments the plan itself
+commissioned.**
+
+**(iii) Steps 7 and 8's second half did not run.** [F83](followups.md)'s `P-D08` at `n = 3` (~2 m) has no
+artifact, against design §11's explicit *"an item under two minutes is never dropped"* and its citation of
+`RULE C19`. The closing `V29` has no artifact, against design §11's *"NOT cut, at any budget."* Neither is
+laundered as done; both are priced in §11.
+
+**(iv) No scorer `--self-test` capture is on disk.** The plan's Step 4 and Step 6 gates name
+`w29s_selftest.txt` and `w29l_selftest.txt`; the arm driver's and the verifier's self-tests **are** captured
+(`SELFTEST W29L-ARM 33 of 33`, `SELFTEST V29 27 of 27`), the three scorers' are not. Wave 28's §7.7 recorded
+the identical class of omission for `fp_w28.sh`. **Named, not assumed.**
+
+---
+
+## §9 — UNDER-SPECIFIED IN THE PLAN, per the instrument agent
+
+| the plan said | what was true |
+|---|---|
+| *"Five files under `/mnt/d/hf_w29/`"* (Step 1) | **Seven.** `V29` reports `files checked: 7` — `layout_w29.sh` (the shared layout function design §12 requires) and the split of the `W29-L` driver from its scorer were never counted |
+| edit `MinimumStarBoundingBoxSize` and `Sensitivity` (design §6, `StarDetectorParams` spellings) | The file the arm edits is `optimized_settings.json`, whose keys are **`MinStarBoundingBoxSize`** and **`BrightnessSensitivity`**. The arm's self-test `[4]` asserts the landed FROM values against the tree by those names, and `[6]` proves *"editing a field the file does not declare REFUSES rather than inventing it"* — so the mismatch was caught by an instrument rather than by the plan |
+| *"`Sensitivity` relaxed one notch"* (design §6, `L3`) | **"One notch" was undefined.** Read at run time from the product's own axis declaration — `OptimizerVariable.cs:168`, `Continuous(nameof(StarDetectorParams.Sensitivity), …, 1.0, …)` — giving `36.333 → 35.333`. That is a **2.75 %** relaxation, which is why `exclusive(Sensitivity)` is only **101** and is weak evidence for anything |
+| *"pins `--settings`"* (plan Step 6) | Pinned to **the file wave 28's own log records** — `C:\Users\ghili\AppData\Local\HocusFocusHarness\harness_settings.json`, sha256 `b7e81813…` — recorded in the manifest, because the plan named no file |
+| `binary_provenance_w25.txt` line `tree:` (plan Step 5) | **The `tree:` line holds a COMMIT.** `git cat-file -t 29665a62e4f8` returns `commit` (`29665a6 W25: floor the half-width when the sweep demonstrably never reached the band`). The assertion works, and the field name is wrong wherever it is quoted |
+| the `MaxDistortion` direction (design §6) | Not specified at all, and wrong — §3.1 |
+
+---
+
+## §10 — [F21](followups.md): estimate vs actual, per step, and the budget error
+
+| step | est | actual | note |
+|---|---|---|---|
+| 0 vessel + pre-registration | 10 m | — | two commits (`544f2b2`, `80e42c5`); `T0.txt` never written, so no in-band start stamp |
+| 1 write **all** instruments | 60 m | **~37 m** | first write `16:41:51Z` (`layout_w29.sh`), last `17:18:45Z` (`verify_derivation_w29.py`) |
+| 2 `RULE V29` pre-flight | 20 m | **~15 m** | probes `17:20:58Z` → verdict `17:35:55Z` |
+| 3 `W29-FP` BEFORE | 8 m | **NOT RUN** | and mispriced — see below |
+| 4 `RULE W29-S` | 25 m | **~13 s** at run time | zero compute; the cost was paid in Step 1 |
+| 5 `RULE W29-R` | 25 m | **~11 s** at run time | zero compute; likewise |
+| 6 `RULE W29-L` arm + scoring | 55 m / ~25 m compute | **15 m 32 s**, of which **14 m 34 s** compute | `17:36:41Z → 17:52:13Z`; arm 874 s against its own 900–1500 s band |
+| 7 `P-D08` at `n = 3` | 2 m | **NOT RUN** | §8 (iii) |
+| 8 fingerprint AFTER + closing `V29` | 12 m | **12 m 19 s for the AFTER half alone**; closing `V29` NOT RUN | `17:52:45Z → 18:05:04Z` |
+| 9 results | 75 m | this document | |
+
+**The budget error, and it is the one durable number here.** The six declared read-only roots measure
+**~41.8 GB** (`hf_w25/after` 17 G, `hf_w25/before` 15 G, `SyntheticAutofocusBank` 8.7 G, `hf_w28/nc` 889 M,
+`hf_w25/exe` 196 M, `hf_w25/table18` 14 M). The AFTER sweep hashed all 2 452 files in **11 m 42 s**
+(`17:52:45Z → 18:04:27Z`) — **~61 MB/s**. The plan priced **Step 3 at 8 m** (a sweep alone is 1.5× that) and
+**Step 8 at 12 m** to cover a second sweep *plus* the reversal check *plus* the closing `V29` (the sweep alone
+consumed it, and the closing run is why Step 8 is ~2× under). **Steps 3 and 8 are both under-priced by ~1.5–2×,
+and the omission in §8 (iii) is downstream of the mispricing, not independent of it.** A wave declaring these
+six roots owes **~24 m of pure I/O** for a two-sided fingerprint and should price it from the measured
+61 MB/s, not from instinct.
+
+Design §11 predicted the analysis halves would again come in under (wave 28 ~59 % under, wave 27 ~36 %). They
+did — Steps 1, 2, 4, 5 and 6 all landed under. **The compute step priced from a measured rate (Step 6) was the
+most accurate one in the wave**, and the two steps priced from instinct (3 and 8) were the only ones that
+overran. That is the fourth consecutive confirmation of the same lesson and it is now boring: *price compute
+from the measured rate.*
+
+---
+
+## §11 — WHAT WAS NOT RUN, AND WHAT IT COSTS
+
+| not run | price | why, and is it owed |
+|---|---|---|
+| **the 42 m `optimize` gate** | **42 m** measured (wave 25: 42 m 43 s, ~5.2 m/run, seven consecutive waves); predicted verdict `G-PASS`, 8 of 8 bit-identical to K8 | **NOT OWED this wave, and it is checked rather than asserted.** `git diff --name-only 6ffa498..HEAD -- '*.cs'` is **empty** — wave 29's two commits touch `docs/…wave29-design.md` and `plans/…wave29-plan.md` and nothing else — and no binary was built: the arm ran `/mnt/d/hf_w25/exe`, dll sha256 `2fb0c8fd…` asserted against `binary_provenance_w25.txt` before its first cell. **All three of design §8's reversal conditions are negative.** **It is owed, certainly and not probably, by the wave that ships any F82 fix** — `Q27-V1`'s own FAIL end names `StepSizeRecommender.cs` by path |
+| **a wave-29 BEFORE fingerprint** | **~12 m** (measured: 11 m 42 s at 61 MB/s over 41.8 GB) | Owed by the plan and not taken (§8 (i)). Cannot be recovered retroactively — a BEFORE taken now is an AFTER. **The next wave must take it first, or declare fewer roots** |
+| **the closing `V29`** | **~2 m** | Owed by design §11's *"NOT cut, at any budget"*. F95's remedy is half-executed (§4) |
+| **`P-D08` at `n = 3`** | **~2 m** | Owed by charter §4 and design §11's cut-list, which explicitly refused to cut it |
+| **the three scorers' self-test captures** | **~5 m** | The gates the plan wrote for Steps 4/5/6 (§8 (iv)) |
+| **localising `D01`** | **~25 m** compute for a corrected 3-cell arm (`MaxDistortion` **lowered**, plus the two gates §3.2 identifies), on the binary already on disk | **The wave's largest open question and it is still open.** Two candidate gates now excluded to within 0.2 %; the third was never opened; §3.2 names `TooDistorted` + `LowSensitivity` as where the released candidates go |
+| the unit suite | ~4 m | **Vacuously satisfied** — no C# changed. Baseline for the wave that does change it is **3997** (wave 28's measured close), not the charter's stale 3973 |
+| a full paired 18-cell S1 arm | ~2 h 40 m | Unchanged: `W-UNEXERCISED` means a second arm buys a second `SAME 13` |
+| `S27-1` and wave 27's three mutants | ~20 m | **STILL OPEN, THREE waves running.** Named again so it is not lost a fourth time |
+| wave 28's `M1`–`M6` mutant records | ~10 m | Not applicable — wave 29 ships nothing and writes no test. Wave 28's debt stays wave 28's |
+| new datasets between 1.4 and 19.4 ″/px | ≥ 1 h render | The only route to a **blind** wide-field dataset; the coverage hole is unchanged, and §7 has now spent the blindness that existed |
+| the blur/layer decoupling build ([F92](followups.md)) | ~45 m + 10 m (+ 42 m to ship) | Unchanged |
+| the `A4` truth-model gap | 20 m code **+ 42 m gate** | And §1 has now made it **more** urgent, not less: `S-a` shows the harness's own bar is produced by the code under test |
+| anything on real frames | — | The bank has no real under-sampled dataset |
+
+---
+
+## §12 — REGISTER ENTRIES, READY TO PASTE
+
+The register's highest existing entry is **F95**. These continue from it.
+
+---
+
+### F96 — The harness's `stepBehavioral` "truth" is a fixed point of the recommender it scores, so every goal-2 conclusion is denominated in a bar the code under test produces
+
+**Status:** Open (diagnosed to a line; no fix priced) · found 2026-08-13, wave 29, `RULE W29-S` clause `S-a`
+= HOLDS · `/mnt/d/hf_w29/w29s_score.txt`
+
+`SynthValidateRunner.ComputeStepBehavioral` (`:1213–1270`) builds an analytic curve, fits it, calls
+`StepSizeRecommender.Recommend` at **`:1262`**, and loops until `rec.StepSize == step`. `RULE W29-S` asserts
+from source, at `HEAD`, by sha256, that the method is **declared once**, contains **exactly one** `Recommend(`
+call site inside its body (whole-file count 2, at `:792` and `:1262`, printed so the scoping is visibly doing
+work), and is the **only writer** over 70 harness files of the value serialized as `terminal.stepBehavioral`.
+
+**Consequence.** A change to `Recommend` moves the bar **and** the measurement together. This is the mechanism
+behind [F82](#f82)'s observation that `stepBehavioral` moved 8.0 → 9.0 across wave 25's two arms while it was
+identical on the other 17 cells: wave 25 changed `Recommend`. **Assertion `A3`, and every goal-2 statement in
+waves 20–29 that quotes `stepBehavioral` as truth, is a self-consistency check and not an accuracy measurement.**
+
+**What it does NOT say.** It does not say the recommender is wrong; a fixed point can be correct. It says the
+harness cannot tell. **The remedy is a spec-derived truth model** — backlog item 4's `A4` gap, priced at 20 m
+of code **+ 42 m of gate** because it rebuilds `TestApp`.
+
+**Note on scope.** Design §14 pre-registered F96 as a two-part entry — the truth-model coupling **and** "F82's
+fix has no product carrier" — to be **withdrawn in place** on `S-CARRIER-EXISTS`. The verdict was
+`S-CARRIER-EXISTS`, so **the carrier half is withdrawn and is not registered.** The coupling half is `S-a`,
+which held, and stands.
+
+---
+
+### F97 — F82's shrink-while-widening transition occurs on exactly ONE cell in the bank, and on ZERO of the fifteen that were blind
+
+**Status:** Open (measured; F82's fix choice unchanged) · found 2026-08-13, wave 29, `RULE W29-R` =
+**`R-STANDS`** · `/mnt/d/hf_w29/w29r_score.txt`
+
+Wave 26 pre-registered a reversal condition on its choice between F82's two fixes — *"if a later wave measures
+that `SearchSpan` … shrinks on more than a single cell while the requested sweep widens, then … (2) becomes
+correct."* **Three waves quoted it; none ran it.** Wave 29 ran it at zero compute over the 18 addressable
+paired S1 cells under `/mnt/d/hf_w25/after`, via the exact inversion
+`impliedSearchSpan = stepRecommendation.halfWidth / (1.5 × 0.5)`, with the multiple asserted `= 1.5` at **both**
+the B15 tree `29665a62e4f8` and `HEAD`, and with all 37 rounds confirmed capped-or-floored and none
+detect-bounded before any statistic was taken.
+
+```
+k = 18   c = 1   c_blind = 0   qualifying cells: ['D01_ultrawide_40mm']
+```
+
+**`c = 1`, and the one cell is `D01`, which was already burned.** `D05_tec140_1000mm` and
+`D19_cygnus_deep_shed` produced no report and **left the denominator** as named `CNL-NOREPORT`, never as zeros.
+
+**What this changes.** F82 is real and (per [F98's sibling finding in `RULE W29-S`](#f96)) reaches a real
+product path — but it is **rare, not general**: one cell in eighteen, zero in fifteen blind. On all 17 other
+cells the implied and requested spans move together on every transition. **Anyone pricing a fix should price it
+against 1 of 18, not against the 37-of-37 capped-or-floored population.** Wave 26's choice of fix (1) stands on
+wave 26's own grounds; the reversal condition is now **evaluated** rather than merely unexamined.
+
+**Blindness spent.** Producing this verdict required publishing the per-cell table for all 18 cells, so the 15
+formerly-blind cells' `halfWidth`/`bootstrap`/implied-span values are now read. See F100.
+
+---
+
+### F98 — `MaxDistortion` is a MINIMUM fill-ratio despite its name, and 0.9 is above the ~0.79 ceiling of a perfect disk, so a whole arm cell was dead before it ran
+
+**Status:** Open — **candidate goal-3 product finding** · found 2026-08-13, wave 29, `RULE W29-L` =
+**`L-UNEVALUATED`** · `/mnt/d/hf_w29/w29l_score.txt`, `/mnt/d/hf_w29/l/out/L{0,2,4}.log`
+
+`StarDetector.cs:1804` rejects a candidate as `TooDistorted` when `fillRatio < effectiveMaxDistortion`. The
+parameter is a **lower bound on bounding-box fill ratio**; **raising it tightens the gate.** The file's own
+comment at `:1786` states the ceiling: *"a perfect disk fills ~PI/4 ≈ 0.79."* With `DefocusAwareGates: false`
+in `D01`'s landed tree, `ComputeEffectiveMaxDistortion` returns `p.MaxDistortion` verbatim.
+
+Wave 29's design §6 pre-registered `MaxDistortion` **0.5 → 0.9** under the heading *"one knob relaxed per
+cell"*. Measured result on `D01`, 9 frames: **`TP=0 FP=0 FN=110384`, `recall@high = 0.000 (0/62 411)`** on
+both `L2` and `L4` — total detection collapse. Corroborated by wall clock: `L2` (152 s) and `L4` (145 s) were
+the two **fastest** cells in a five-cell arm, because nothing survived the gate to do downstream work.
+
+**Two findings, and they are separable.**
+
+1. **The instrument finding.** A pre-registration can specify a knob edit whose *direction* no clause reads.
+   The arm's self-test proved the edit was **surgical** (`33 of 33`, *"exactly 1 file changed"*, *"an unnamed
+   field is UNCHANGED"*) — surgical is not correctly signed. `RULE W29-L`'s verdict is
+   **`L-UNEVALUATED`** and it stands; the cell was not re-run at a corrected value and scored.
+2. **The product finding.** `OptimizerVariable.cs:176` declares the searchable axis
+   `Continuous(nameof(StarDetectorParams.MaxDistortion), 0.1, 1.0, 0.1)`. **The upper ~21 % of that axis
+   (> π/4 ≈ 0.785) is provably detection-killing for round stars** — any value above the perfect-disk fill
+   ratio rejects every candidate. A searchable range whose top fifth returns zero detections is a parameter
+   space that wastes optimizer evaluations, and the name `MaxDistortion` reads as the opposite of what it
+   gates. **Worth ~20 m to bound the axis at π/4 and rename or document the field; owes the 42 m gate because
+   it touches plugin code.**
+
+---
+
+### F99 — Relaxing the bounding-box floor on `D01` releases 9 537 candidates and three survive: the binding gates are downstream, and the pre-registered statistic could not see it
+
+**Status:** Open — the hypothesis wave 30 should pre-register · found 2026-08-13, wave 29 ·
+`/mnt/d/hf_w29/l/out/L{0,1}/attempt01/golden_eval.txt`
+
+`RULE W29-L`'s pre-registered statistic is the difference in `FN_total`. On `D01`, lowering
+`MinStarBoundingBoxSize` 6 → 3 gives `FN_total` 50 249 → 50 246, i.e. **−3**, which reads as "this gate does
+almost nothing". The per-gate blocks in the same artifact say otherwise:
+
+| gate | `L0` | `L1` (MinBox 6→3) | Δ |
+|---|---|---|---|
+| `REJECTED:TooSmall` | 11 372 | 1 835 | **−9 537** |
+| `REJECTED:TooDistorted` | 14 876 | 20 573 | **+5 697** |
+| `REJECTED:LowSensitivity` | 13 612 | 17 426 | **+3 814** |
+| others | | | +23 |
+
+**9 537 high-tier candidates were released from the bounding-box floor and 99.97 % of them were immediately
+re-caught by `TooDistorted` and `LowSensitivity`. Three reached acceptance.** The gate is not inert; its entire
+yield is absorbed one and two gates downstream.
+
+**The lesson is about the statistic, not the detector.** A first-rejection-wins attribution differenced only at
+the *total* cannot distinguish a gate that never fires from a gate whose output is fully captured downstream.
+**Wave 30's rule over sequential gates must read the per-gate flow, not the net.** And the substantive
+hypothesis this generates, stated so it can be wrong: **`D01`'s binding constraint is `TooDistorted`, jointly
+with `LowSensitivity`, and no single-knob change recovers it** — which is `L-JOINTLY-BOUND`'s claim arrived at
+by a different route than the rule that could not evaluate it.
+
+---
+
+### F100 — A blindness ledger that promises a quantity will stay unread, beside an instrument that must read it, burns the population at pre-registration time
+
+**Status:** Recorded (the burn is spent; the structural fix is cheap) · found 2026-08-13, wave 29 ·
+design §7 vs `/mnt/d/hf_w29/w29r_score.txt`
+
+Wave 29's design §7 wrote: *"the requested-vs-implied comparison has **never** been computed on any other
+cell"*, and named the 15 non-burned cells as **BLIND, and carrying `W29-R`'s verdict**. The same document's
+§5.3 pre-registered a scorer that computes exactly that comparison over all 18 addressable cells and prints
+`c` and `c_blind`. **`w29r_score.txt` publishes the full 18-row table.** The ledger's claim is now false, and
+the instrument that falsified it was commissioned by the document that made the claim.
+
+**The rule was not tuned** — `W29-R` is implemented exactly as §5.3 writes it, and its verdict was taken on the
+first computation of the statistic, which is what blindness protects. **But it is the last verdict on this
+population that can claim blindness.** Any future rule over `SearchSpan` persistence on `/mnt/d/hf_w25/after`
+has no blind cells left.
+
+**Fix, ~5 m per wave:** the design's blindness ledger must be checked against the design's own instrument
+specifications before the pre-registration commit — every quantity the ledger promises stays unread must not
+appear in any clause's per-member output. Nothing does this today.
+
+---
+
+### F101 — The derivation checker's `historical_ranges` has now failed THREE generations, each time with a passing self-test
+
+**Status:** Repaired in wave 29's checker; the pattern is the entry · found 2026-08-13, wave 29 ·
+`/mnt/d/hf_w28/verify_derivation_w28.py:579`, `/mnt/d/hf_w29/verify_derivation_w29.py:224–238`
+
+[F87](followups.md) recorded this function eating its own file; wave 27 repaired it; wave 28's design required
+the repair be carried forward and demonstrated, and wave 28's self-test clause `[6]` did demonstrate both ends
+it knew about. **It was still broken.** Wave 28 counted brackets on the **raw** line, so an unbalanced `[` or
+`{` inside a **string literal** opened a phantom block that ran to EOF. Measured on wave 28's own 599-line
+file:
+
+```
+ranges computed by WAVE 28's own function: [(93, 120), (557, 565), (579, 598)]
+  range 579 -> 598   opener: defonly = ['HISTORICAL_BLOCKS = ("PRIOR_BUILD_IDS", "ALLOW = [")',  ...
+   *** RUNS TO EOF ***
+```
+
+**29 of 599 lines of wave 28's own checker, including its tail, were exempt from `V28-B` and `V28-C` for the
+whole of wave 28.** It concealed nothing — every token in the exempt span is wave 28's own wave id — and that
+is luck, not design. Wave 29 blanks string literals length-preservingly before counting and asserts all four
+ends in clause `[6]`, including *"a token INSIDE the declared historical literal is NOT reported"*.
+
+**The durable finding is the pattern:** three generations, three passing self-tests, because each generation's
+self-test tested the ends the previous generation broke. **A self-test that only covers the last bug found is a
+regression test, not a specification.**
+
+---
+
+### F102 — `V28-C` returned zero because its population was almost empty: 124 of 126 printing lines in wave 28's scorers were never scanned
+
+**Status:** Repaired in wave 29's checker; the vacuity class is the entry · found 2026-08-13, wave 29 ·
+`/mnt/d/hf_w28/verify_derivation_w28.py:170`, `/mnt/d/hf_w29/verify_derivation_w29.py:160`
+
+`V*-C` forbids typed ordinals and counts in an instrument's printed output. Wave 28's line-selector was
+`\b(print|log|echo|printf|Prog|tee)\b`; wave 28's three scorers emit through `out.write(`, which matches none
+of it. Measured over `score_w28b.py` (36), `score_w28n.py` (52), `score_w28s.py` (38):
+
+```
+out.write( lines total : 126
+matched by w28 PRINTS  : 2      (incidentally -- the string being WRITTEN contained a keyword)
+matched by w29 PRINTS  : 126
+```
+
+**Wave 28's `V28-C: 0` was vacuous.** Wave 29 widened the selector to
+`\b(?:\w*[._])?(?:printf|print|echo|log|write|emit|say|tee|Prog)\b` and **demonstrated** the widening rather
+than asserting it — self-test `[3]` carries *"V29-C via `out.write` fired on its own mutant"* and *"V29-C via
+an underscored helper fired on its own mutant"*.
+
+**The class, which is the same as F101's and should be read with it:** a clause can pass for three waves
+because it has no candidates, and **no verdict tree in this series distinguishes "zero findings" from "zero
+candidates".** [F94](followups.md) made trees total over their *outcomes*; nothing makes a clause report its
+*population*. **~10 m to make every clause print `candidates: N   findings: M` and refuse on `N = 0` where a
+population is expected.**
+
+---
+
+### F103 — A pinned per-clause fixture goes silent exactly one wave later, as predicted in an instrument's own header and confirmed by measurement
+
+**Status:** Closed as a mechanism; standing obligation to re-measure each wave · found 2026-08-13, wave 29 ·
+`/mnt/d/hf_w29/vdrift_selftest_w29.txt` `[5b]`, `vdrift_probe_hf_w2{4,6,7,8}.txt`
+
+Wave 28 pinned `/mnt/d/hf_w27` as its live `V28-B` fixture and wrote into its own instrument's header that such
+a pin expires one wave later, because `PREV` advances and last wave's tokens stop being "previous-wave". Wave
+29 measured all four candidate roots before pinning anything:
+
+| root | `-A` resolving | `-B` findings | `-C` findings | role |
+|---|---|---|---|---|
+| `hf_w24` | 1 of 1 | 0 | **2** | durable `-C` fixture, third wave running |
+| `hf_w26` | 2 of 6 | **0** | 1 | expired at wave 28; kept and **asserted silent** |
+| `hf_w27` | 1 of 5 | **0** | 1 | **EXPIRED as predicted** — wave 28's live `-B` |
+| `hf_w28` | 0 of 5 | **100** | 1 | the new live `-B` |
+
+**This is the strongest evidence class this series has produced**, and the reason is structural: it is a
+**falsifiable forward claim about the instruments, written before the measurement, with a stated mechanism, and
+checked one wave later.** Everything else in the series is a rule scored against artifacts that already
+existed. **`hf_w28` is next to expire; wave 30 must re-measure and must treat a clause with no live fixture as
+a FAIL, not a pass.**
+
+---
+
+### AMENDMENTS TO EXISTING ENTRIES
+
+**[F82](followups.md) — AMEND IN PLACE. Its fix choice stands; its scope, its generality and its truth
+model are now measured.** Append:
+
+> **Amended 2026-08-13, wave 29.** Three things about this entry were unmeasured when it was written.
+>
+> 1. **The "truth of 9" is a PRODUCT-DERIVED FIXED POINT, not a spec-derived truth.** `terminal.stepBehavioral`
+>    is `StepSizeRecommender.Recommend` iterated to a fixed point by
+>    `SynthValidateRunner.ComputeStepBehavioral:1262` — see **F96**. `D01`'s stall is measured against a bar the
+>    recommender itself produces, and wave 25 moved both together.
+> 2. **"Confined to the recommender's caller state" names a caller, and it is
+>    `StarDetectionOptimizerWizardVM.CaptureNewSweepAsync` (`:5012`).** `RULE W29-S` clause `S-b` returned
+>    **FALSE**: of `BuildSummaryAsync`'s five callers, `CaptureNewSweepAsync` takes a **fresh sweep**
+>    (`RunLiveAttemptAsync`, `:5071`), calls `BuildSummaryAsync` at `:5098`, and carries the previous round's
+>    recommended geometry forward through the instance field `recaptureStepSize` (`:2608`, assigned `:5037`,
+>    consumed `:3236`). **F82 is a real product defect on a real product path**, and the wave-29
+>    pre-registration's claim that it "reaches no user" and "scores goal 2 zero" is **withdrawn**.
+> 3. **Its generality is one cell in eighteen.** `RULE W29-R` = `R-STANDS`: `k = 18`, `c = 1`, `c_blind = 0`.
+>    The only qualifying cell is `D01` itself. See **F97**. Wave 26's choice of fix (1) stands, on wave 26's
+>    own grounds, with the escape clause now **evaluated** rather than unexamined.
+> 4. **A third candidate fix is registered and deliberately NOT chosen** (wave 29 design §4.4): bound
+>    `maxHalfWidth` below by the span the sweep actually **requested**, guarded by
+>    `BandDemonstrablyUnsampled(sampledHfrRange)`. `RULE W29-S` clause `S-c` **HOLDS** — the requested positions
+>    are in `SweepDetectability.FrameFocuserPositions`, reachable inside `Recommend` via
+>    `MeasureMaxUsefulHalfSpan`. It needs **no cross-round state and no `A3` re-derivation**, which makes it the
+>    cheapest of the three (~45 m + a 3-cell re-run + the 42 m gate) and is precisely why the wave that thought
+>    of it did not select it. **The next wave pre-registers the choice among three.**
+
+**[F81](followups.md)** — append: the floor F81 shipped **is** reached in the product on a re-swept round, not
+only at round 0 of a session. `CaptureNewSweepAsync` (`:5012`) re-captures and carries `recaptureStepSize`
+forward, so the wizard's `Capture new sweep` path has genuine cross-round sweep state. The `Continue` and
+`Re-optimize` paths do not — they call `LoadRunStampedAsync` and re-optimize already-captured frames — so on
+those two the floor is inert after round 0, and that half of the original claim stands.
+
+**[F94](followups.md)** — append: wave 29's design §10 is the first in the series to publish its own outcome
+space as a table, and **every scorer re-derived it in code and agreed with the published counts**: `W29-S`
+**8 / 0 uncovered**, `W29-R` **4 / 0**, `W29-L` **8 / 0** — matching design §10's three tables exactly — and
+`V29`, which §10 declared as inheriting wave 28's tree without a count, re-derived **12 / 0** including the
+`A=None` empty-population region. The two logically-unreachable regions (`R-INCOHERENT`, `L-INCOHERENT`) are
+present, asserted empty, and checked against the measured numbers (`c = 1 ≤ k = 18 is True`; `L-1 ∧ L-2 =
+False`). **The remedy works for outcome coverage.** It does **not** cover two adjacent failures found this wave: a clause whose *population* is
+empty (**F102**) and a clause whose realized value is **neither `True` nor `False`** — `W29-L` ended at
+`L-0 = True, L-1 = None, L-2 = None`, a state outside the enumerated boolean cube, yet the scorer still printed
+`uncovered: 0` and appended a canned `READING:` line saying *"the control did not hold"* **when `L-0` in fact
+HELD**. The tree was total over booleans and the run was not a boolean. **Trees must enumerate `None` as a
+clause value, and a verdict's explanatory text must be derived from the clause values rather than templated per
+verdict name.**
+
+**[F95](followups.md)** — append: **the remedy's first half works and was proved this wave.** Wave 29's plan
+ordered instruments (Step 1) before the blocking pre-flight (Step 2); the last instrument was written at
+`17:01:28Z`, the pre-flight ran at `17:35:55Z` over a **populated root of 7 files**, and returned `V-CLEAN`
+with `SELFTEST V29 27 of 27`. Wave 28's equivalent certified **one file**. **The second half did not run** —
+the closing `V29` (`vdrift_w29_FINAL.txt`) has no artifact, against design §11's *"NOT cut, at any budget."*
+Both halves are needed and the series has now demonstrated one of them.
+
+**[F21](followups.md)** — append wave 29's per-step estimate vs actual (§10). Steps 1, 2, 4, 5 and 6 all landed
+**under**; the only two that overran were the two priced from instinct rather than from a measured rate
+(fingerprint sweeps, §10). Measured constant for future waves: **the six declared read-only roots are ~41.8 GB
+/ 2 452 files and hash at ~61 MB/s, i.e. ~12 m per sweep, ~24 m for a two-sided fingerprint.**
+
+**`docs/synthetic-af-bank-results-table.md`** — still owed from wave 28: the `K` column from `truthModel`
+(`max(hfrMin, hfrMinEffective)`), the note that `D01`/`D02`/`D03` are the only three floored by the generator,
+and **no 2–4 px band claim below the band** (`W28-B` = `B-SPLIT`). **Not paid this wave.** ~10 m.
+
+---
+
+## §13 — WAVE 30, priced and goal-scored
+
+| # | item | price | compute | goals | why |
+|---|---|---|---|---|---|
+| **1** | **Pay wave 29's four small debts**: the closing `V29`, `P-D08` at `n = 3`, the three scorer self-test captures, and the results-table `K` column | **~20 m** | ~2 m | instrument, **3** ✓ | All four were owed, all four are cheap, and two of them (`P-D08`, the closing `V29`) were explicitly refused-to-cut by the design that then cut them. **Starting a wave by paying the previous wave's named debts is the only thing that stops the list growing** |
+| **2** | **`D01` localised properly** — a 4-cell arm on the binary already on disk, with `MaxDistortion` **lowered** (0.5 → 0.3, 0.2), and a rule whose statistic is the **per-gate flow** (F99), not `FN_total` | **~50 m** | **~13 m** | **3** ✓✓ | The wave's largest open question, now with a corrected direction (F98) and a stated hypothesis that can be wrong (F99: `TooDistorted` + `LowSensitivity` bind jointly). `MinStarBoundingBoxSize` landed at **6** against a shipped default of **5** on the rig with the smallest stars — goal 3 verbatim |
+| **3** | **Choose among F82's three fixes, pre-registered before reading**, and price the winner | **~40 m** | — | **2** ✓✓ | `RULE W29-S` and `W29-R` have delivered everything a choice needs: the carrier exists (`S-b` FALSE), the reversal condition is evaluated (`c = 1`), and `S-c` holds so candidate (3) is live. **The `RULE D20` fence forbade choosing in the wave that proposed (3); it does not forbid the next one.** Ship price is separate: fix (3) ~45 m + 3-cell re-run + **42 m gate** |
+| **4** | **`MaxDistortion`'s axis and name** (F98 part 2) | ~20 m + **42 m gate** | — | **3** ✓✓ | The top ~21 % of a searchable axis returns zero detections for round stars. Touches plugin code, so the gate is owed — predict `G-PASS`, 8 of 8 bit-identical |
+| **5** | **Clause populations** (F102) — every clause prints `candidates: N   findings: M` and refuses on an unexpected `N = 0`; and trees enumerate `None` (F94 append) | ~25 m | — | instrument | Two waves of vacuous clauses (F101, F102) and one verdict that landed outside its own tree. **This is the cheapest structural fix on the list** |
+| **6** | `S27-1` and wave 27's three mutants | ~20 m | — | instrument | **Open three waves running.** Cut again and it should be formally withdrawn rather than re-listed a fifth time |
+
+**Recommended wave 30 = items 1, 2 and 5** — ~1 h 35 m, ~15 m compute, no C# and therefore no gate. Item 3 is
+the natural wave 31 and should be its own pre-registration; item 4 is a genuine ship and owes the 42 m gate.
+
+**Run hard stop: `2026-08-14T00:45:17Z`.**
+
+### Is the register thinning? Yes, and it should be said
+
+**Of the eight entries this wave produces, five are about the instruments and three are about the product** —
+and of those three, one (**F97**) is a *reduction* in an existing finding's scope, one (**F98** part 2) is a
+20-minute parameter-range fix, and one (**F96**) says the series' own measuring stick is self-referential.
+**Wave 29 found no new product defect.** It found that a known one is rarer than believed, that its fix does
+reach a user after all, and that three of the checkers have been passing vacuously.
+
+That is a real and useful wave, and it is also a pattern worth naming: **the marginal finding in this series is
+increasingly about the apparatus rather than about HocusFocus.** The bank's coverage hole (no real
+under-sampled dataset, [F35](followups.md)/[F43](followups.md)) is unchanged after ten waves, §7 has now spent
+the blindness that remained on `/mnt/d/hf_w25/after`, and `RULE W-UNEXERCISED` has twice shown that a full
+paired arm buys a second `SAME 13`.
+
+**The charter's stop condition is *"two consecutive waves producing no finding worth a register entry."* That
+condition is NOT met** — waves 28 and 29 both produced product findings (`B-SPLIT`/`N-RECOVERS`; F97/F98).
+**But the honest forward-looking statement is that items 2 and 4 above are the last two product questions this
+bank can answer without new data**, and once they are closed, the next wave that cannot name a product question
+should stop rather than audit its own instruments a fourth time.
+
+---
+
+## §14 — HANDOFF (design §11's cut 4: folded here rather than written separately)
+
+**Branch** `ghilios/synthetic-af-bank-followups-wave29`, **PR #197**, stacked on #196. Commits: `544f2b2`
+(pre-registration — **its message contains the false §1(b) claim and cannot be edited**), `80e42c5`
+(the CORRECTION), plus this results commit.
+
+**Read first, in this order:** the design's CORRECTION block (above its §1) · §1 and §2 of this document ·
+F96, F97, F82's amendment.
+
+**Do not repeat:** (a) taking the fingerprint after the measurements — it cost `W29-FP` its verdict on four of
+six roots; (b) pricing a sweep from instinct — the constant is ~61 MB/s, ~12 m per sweep; (c) writing a
+blindness ledger without checking it against your own instruments (F100); (d) inheriting a fixture pin
+(F103) — `hf_w28` is next to expire.
+
+**Standing:** never push `develop`; commit with `322725+ghilios@users.noreply.github.com` as author **and**
+committer; pass scorers WSL paths; `--out` mandatory; `--rule` asserted against the file's own declared name;
+one `TestApp.exe` at a time; no directory rebuilt mid-wave.

--- a/plans/synthetic-af-bank-followups-wave29-plan.md
+++ b/plans/synthetic-af-bank-followups-wave29-plan.md
@@ -1,0 +1,355 @@
+# Wave 29 — implementation plan
+
+**Spec:** `docs/synthetic-af-bank-followups-wave29-design.md`. Read it first; this file only executes it.
+**The controller runs every measurement.** A subagent's background processes die with its session and its tool
+timeouts cap at 10 minutes.
+
+**Order is load-bearing, and Step 1 → Step 2 is the whole of [F95](../docs/followups.md)'s remedy.** Every
+instrument is written **before** the blocking pre-flight runs, so the pre-flight has a non-empty population.
+Wave 28 ran its pre-flight at the moment its plan said to — which was before the six instruments it guards
+existed — and certified a root of one file. **A blocking pre-flight must run BEFORE the measurement and AFTER
+the instruments.** No previous plan in this series has said so.
+
+**Step 4 (`W29-S`) and Step 5 (`W29-R`) must both be scored before anything is written about F82's fix.**
+Nothing in this wave ships (design §9); if that changes for any reason, Step 8's reversal conditions fire and
+the wave owes the suite and the 42 m gate.
+
+---
+
+## Step 0 — vessel, ~10 m
+
+```bash
+gh pr view 196 --json state,mergeable --jq '"\(.state) \(.mergeable)"'      # expect: OPEN MERGEABLE
+cd /home/ghilios/src/hocus-focus
+git checkout ghilios/synthetic-af-bank-followups-wave27 && git pull
+git checkout -b ghilios/synthetic-af-bank-followups-wave29
+mkdir -p /mnt/d/hf_w29
+date -u +%FT%H:%M:%SZ > /mnt/d/hf_w29/T0.txt
+```
+
+**A fresh branch and a fresh PR. Do not add a third section to #196** — design §0; wave 28 §13 deviation 2
+already measured what that costs.
+
+Commit the design and this plan **before any measurement**:
+
+```bash
+GIT_COMMITTER_NAME="George Hilios" GIT_COMMITTER_EMAIL="322725+ghilios@users.noreply.github.com" \
+  git commit --author="George Hilios <322725+ghilios@users.noreply.github.com>" \
+  -m "W29 pre-registration: F82's pre-registered fix has no carrier in the product, and its reversal condition has never been run"
+```
+
+**Gate:** `git log --oneline -1` shows the pre-registration commit before Step 4 runs anything.
+
+---
+
+## Step 1 — write EVERY instrument, ~60 m. Nothing runs yet
+
+Five files under `/mnt/d/hf_w29/`, **LF endings**, all derived from `/mnt/d/hf_w28/`:
+
+| file | derived from | role |
+|---|---|---|
+| `verify_derivation_w29.py` | `verify_derivation_w28.py` (**not** a `.bak`) | `RULE V29` |
+| `fp_w29.sh` | `fp_w28.sh` | `W29-FP`, one `sweep()` called twice |
+| `score_w29s.py` | `score_w28s.py` | `RULE W29-S` |
+| `score_w29r.py` | new, but reusing `score_w28n.py`'s manifest + refusal skeleton | `RULE W29-R` |
+| `w29l_arm.sh` + `score_w29l.py` | `w28n_arm_w28.sh` + `score_w28n.py` | `RULE W29-L` |
+
+Standing requirements for all of them (design §12):
+
+1. **`--out` is mandatory and the scorer REFUSES without it.** A stdout redirect puts the evidence in a
+   job-scoped temp directory that is deleted without ceremony.
+2. **`--rule` is asserted against the file's own declared rule name** ([F90](../docs/followups.md)) — a hard
+   refusal, not a warning. Wave 28's scorers caught the controller within a minute with this.
+3. **Every ordinal and count in printed output is COMPUTED**, never typed (`V29-C` will check).
+4. **Populations asserted** inside the output file. Paths reach a scorer through a **manifest**, never a
+   template ([F74](../docs/followups.md)); both drivers source **one** layout function.
+5. **Each scorer re-derives its own outcome-space enumeration in code** and prints
+   `regions enumerated: N   uncovered: 0`, against design §10's tables. A mismatch prints `<RULE>-TREE-GAP`,
+   enumerates the uncovered regions, prints what design §10 would have said, and **does not repair and
+   re-score** ([F94](../docs/followups.md)).
+6. **Every clause's FAIL end is reachable and demonstrated on real files**, and each demonstration asserts
+   **which clause fired**, not merely that something did.
+
+### 1a. `verify_derivation_w29.py` — the three repairs to carry, and the one thing to MEASURE
+
+1. `sed` the wave id forward with **shape-matched** token patterns, both affixes, `_` treated as a word
+   character. **Then grep the result for `V28`/`w28` residue** — wave 28's own controller `sed`
+   (`s/\bV27\b/V28/g`) failed to rewrite `V27_OK` because `_` is a word character, and the checker caught its
+   author. Expect the same class here with `V28_OK`.
+2. **Carry [F87](../docs/followups.md)'s `historical_ranges` repair and prove it did not regress.**
+   `in_historical_block()` must compute ranges top-down by **bracket depth**, require the opener line to
+   actually open a bracket, and exclude the **definition line of `HISTORICAL_BLOCKS`** by name
+   (`is_definition`). The regression test is direct: the checker must report findings on its own file when
+   its own file names `w28`, and must **not** report a token inside a declared historical block.
+3. **Self-test clause `[6]` carried forward, both ends**: a real historical block is exempt · the file after
+   it is not · the definition line opens nothing.
+4. **Per-clause fixture pinning `[5b]` carried forward — and the fixtures are MEASURED, not inherited.**
+   Wave 28 established that a root pinned for its `-B` findings goes silent one wave later. Run first:
+
+   ```bash
+   for R in /mnt/d/hf_w24 /mnt/d/hf_w26 /mnt/d/hf_w27 /mnt/d/hf_w28; do
+     python3 /mnt/d/hf_w29/verify_derivation_w29.py "$R" --out "/mnt/d/hf_w29/vdrift_probe_$(basename $R).txt"
+   done
+   ```
+
+   **Pin `-B` to a root that still refuses and `-C` to a root that still refuses**, from those counts.
+   `/mnt/d/hf_w27` was wave 28's `-B` fixture and `PREV` is now 28 — **assume nothing, read the four probe
+   files.** Keep every expired root pinned and **asserted silent**, so the expiry is demonstrated rather than
+   described. **A clause with no live fixture is a FAIL**, not a pass.
+
+**Nothing in Step 1 is run for its verdict.** The probe runs above are fixture selection and their outputs are
+kept.
+
+---
+
+## Step 2 — `RULE V29`, BLOCKING, over the POPULATED root, ~20 m
+
+**This step runs only after Step 1 has written all five instruments.** That ordering is the deliverable.
+
+```bash
+ls -la --time-style=full-iso /mnt/d/hf_w29/        # capture: the population must be > 1 file
+python3 /mnt/d/hf_w29/verify_derivation_w29.py --self-test --out /mnt/d/hf_w29/vdrift_selftest_w29.txt
+python3 /mnt/d/hf_w29/verify_derivation_w29.py /mnt/d/hf_w29 --out /mnt/d/hf_w29/vdrift_w29.txt
+```
+
+**Gates — READ THE OUTPUT, NOT THE EXIT CODE:**
+
+- `vdrift_selftest_w29.txt` ends `>>> SELF-TEST PASS`, with clause groups `[1] [2] [3] [4] [5] [5b] [6]` all
+  present and `[6]` showing **both** ends;
+- each pinned fixture **refuses on its own clause**, count printed;
+- the expired root is present and **asserted silent**;
+- `vdrift_w29.txt` verdict is `V-CLEAN`, **`files checked` is ≥ 5**, and its banner reads `RULE V29` — not
+  `V28`. **A `V-CLEAN` from a checker printing the previous wave's rule name is [F87](../docs/followups.md);
+  a `V-CLEAN` over a root of one file is [F95](../docs/followups.md). Both block the wave.**
+
+**Nothing downstream runs until this passes.**
+
+---
+
+## Step 3 — `W29-FP` fingerprint, BEFORE, ~8 m
+
+Read-only for the whole wave: `/mnt/d/hf_w25/{after,before,table18,exe}`, `/mnt/d/hf_w28/nc`,
+`/mnt/d/SyntheticAutofocusBank`.
+
+**[F91](../docs/followups.md): ONE `sweep <root> <outfile>` function, called twice.** No second `find`.
+
+```bash
+find "$ROOT" -type f -print0 | sort -z | xargs -0 sha256sum
+```
+
+- `-print0 | sort -z | xargs -0` — `/mnt/d/Autofocus Bank` contains a space and plain `xargs` splits it.
+- **Assert `ROOTPOPULATION` per root and `POPULATION <n>` overall inside the file.** It is the only thing that
+  catches a false `VIOLATED`.
+- Write the artifact **outside** every tree it sweeps (wave 28 §7.10).
+- **Run `fp_w29.sh --self-test` and KEEP ITS OUTPUT** — wave 28's self-test left no artifact (§7.7), and so
+  did its verdict line. Both are two minutes and both are captured here: `fp_selftest_w29.txt`.
+
+**Gate:** `fp_BEFORE.txt` exists with its asserted counts printed, and `fp_selftest_w29.txt` contains
+`SELFTEST W29FP`.
+
+---
+
+## Step 4 — `RULE W29-S` (source), ~25 m, zero compute
+
+```bash
+python3 /mnt/d/hf_w29/score_w29s.py --rule W29-S --out /mnt/d/hf_w29/w29s_score.txt
+```
+
+Reads four files at `HEAD` and **records each sha256 in the output** (design §4). Refuses if any is absent.
+
+| clause | what the scorer does |
+|---|---|
+| `S-a` | Locate `ComputeStepBehavioral` **by declaration, not first textual occurrence** — wave 28 §7.9's real bug, where the first occurrence was a call site and the "body" contained zero of the thing being counted. **An overloaded declaration REFUSES rather than picking a body.** Count `StepSizeRecommender.Recommend(` sites in the body; assert exactly 1; print the count seen and the whole-file count (**2**, at `:792` and `:1262`) so a reader can see the scoping is doing work. Then assert `ComputeStepBehavioral` is the only writer of the value serialized as `terminal.stepBehavioral` |
+| `S-b` | Enumerate **every** `Recommend(` site under `Joko.NINA.Plugins.HocusFocus/`, print the count and the list. For each, assert its enclosing round loop reloads previously-captured runs (`LoadRunStampedAsync`) rather than capturing a sweep. Then scan `OptimizedStarDetectionSettings` and `OptimizationSummary` for any member matching `(?i)halfwidth` and assert **zero** |
+| `S-c` | Assert `SweepDetectability` declares a member carrying requested focuser positions, and that it is reachable inside `Recommend` |
+
+**String literals are blanked length-preservingly before any pattern is counted**, so a decoy in a comment or
+literal cannot inflate a count and offsets stay aligned (wave 28 §7.9).
+
+**Self-test, on real files, both ends per clause:** `S-a`'s zero-site end against `StepSizeRecommender.cs`;
+its multi-site end against the whole of `SynthValidateRunner.cs` (2 sites); `S-b`'s carrier end against
+`StepSizeRecommendation`, which **does** declare `HalfWidth`; `S-c`'s absent end against the same type.
+
+**Gate:** `w29s_score.txt` ends `>>> RULE W29-S = <verdict>` with `regions enumerated: 8   uncovered: 0`,
+and `w29s_selftest.txt` ends `SELFTEST W29S <n> of <n>`.
+
+---
+
+## Step 5 — `RULE W29-R` (the verdict on wave 26's escape clause), ~25 m, zero compute
+
+```bash
+python3 /mnt/d/hf_w29/score_w29r.py --rule W29-R \
+   --root /mnt/d/hf_w25/after --out /mnt/d/hf_w29/w29r_score.txt
+```
+
+**Before any statistic, in this order:**
+
+1. Assert `MaxHalfWidthSampledHalfSpanMultiple == 1.5` **in source at both trees** — B15's tree hash read out
+   of `/mnt/d/hf_w25/binary_provenance_w25.txt` (line `tree:`), **never assumed from a previous HEAD** — and
+   at `HEAD`. A mismatch is `R-UNSATISFIABLE`; the inversion is only valid if the constant that produced the
+   artifacts is the one the scorer divides by.
+2. Assert the addressable population: **18** cells, and assert the gap against the 20 datasets is **exactly**
+   `D05_tec140_1000mm` and `D19_cygnus_deep_shed` ([F74](../docs/followups.md); wave 24's 40-vs-38).
+3. Assert every round read is `wasCapped || wasBandFloored` and `wasDetectBounded == false`. **Any round that
+   is not is a could-not-look**: named, counted, and excluded — never silently included.
+4. Assert the field copies read are the **per-round** `stepRecommendation` and `bootstrap`, exactly one
+   `stepRecommendation` per round index, and that **no value is read from `terminal`**
+   ([F68](../docs/followups.md) part 5).
+
+Then, per cell, per transition `r → r+1`:
+
+```
+impliedSearchSpan(r) = stepRecommendation.halfWidth / 0.75
+requested(r)         = 2 * bootstrap.offsetSteps * bootstrap.stepSize
+qualifies(r)         = requested(r+1) > requested(r)  AND  impliedSearchSpan(r+1) < impliedSearchSpan(r)
+```
+
+Cell qualifies if **any** transition does. Print `k`, `c` (over 18) **and** `c_blind` (over the 15 excluding
+`D01`/`D02`/`D03`), plus the names of every qualifying cell. **The verdict is taken on `c >= 2`, as wave 26
+wrote it** — not on a rate this wave invented.
+
+**Reachability of both branches, demonstrated before the population is read:** the scorer's self-test asserts
+that the identity reproduces `D01`'s published rounds (implied 16 → 12 against requested 16 → 24) **and** that
+`D02`'s published rounds (implied 16 → 24) do **not** qualify — one end each, on real published numbers.
+
+**Gate:** `w29r_score.txt` ends `>>> RULE W29-R = <verdict>` with `regions enumerated: 4   uncovered: 0`, and
+the `R-0`-false / `R-1`-true region is printed as asserted-empty.
+
+**Do not write a line of C# on either verdict.** Design §5.4 and §9.
+
+---
+
+## Step 6 — `RULE W29-L` (the one arm), ~55 m, **~25 m compute**
+
+**No build.** Binary `/mnt/d/hf_w25/exe`; assert `TestApp.dll` sha256 `2fb0c8fd…` against
+`/mnt/d/hf_w25/binary_provenance_w25.txt` before the first cell.
+
+`w29l_arm.sh` — derived from `w28n_arm_w28.sh`, keeping its structure:
+
+- copies the settings tree per cell **without `-p`** and `touch`es every copied file
+  ([F89](../docs/followups.md));
+- edits the named fields **only**, and its own self-test proves the edit is surgical (*exactly N files changed
+  and they are the settings files*; an unedited tree fingerprints identically twice);
+- writes per-cell fingerprints to `/mnt/d/hf_w29/l/fp/`, **outside** every tree they sweep
+  (wave 28 §7.10 — a fingerprint written inside the tree it sweeps makes the AFTER population one larger);
+- pins `--settings` **and** `--profile-id`;
+- gives `TestApp.exe` `< /dev/null`;
+- writes `w29l_manifest.tsv` (cell, settings path, out path, exit, seconds) **last**, and the
+  `W29L_MANIFEST_READY` marker is written **by the driver, on success only** ([F75](../docs/followups.md)) —
+  never by a controller `printf`;
+- the scorer reads paths **only** out of the manifest.
+
+Five cells, `NoiseClippingMultiplier = 1.0` throughout (design §6): `L0` baseline · `L1` `MinimumStarBoundingBoxSize`
+6 → 3 · `L2` `MaxDistortion` 0.5 → 0.9 · `L3` `Sensitivity` one notch · `L4` all three.
+
+**Budget from the measured rate, not from instinct:** wave 28 measured `D01` at `NC = 1.0` at **179 s** for a
+9-frame cell — 3.9× the previous published maximum, because lowering the threshold multiplies the candidate
+count. `L1`/`L2`/`L4` open gates *further*, so they may exceed it. **Reserve 25 m and check the manifest's
+per-cell seconds against 179 s; report the range in the results.**
+
+```bash
+python3 /mnt/d/hf_w29/score_w29l.py --rule W29-L \
+   --manifest /mnt/d/hf_w29/w29l_manifest.tsv --out /mnt/d/hf_w29/w29l_score.txt
+```
+
+The scorer anchors on the **`FALSE-NEGATIVE ATTRIBUTION, HIGH TIER ONLY`** header and asserts it consumed
+exactly one block — the same line appears twice per report and the aggregate copy appears **first**, so a
+first-match reader takes the wrong one (wave 28 self-test [3]).
+
+**`L-0` is the control and it can fail:** `L0` must reproduce wave 28's published `D01` `NC = 1.0` high-tier
+attribution block **field for field**. If it does not, every downstream number is uninterpretable and the
+verdict is `L-UNEVALUATED`.
+
+**Gate:** `w29l_score.txt` ends `>>> RULE W29-L = <verdict>` with `regions enumerated: 8   uncovered: 0`, the
+exclusive and joint shares printed, and the `L-1 ∧ L-2` region printed as asserted-empty.
+
+**No branch reads `L3` alone, and nothing this wave writes may cite `L3` as evidence for or against a
+sensitivity bound** ([F84](../docs/followups.md), `RULE S16` fence).
+
+---
+
+## Step 7 — [F83](../docs/followups.md)'s `P-D08` at `n = 3`, ~2 m
+
+*"The cheapest decision-moving measurement left in the register."* **An item under two minutes is never
+dropped** (charter §4). Run it, capture it with `--out`, record it whether it moves anything or not.
+
+---
+
+## Step 8 — fingerprint AFTER, the reversal check, and the CLOSING `V29`, ~12 m
+
+```bash
+bash /mnt/d/hf_w29/fp_w29.sh after                 # same sweep() expression, second call
+git status --short && git diff --stat              # the reversal check
+python3 /mnt/d/hf_w29/verify_derivation_w29.py /mnt/d/hf_w29 --out /mnt/d/hf_w29/vdrift_w29_FINAL.txt
+```
+
+**The reversal check, explicitly (design §8):** if **any** `.cs` file changed for any reason, or the
+`/mnt/d/hf_w25/exe` dll hashes do not match `binary_provenance_w25.txt`, or the arm proved non-deterministic —
+then **the unit suite is owed by COUNT** ([F37](../docs/followups.md), baseline **3997**, not the charter's
+stale 3973) **and the 42 m `optimize` gate becomes owed** and the wave stops until both are run.
+
+**The closing `V29` run is not optional at any budget.** It is [F95](../docs/followups.md)'s entire remedy:
+the first run proves the checker works, the closing run proves the wave is clean, and this series has been
+conflating them. **Keep `vdrift_w29.txt` beside `vdrift_w29_FINAL.txt`** so both states are on the record.
+**Capture the `W29-FP` verdict LINE to a file** — wave 28's existed only in a terminal.
+
+**Gate:** `W29-FP = PRESERVED`, populations asserted equal, and `vdrift_w29_FINAL.txt` reads `V-CLEAN` over a
+root of every instrument the wave wrote.
+
+---
+
+## Step 9 — record, ~75 m
+
+**First action of the results document is `ls -la --time-style=full-iso /mnt/d/hf_w29/`, with the timestamp
+PRINTED at the top.** Any row still open at that instant is marked open **in place**, not reported as done.
+Wave 19's document was falsified by an artifact written 33 seconds before its own commit.
+
+1. `docs/synthetic-af-bank-followups-wave29-results.md` — every verdict quoted from an artifact and cited;
+   the pre-registered rules **applied as written**; an unsatisfiable or under-specified clause reported as a
+   **finding**, not repaired and not re-scored. Estimate **and** actual per step
+   ([F21](../docs/followups.md)). What was not run, and its price.
+2. `docs/followups.md` — the entries design §14 names: **F96** (conditional on `W29-S`), **F97**, **F98**, and
+   the amendments to **F82** (in place: the *"truth of 9"* is a product-derived fixed point; name which
+   caller; add the third candidate), **F81**, **F94**, **F95**, **F21**.
+3. `docs/synthetic-af-bank-results-table.md` — wave 28's owed `K` column from `truthModel`
+   (`max(hfrMin, hfrMinEffective)`) and the note that `D01`/`D02`/`D03` are the only three floored by the
+   generator. **No 2–4 px band claim below the band** — `W28-B` is `B-SPLIT`.
+4. `docs/waves30+-…` handoff, **or** design §11's cut 4: fold it into the results file's §12 and say so.
+
+---
+
+## Step 10 — close, ~20 m
+
+```bash
+git add -A && GIT_COMMITTER_NAME="George Hilios" \
+  GIT_COMMITTER_EMAIL="322725+ghilios@users.noreply.github.com" \
+  git commit --author="George Hilios <322725+ghilios@users.noreply.github.com>" -m "W29 results: ..."
+git push -u origin ghilios/synthetic-af-bank-followups-wave29
+gh pr create --base develop --head ghilios/synthetic-af-bank-followups-wave29 --title "Wave 29: ..." --body "..."
+```
+
+**Never push `develop`.** Verify CI by **COUNT read out of the log**, never by the tick. Delete the status
+cron.
+
+---
+
+## Standing constraints (apply to every step)
+
+- **Only one `TestApp.exe` at a time.** Never run NINA during the arm. No fan-out.
+- **Never rebuild any directory mid-wave** — every instrument is written at Step 1.
+- **Pass scorers WSL paths** (`/mnt/d/...`). A Windows path yields `UNEVALUATED` and looks like a failed arm.
+- **Read the output, not the exit code.** A background job reporting `exit 0` has repeatedly meant a driver
+  aborted in one second; a `*_START` line alone is not evidence.
+- **A `--self-test` dispatcher in a SOURCED file sees the parent's `$1`** — wave 26's fired inside its
+  caller's `source` line, terminated it, and printed a clean PASS.
+- Newtonsoft writes NaN/Infinity as the **strings** `"NaN"`/`"Infinity"`. Every `table18` log carries **CRLF**;
+  strip `\r` before any comparison. Wave roots at or before 23 carry a `0xE5` — read old logs on bytes.
+- Commit with the privacy email, both author and committer.
+
+## Stop conditions
+
+- `RULE V29` not `V-CLEAN`, or its population ≤ 1 file → **stop**; nothing downstream runs.
+- `W29-FP` not `PRESERVED` → **stop**; a read-only root was written.
+- Any `.cs` file changed → Step 8's reversal fires: suite by COUNT **and** the 42 m gate, or stop.
+- Two consecutive waves producing no finding worth a register entry → **stop and say so.** *"There is nothing
+  left worth a wave"* is an acceptable and welcome answer.


### PR DESCRIPTION
Wave 29 of the synthetic-AF-bank followup series, on **backlog item 1 ([F82](../blob/develop/docs/followups.md))**: the step-size floor is not sticky across rounds.

**Stacked on PR #196** (waves 27 and 28), which should be reviewed first. Wave 29 opens its own branch deliberately: #196 already carries two waves plus a user-visible product change under a title naming only wave 27, wave 28 pre-registered a fresh branch and did the opposite and recorded the cost, and a third section would be the accretion the charter warns about rather than a step toward it.

## The pre-registration found two things in source, at zero compute, and both change what the wave does

**(a) The "truth" F82 is scored against is produced by the code under test.** `SynthValidateRunner.ComputeStepBehavioral` (`:1213-1270`) builds an analytic curve, fits it, and calls `StepSizeRecommender.Recommend` at `:1262` in a loop until `rec.StepSize == step`. Its own XML doc says so: *"the fixed point A3 compares against is produced by the same rule as the landing it scores."* **That is why `stepBehavioral` moved 8.0 → 9.0 across wave 25's two arms while staying identical on the other 17 cells — wave 25 changed `Recommend`, so it moved the bar as well as the measurement.** F82 recorded the symptom and called it *"an assumption this series can no longer make for free"*; the cause is one line and nobody had looked.

**(b) F82's pre-registered fix has no carrier in the product.** The fix is *(1) the monotone floor — carry the previous round's floored half-width forward*, chosen partly because it is *"confined to the caller's round state."* Enumerating the callers: the wizard's `Continue` and `Re-optimize` both re-optimize **frames already captured**, so no new sweep is taken and `SearchSpan` cannot change between rounds — **the defect cannot occur there at all**. `optimize` (×4) and the tilt runner are single-pass. The only caller with cross-round sweep state is `SynthValidateRunner` — **the test harness**. And nothing persists a half-width across sessions: `OptimizationSummary` has no `HalfWidth` member.

**So the fix as pre-registered reaches no user, and scores goal 2 zero rather than the triple-tick the previous wave gave it.** The product version needs new persisted session state — a ~2–4 h band nobody has priced, plus the question of whether it is an option and therefore owes a control in `OptionsDataTemplates.xaml`.

## What the wave does NOT do

**It does not ship a fix and does not flip wave 26's choice.** Two of wave 26's three reasons for choosing fix (1) are impeached, the third is confirmed and quantified for the first time (**37 of 37 rounds capped-or-floored**), and a fourth is added — fix (2) changes `SearchSpan`, which the truth model also consumes, so **(2) would move the truth model as well as the landing**. That is a finding, registered rather than repaired: *choosing a fix in the same wave that discovers a new reason to prefer it is the F14 / RULE D20 fence in a new costume.*

Instead it runs **wave 26's own reversal condition, which three waves have quoted and none has ever executed.**

## Rules

| rule | what | compute |
|---|---|---|
| **`W29-S`** | the two source facts above, as a rule with a total verdict tree | 0 |
| **`W29-R`** | wave 26's reversal condition, on 18 addressable paired S1 cells | 0 |
| **`W29-L`** | which gate actually binds on `D01` at `NC = 1.0` — 5 cells, so `joint − Σexclusive` is an **exact** decomposition rather than a ranking | ~25 m |

The gate is **certainly owed** for any future F82 fix — `Q27-V1`'s FAIL end was *run* against a diff whose two files are `StepSizeRecommender.cs` and `StarDetectionOptimizerWizardVM.cs`, i.e. F82's own. For wave 29 itself it is not owed: no C# changes, no binary, and no verdict tree reads a gate landing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QTNWdSNar6g3Nj5wXnLZc6
