### PR TITLE
AutoFocus footer row: wrap instead of overlapping when the pane is narrow

### DIFF
--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/AutoFocus/AutoFocusFooterRowMarkupTests.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/AutoFocus/AutoFocusFooterRowMarkupTests.cs
@@ -1,7 +1,10 @@
 using NUnit.Framework;
 using System;
+using System.Collections.Generic;
+using System.Globalization;
 using System.IO;
 using System.Linq;
+using System.Runtime.CompilerServices;
 using System.Xml.Linq;
 
 namespace NINA.Joko.Plugins.HocusFocus.Tests.AutoFocus;
@@ -23,16 +26,14 @@ public class AutoFocusFooterRowMarkupTests {
     private static readonly XNamespace Presentation = "http://schemas.microsoft.com/winfx/2006/xaml/presentation";
     private static readonly XNamespace Xaml = "http://schemas.microsoft.com/winfx/2006/xaml";
 
-    private static XElement DockableTemplate() {
-        var dir = new DirectoryInfo(AppContext.BaseDirectory);
-        while (dir != null && dir.GetDirectories("Joko.NINA.Plugins.HocusFocus").Length == 0) {
-            dir = dir.Parent;
-        }
-        Assert.That(dir, Is.Not.Null, "Could not locate the plugin source directory from the test binaries.");
-
-        var xaml = Path.Combine(dir.GetDirectories("Joko.NINA.Plugins.HocusFocus").Single().FullName,
-            "AutoFocus", "DataTemplates.xaml");
-        Assert.That(File.Exists(xaml), Is.True, $"{xaml} not found");
+    // Anchored on the source file's own path, like OptionsDataTemplatesLayoutTests, rather than walking up from the
+    // test binaries — the walk breaks the moment the build output moves.
+    private static XElement DockableTemplate([CallerFilePath] string thisFile = null) {
+        // thisFile: <repo>/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/AutoFocus/AutoFocusFooterRowMarkupTests.cs
+        var testsProjectDir = Directory.GetParent(Path.GetDirectoryName(thisFile)).FullName;
+        var xaml = Path.GetFullPath(Path.Combine(
+            testsProjectDir, "..", "Joko.NINA.Plugins.HocusFocus", "AutoFocus", "DataTemplates.xaml"));
+        Assert.That(File.Exists(xaml), Is.True, $"Could not locate DataTemplates.xaml at '{xaml}'");
 
         var template = XDocument.Load(xaml).Descendants(Presentation + "DataTemplate")
             .SingleOrDefault(t => ((string)t.Attribute(Xaml + "Key"))?.EndsWith("HocusFocusVM_Dockable",
@@ -44,6 +45,25 @@ public class AutoFocusFooterRowMarkupTests {
     /// <summary>Real child elements. Property elements — <c>&lt;Grid.RowDefinitions&gt;</c> and friends — are not children.</summary>
     private static XElement[] ElementChildren(XElement e) =>
         e.Elements().Where(c => !c.Name.LocalName.Contains('.')).ToArray();
+
+    /// <summary>
+    /// The left and right components of an element's Margin, parsed. Thickness accepts 1, 2 and 4 components
+    /// (uniform, horizontal/vertical, then left/top/right/bottom), so "0.0", ".0" and "0" must all read as zero.
+    /// </summary>
+    private static IEnumerable<(string Edge, double Value)> HorizontalMarginsOf(XElement e) {
+        var margin = (string)e.Attribute("Margin");
+        if (margin == null) {
+            yield break;
+        }
+
+        var parts = margin.Split(',');
+        Assert.That(parts.Select(p => double.TryParse(p, NumberStyles.Float, CultureInfo.InvariantCulture, out _)),
+            Is.All.True, $"Margin=\"{margin}\" on <{e.Name.LocalName}> is not a literal Thickness this guard can read.");
+
+        var values = parts.Select(p => double.Parse(p, NumberStyles.Float, CultureInfo.InvariantCulture)).ToArray();
+        yield return ("left", values[0]);
+        yield return ("right", values.Length == 4 ? values[2] : values[0]);
+    }
 
     [Test]
     public void FooterRow_IsASingleWrappingPanel_NotTwoSiblingsSharingOneCell() {
@@ -69,15 +89,17 @@ public class AutoFocusFooterRowMarkupTests {
             Assert.That(panel.Attribute("HorizontalAlignment"), Is.Null,
                 "The panel must keep the default Stretch to have a full row width to justify against.");
 
+            // The gaps are the ONLY source of spacing left, since child margins are forbidden below.
+            Assert.That((string)panel.Attribute("ItemGap"), Is.EqualTo("12"),
+                "Without ItemGap the Review Frames button butts straight against the ON/OFF pill.");
+            Assert.That((string)panel.Attribute("LineGap"), Is.EqualTo("6"),
+                "Without LineGap the wrapped lines touch.");
+
             // WPF margins do not collapse, so a horizontal child margin ADDS to ItemGap rather than absorbing into it.
             foreach (var child in ElementChildren(panel)) {
-                var margin = (string)child.Attribute("Margin");
-                if (margin != null) {
-                    var parts = margin.Split(',');
-                    Assert.That(parts[0].Trim(), Is.EqualTo("0"), $"left margin on <{child.Name.LocalName}> doubles ItemGap");
-                    if (parts.Length == 4) {
-                        Assert.That(parts[2].Trim(), Is.EqualTo("0"), $"right margin on <{child.Name.LocalName}> doubles ItemGap");
-                    }
+                foreach (var (edge, value) in HorizontalMarginsOf(child)) {
+                    Assert.That(value, Is.EqualTo(0.0),
+                        $"{edge} margin on <{child.Name.LocalName}> adds to ItemGap rather than absorbing into it");
                 }
                 Assert.That(child.Attribute("HorizontalAlignment"), Is.Null,
                     $"HorizontalAlignment on <{child.Name.LocalName}> does nothing — the panel arranges children at their desired width.");

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/AutoFocus/AutoFocusFooterRowMarkupTests.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/AutoFocus/AutoFocusFooterRowMarkupTests.cs
@@ -1,0 +1,114 @@
+using NUnit.Framework;
+using System;
+using System.IO;
+using System.Linq;
+using System.Xml.Linq;
+
+namespace NINA.Joko.Plugins.HocusFocus.Tests.AutoFocus;
+
+/// <summary>
+/// Structural guard on the AutoFocus pane's footer row — the "Replay Saved AF" / "Review Frames" / "Keep frames for
+/// review" strip — in the shipped markup. The STA fixture for
+/// <see cref="NINA.Joko.Plugins.HocusFocus.Controls.EdgeJustifiedWrapPanel"/> can only exercise stub trees: the real
+/// template needs NINA theme dictionaries, {ns:Loc} and ninactrl:CancellableButton and does not load in a test host.
+/// So this reads the XAML as XML instead, and pins the handful of properties that, if broken, silently restore the
+/// original bug with no build error and no failing layout test.
+///
+/// The bug: the Replay button and a right-aligned StackPanel were two children of ONE Auto grid-row cell. A Grid cell
+/// gives every child the full cell and nobody yields, so below roughly a 500px pane they drew on top of each other.
+/// </summary>
+[TestFixture]
+public class AutoFocusFooterRowMarkupTests {
+
+    private static readonly XNamespace Presentation = "http://schemas.microsoft.com/winfx/2006/xaml/presentation";
+    private static readonly XNamespace Xaml = "http://schemas.microsoft.com/winfx/2006/xaml";
+
+    private static XElement DockableTemplate() {
+        var dir = new DirectoryInfo(AppContext.BaseDirectory);
+        while (dir != null && dir.GetDirectories("Joko.NINA.Plugins.HocusFocus").Length == 0) {
+            dir = dir.Parent;
+        }
+        Assert.That(dir, Is.Not.Null, "Could not locate the plugin source directory from the test binaries.");
+
+        var xaml = Path.Combine(dir.GetDirectories("Joko.NINA.Plugins.HocusFocus").Single().FullName,
+            "AutoFocus", "DataTemplates.xaml");
+        Assert.That(File.Exists(xaml), Is.True, $"{xaml} not found");
+
+        var template = XDocument.Load(xaml).Descendants(Presentation + "DataTemplate")
+            .SingleOrDefault(t => ((string)t.Attribute(Xaml + "Key"))?.EndsWith("HocusFocusVM_Dockable",
+                StringComparison.Ordinal) == true);
+        Assert.That(template, Is.Not.Null, "The AutoFocus pane's _Dockable DataTemplate is gone or was renamed.");
+        return template;
+    }
+
+    /// <summary>Real child elements. Property elements — <c>&lt;Grid.RowDefinitions&gt;</c> and friends — are not children.</summary>
+    private static XElement[] ElementChildren(XElement e) =>
+        e.Elements().Where(c => !c.Name.LocalName.Contains('.')).ToArray();
+
+    [Test]
+    public void FooterRow_IsASingleWrappingPanel_NotTwoSiblingsSharingOneCell() {
+        var row1 = DockableTemplate().Descendants()
+            .Where(e => (string)e.Attribute("Grid.Row") == "1")
+            .ToArray();
+
+        Assert.That(row1.Length, Is.EqualTo(1),
+            "Two or more elements share the footer's Auto row cell again — that is the overlap bug itself.");
+        Assert.That(row1[0].Name.LocalName, Is.EqualTo("EdgeJustifiedWrapPanel"));
+        Assert.That(ElementChildren(row1[0]).Length, Is.EqualTo(3),
+            "Replay, Review Frames and the toggle group must be three separate children so the row can break.");
+    }
+
+    [Test]
+    public void FooterPanel_KeepsTheContractThatMakesJustificationWork() {
+        var panel = DockableTemplate().Descendants()
+            .Single(e => e.Name.LocalName == "EdgeJustifiedWrapPanel");
+
+        Assert.Multiple(() => {
+            // A non-Stretch panel is arranged at its DesiredSize, so there is never any slack: the trailing group
+            // silently stops being flush right, with no error and nothing else to notice.
+            Assert.That(panel.Attribute("HorizontalAlignment"), Is.Null,
+                "The panel must keep the default Stretch to have a full row width to justify against.");
+
+            // WPF margins do not collapse, so a horizontal child margin ADDS to ItemGap rather than absorbing into it.
+            foreach (var child in ElementChildren(panel)) {
+                var margin = (string)child.Attribute("Margin");
+                if (margin != null) {
+                    var parts = margin.Split(',');
+                    Assert.That(parts[0].Trim(), Is.EqualTo("0"), $"left margin on <{child.Name.LocalName}> doubles ItemGap");
+                    if (parts.Length == 4) {
+                        Assert.That(parts[2].Trim(), Is.EqualTo("0"), $"right margin on <{child.Name.LocalName}> doubles ItemGap");
+                    }
+                }
+                Assert.That(child.Attribute("HorizontalAlignment"), Is.Null,
+                    $"HorizontalAlignment on <{child.Name.LocalName}> does nothing — the panel arranges children at their desired width.");
+            }
+        });
+    }
+
+    [Test]
+    public void ToggleAndItsCaption_StayASingleChild() {
+        var panel = DockableTemplate().Descendants()
+            .Single(e => e.Name.LocalName == "EdgeJustifiedWrapPanel");
+
+        var checkBox = panel.Descendants().Single(e => e.Name.LocalName == "CheckBox");
+        var caption = panel.Descendants().Single(e =>
+            e.Name.LocalName == "TextBlock" && (string)e.Attribute("Text") == "Keep frames for review");
+
+        // The themed ON/OFF pill must never wrap away from the text that says what it does.
+        Assert.That(caption.Parent, Is.EqualTo(checkBox.Parent));
+        Assert.That(caption.Parent, Is.Not.EqualTo(panel), "they must be grouped in one child, not two");
+    }
+
+    [Test]
+    public void FooterRow_HasNoWrappingText() {
+        var panel = DockableTemplate().Descendants()
+            .Single(e => e.Name.LocalName == "EdgeJustifiedWrapPanel");
+
+        // A wrapping caption inside a Height="Auto" row grows the row without bound as the pane narrows — the text
+        // degenerates towards one word per line and the space comes straight out of the focus chart above.
+        foreach (var text in panel.Descendants().Where(e => e.Name.LocalName == "TextBlock")) {
+            Assert.That(text.Attribute("TextWrapping"), Is.Null,
+                $"TextWrapping on \"{(string)text.Attribute("Text")}\" makes the footer's height unbounded.");
+        }
+    }
+}

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/Controls/EdgeJustifiedWrapPanelTests.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/Controls/EdgeJustifiedWrapPanelTests.cs
@@ -1,0 +1,467 @@
+using NINA.Joko.Plugins.HocusFocus.Controls;
+using NUnit.Framework;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Windows.Controls;
+using Brushes = System.Windows.Media.Brushes;
+using FrameworkElement = System.Windows.FrameworkElement;
+using GridLength = System.Windows.GridLength;
+using GridUnitType = System.Windows.GridUnitType;
+using HorizontalAlignment = System.Windows.HorizontalAlignment;
+using Point = System.Windows.Point;
+using Rect = System.Windows.Rect;
+using Size = System.Windows.Size;
+using Thickness = System.Windows.Thickness;
+using UIElement = System.Windows.UIElement;
+using VerticalAlignment = System.Windows.VerticalAlignment;
+using Visibility = System.Windows.Visibility;
+using Visual = System.Windows.Media.Visual;
+
+namespace NINA.Joko.Plugins.HocusFocus.Tests.Controls;
+
+/// <summary>
+/// Layout contract for <see cref="EdgeJustifiedWrapPanel"/>, which exists to fix a real rendering bug in the docked
+/// AutoFocus pane: "Replay Saved AF" and the "Review Frames" + "Keep frames for review" group used to be a
+/// left-aligned and a right-aligned child of ONE Auto grid-row cell, and a Grid cell hands every child the full cell
+/// with nobody yielding — so below roughly a 500px pane they drew on top of each other.
+///
+/// Stub widths 130 / 110 / 195 and heights 25 / 25 / 28 stand in for the three real controls. The pill being TALLER
+/// than the buttons is load-bearing: an all-25px fixture cannot tell "arranged at the line height" from "arranged at
+/// the child's own height", and would let the wide-case identity claim pass vacuously.
+///
+/// Geometry is read from RENDERED rects, so a child shorter than its line appears at its VerticalAlignment's offset
+/// within that line rather than at the line's top. Fixtures are built from stub Borders, never from the real
+/// DataTemplates.xaml — that markup needs NINA theme dictionaries, {ns:Loc}, {StaticResource CancelSVG} and
+/// ninactrl:CancellableButton, none of which resolve in the test host.
+/// </summary>
+[TestFixture]
+[Apartment(ApartmentState.STA)]
+public class EdgeJustifiedWrapPanelTests {
+
+    private const double ItemGap = 12.0;
+    private const double LineGap = 6.0;
+
+    // 130 + 12 + 110 + 12 + 195. The one-line/wrap boundary for the standard fixture.
+    private const double PackedWidth = 459.0;
+
+    private static readonly Size Unbounded = new Size(double.PositiveInfinity, double.PositiveInfinity);
+
+    private static Border Stub(double width, double height, VerticalAlignment valign = VerticalAlignment.Center) =>
+        new Border { Width = width, Height = height, VerticalAlignment = valign };
+
+    /// <summary>The three AutoFocus footer controls, in shipped order and with their shipped alignments.</summary>
+    private static EdgeJustifiedWrapPanel StandardPanel() {
+        var panel = new EdgeJustifiedWrapPanel { ItemGap = ItemGap, LineGap = LineGap };
+        panel.Children.Add(Stub(130, 25, VerticalAlignment.Bottom)); // Replay Saved AF
+        panel.Children.Add(Stub(110, 25));                           // Review Frames
+        panel.Children.Add(Stub(195, 28));                           // ON pill + "Keep frames for review"
+        return panel;
+    }
+
+    /// <summary>Measure at the given width and arrange at exactly the height the panel asked for.</summary>
+    private static EdgeJustifiedWrapPanel LayOut(EdgeJustifiedWrapPanel panel, double width) {
+        // ALWAYS measure with an unbounded height: MeasureCore clamps DesiredSize to the constraint, so
+        // Measure(new Size(500, 40)) would report Height 40 even when two lines need 59.
+        panel.Measure(new Size(width, double.PositiveInfinity));
+        panel.Arrange(new Rect(0, 0, width, panel.DesiredSize.Height));
+        return panel;
+    }
+
+    private static Rect RectOf(FrameworkElement child, Visual ancestor) =>
+        child.TransformToAncestor(ancestor).TransformBounds(new Rect(new Point(0, 0), child.RenderSize));
+
+    private static List<Rect> RectsOf(EdgeJustifiedWrapPanel panel) =>
+        panel.Children.Cast<FrameworkElement>().Select(c => RectOf(c, panel)).ToList();
+
+    private static bool ShareALine(Rect a, Rect b) => a.Top < b.Bottom - 0.5 && b.Top < a.Bottom - 0.5;
+
+    [Test]
+    public void Wide_LeadingChildFlushLeft_TrailingGroupFlushRightAndCohesive() {
+        var panel = LayOut(StandardPanel(), 1150);
+        var r = RectsOf(panel);
+
+        Assert.Multiple(() => {
+            // The PACKED size, never the constraint — returning the constraint would make an Auto row span the pane.
+            Assert.That(panel.DesiredSize.Width, Is.EqualTo(PackedWidth).Within(0.5));
+            Assert.That(panel.DesiredSize.Height, Is.EqualTo(28).Within(0.5), "the line is as tall as its tallest item");
+
+            Assert.That(r[0].Left, Is.EqualTo(0).Within(0.5), "leading child flush left");
+            Assert.That(r[2].Right, Is.EqualTo(1150).Within(0.5), "trailing child flush right");
+            Assert.That(r[1].Left - r[0].Right, Is.EqualTo(ItemGap + (1150 - PackedWidth)).Within(0.5),
+                "all slack belongs to the one gap after the leading child");
+            Assert.That(r[2].Left - r[1].Right, Is.EqualTo(ItemGap).Within(0.5),
+                "the trailing group stays packed at exactly ItemGap — it must not spread across the row");
+        });
+    }
+
+    [Test]
+    public void Wide_ChildrenArrangedAtLineHeightSoVerticalAlignmentStillResolves() {
+        var panel = LayOut(StandardPanel(), 1150);
+        var r = RectsOf(panel);
+
+        // Arranging children at their OWN height instead of the line height turns VerticalAlignment into a no-op and
+        // top-aligns unequal-height items, which is exactly what would silently break the wide-case appearance.
+        Assert.Multiple(() => {
+            Assert.That(r[0].Bottom, Is.EqualTo(28).Within(0.5), "the Bottom-aligned 25px child sits on the line's floor");
+            Assert.That(r[1].Top, Is.EqualTo(1.5).Within(0.5), "the Center-aligned 25px child is centred in the 28px line");
+            Assert.That(r[2].Top, Is.EqualTo(0).Within(0.5), "the tallest child defines the line");
+        });
+    }
+
+    // THE AMENDMENT. A greedy break from index 0 would fill line 1 with [Replay][Review Frames] and orphan the
+    // toggle on line 2 — directly beneath, and so reading as belonging to, the one control it has nothing to do with.
+    // The toggle is what ENABLES Review Frames, so the two must wrap together.
+    [TestCase(340)]
+    [TestCase(400)]
+    [TestCase(458)]
+    public void Narrow_LeadingChildTakesItsOwnLine_TrailingGroupStaysTogether(double width) {
+        var panel = LayOut(StandardPanel(), width);
+        var r = RectsOf(panel);
+
+        Assert.Multiple(() => {
+            Assert.That(r[0].Bottom, Is.LessThanOrEqualTo(r[1].Top + 0.5), "Replay is alone on the first line");
+            Assert.That(ShareALine(r[1], r[2]), Is.True, "Review Frames and the toggle that enables it stay together");
+            Assert.That(r[2].Left - r[1].Right, Is.EqualTo(ItemGap).Within(0.5));
+            Assert.That(r[0].Left, Is.EqualTo(0).Within(0.5), "wrapped lines pack left, with no justification");
+            Assert.That(r[1].Left, Is.EqualTo(0).Within(0.5));
+        });
+    }
+
+    [Test]
+    public void Narrow_TwoLineGeometryIsExact() {
+        var panel = LayOut(StandardPanel(), 400);
+        var r = RectsOf(panel);
+
+        Assert.Multiple(() => {
+            Assert.That(panel.DesiredSize.Width, Is.EqualTo(317).Within(0.5), "the widest line: 110 + 12 + 195");
+            Assert.That(panel.DesiredSize.Height, Is.EqualTo(59).Within(0.5), "25 + LineGap + 28");
+
+            Assert.That(r[0].Left, Is.EqualTo(0).Within(0.5));
+            Assert.That(r[0].Top, Is.EqualTo(0).Within(0.5));
+            // Line 2 opens at 25 + LineGap and is 28 tall; the 25px Review Frames stub centres within it at 32.5.
+            Assert.That(r[1].Left, Is.EqualTo(0).Within(0.5));
+            Assert.That(r[1].Top, Is.EqualTo(32.5).Within(0.5));
+            Assert.That(r[2].Left, Is.EqualTo(122).Within(0.5), "110 + ItemGap");
+            Assert.That(r[2].Top, Is.EqualTo(31).Within(0.5));
+        });
+    }
+
+    [Test]
+    public void VeryNarrow_BreaksToThreeLinesRatherThanClipping() {
+        var panel = LayOut(StandardPanel(), 250);
+        var r = RectsOf(panel);
+
+        Assert.Multiple(() => {
+            Assert.That(panel.DesiredSize.Height, Is.EqualTo(90).Within(0.5), "25 + 6 + 25 + 6 + 28");
+            Assert.That(r.Select(x => x.Left), Is.All.EqualTo(0.0).Within(0.5));
+            Assert.That(r[0].Top, Is.EqualTo(0).Within(0.5));
+            Assert.That(r[1].Top, Is.EqualTo(31).Within(0.5));
+            Assert.That(r[2].Top, Is.EqualTo(62).Within(0.5));
+        });
+    }
+
+    // The regression pin for the reported bug. Nothing else in this fixture would catch a reintroduction of the
+    // collision at some width nobody thought to enumerate.
+    [Test]
+    public void NoChildEverOverlapsAnother_OrEscapesTheRow_AcrossTheFullWidthRange() {
+        for (var w = 60.0; w <= 1400.0; w += 7.0) {
+            var panel = LayOut(StandardPanel(), w);
+            var r = RectsOf(panel);
+            var height = panel.DesiredSize.Height;
+
+            for (var i = 0; i < r.Count; ++i) {
+                // A Panel does NOT clip its children: a line drawn past the panel's own height renders over the
+                // focus chart in the star row above.
+                Assert.That(r[i].Bottom, Is.LessThanOrEqualTo(height + 0.5), $"child {i} escapes the row at width {w}");
+                Assert.That(r[i].Top, Is.GreaterThanOrEqualTo(-0.5), $"child {i} above the row at width {w}");
+                Assert.That(r[i].Left, Is.GreaterThanOrEqualTo(-0.5), $"child {i} left of the row at width {w}");
+
+                for (var j = i + 1; j < r.Count; ++j) {
+                    var a = r[i];
+                    var b = r[j];
+                    a.Inflate(-0.5, -0.5); // a shared edge is not an overlap
+                    b.Inflate(-0.5, -0.5);
+                    Assert.That(a.IntersectsWith(b), Is.False, $"children {i} and {j} overlap at width {w}");
+                }
+            }
+        }
+    }
+
+    [Test]
+    public void InfiniteConstraint_MeasuresToAFiniteSingleLine() {
+        var panel = StandardPanel();
+        panel.Measure(Unbounded);
+
+        // SizeToContent windows, ScrollViewers and Auto grid columns all measure at infinity. availableWidth is only
+        // ever compared against, never used in arithmetic, so nothing infinite can reach DesiredSize.
+        Assert.Multiple(() => {
+            Assert.That(panel.DesiredSize.Width, Is.EqualTo(PackedWidth).Within(0.5));
+            Assert.That(panel.DesiredSize.Height, Is.EqualTo(28).Within(0.5));
+        });
+    }
+
+    [Test]
+    public void ArrangeWiderThanMeasured_RejustifiesInsteadOfReusingMeasureTimePositions() {
+        var panel = StandardPanel();
+        panel.Measure(new Size(600, double.PositiveInfinity));
+        panel.Arrange(new Rect(0, 0, 1000, panel.DesiredSize.Height));
+
+        // This is the everyday case, not an exotic one: the panel is Stretch inside an Auto row, so it measures
+        // against the row width and is then arranged at the full pane width. Caching measure-time x positions
+        // would leave the trailing group stranded mid-row.
+        Assert.That(RectsOf(panel)[2].Right, Is.EqualTo(1000).Within(0.5));
+    }
+
+    [Test]
+    public void ArrangeNarrowerThanMeasured_IsEnlargedByArrangeCore_AndStaysConsistent() {
+        var panel = StandardPanel();
+        panel.Measure(new Size(1200, double.PositiveInfinity));
+        panel.Arrange(new Rect(0, 0, 450, panel.DesiredSize.Height));
+
+        // A DOCUMENTED PROBE, not a wish: FrameworkElement.ArrangeCore enlarges the arrange slot to the element's
+        // unclipped desired size when the parent offers less, and applies a layout clip instead. ArrangeOverride is
+        // therefore handed 459, not 450, and a genuinely narrower pane always reaches the panel through a fresh
+        // MEASURE. Keep this here so nobody "fixes" the panel to chase a shrink case WPF never produces.
+        Assert.Multiple(() => {
+            Assert.That(panel.RenderSize.Width, Is.EqualTo(PackedWidth).Within(0.5));
+            Assert.That(RectsOf(panel)[2].Right, Is.EqualTo(PackedWidth).Within(0.5));
+        });
+    }
+
+    [Test]
+    public void CollapsedChild_ContributesNeitherWidthNorGap() {
+        var panel = StandardPanel();
+        ((UIElement)panel.Children[1]).Visibility = Visibility.Collapsed;
+        LayOut(panel, 1150);
+
+        Assert.Multiple(() => {
+            // 130 + 12 + 195. Dropping the child but keeping its gap is the classic phantom-gap panel bug.
+            Assert.That(panel.DesiredSize.Width, Is.EqualTo(337).Within(0.5));
+            Assert.That(RectOf((FrameworkElement)panel.Children[2], panel).Right, Is.EqualTo(1150).Within(0.5),
+                "flush right lands on the last VISIBLE child");
+        });
+    }
+
+    [Test]
+    public void HiddenChild_StillOccupiesItsSpace() {
+        var panel = StandardPanel();
+        ((UIElement)panel.Children[1]).Visibility = Visibility.Hidden;
+        panel.Measure(new Size(1150, double.PositiveInfinity));
+
+        // Hidden participates in layout and Collapsed does not; conflating them is a classic panel bug.
+        Assert.That(panel.DesiredSize.Width, Is.EqualTo(PackedWidth).Within(0.5));
+    }
+
+    [Test]
+    public void SingleChild_IsFlushLeftAndNeverStretched() {
+        var panel = new EdgeJustifiedWrapPanel { ItemGap = ItemGap, LineGap = LineGap };
+        panel.Children.Add(Stub(130, 25));
+        LayOut(panel, 1150);
+
+        var r = RectsOf(panel)[0];
+        Assert.Multiple(() => {
+            Assert.That(r.Left, Is.EqualTo(0).Within(0.5));
+            Assert.That(r.Width, Is.EqualTo(130).Within(0.5), "a lone child is not also the flush-right item");
+        });
+    }
+
+    [Test]
+    public void DegenerateInputs_DoNotThrow() {
+        var empty = new EdgeJustifiedWrapPanel { ItemGap = ItemGap, LineGap = LineGap };
+        empty.Measure(Unbounded);
+        Assert.That(empty.DesiredSize, Is.EqualTo(new Size(0, 0)));
+        Assert.DoesNotThrow(() => empty.Arrange(new Rect(0, 0, 0, 0)));
+
+        // Rect throws ArgumentException on a negative dimension, and a Grid legitimately passes a zero width.
+        var panel = StandardPanel();
+        Assert.DoesNotThrow(() => LayOut(panel, 0));
+        Assert.That(RectsOf(panel).Select(r => r.Width), Is.All.GreaterThanOrEqualTo(0.0));
+    }
+
+    [Test]
+    public void ChildWiderThanTheConstraint_TerminatesWithOneItemPerLine() {
+        // The "a line always accepts at least one item" guard is the only thing standing between this and an
+        // infinite loop. NUnit's [Timeout] cannot guard it: that runs the body on a worker thread and defeats
+        // [Apartment(STA)]. Reaching the assertion at all is the proof.
+        var panel = new EdgeJustifiedWrapPanel { ItemGap = ItemGap, LineGap = LineGap };
+        panel.Children.Add(Stub(5000, 25));
+        panel.Children.Add(Stub(110, 25));
+        panel.Measure(new Size(200, double.PositiveInfinity));
+
+        // Do not assert the width: MeasureCore clamps DesiredSize to the 200px constraint.
+        Assert.That(panel.DesiredSize.Height, Is.EqualTo(56).Within(0.5), "25 + LineGap + 25");
+    }
+
+    [Test]
+    public void DesiredHeightNeverDecreasesAsThePaneNarrows() {
+        var previous = 0.0;
+        foreach (var w in new[] { 1400.0, 900, 500, 460, 400, 300, 230, 150, 60 }) {
+            var panel = StandardPanel();
+            panel.Measure(new Size(w, double.PositiveInfinity));
+            Assert.That(panel.DesiredSize.Height, Is.GreaterThanOrEqualTo(previous - 0.5), $"height went down at width {w}");
+            previous = panel.DesiredSize.Height;
+        }
+    }
+
+    [Test]
+    public void ArrangeIsIdempotent() {
+        var panel = LayOut(StandardPanel(), 400);
+        var first = RectsOf(panel);
+
+        panel.InvalidateArrange();
+        panel.Arrange(new Rect(0, 0, 400, panel.DesiredSize.Height));
+
+        // Catches any accumulating cross-pass state, of which this panel has none and should keep none.
+        Assert.That(RectsOf(panel), Is.EqualTo(first));
+    }
+
+    [Test]
+    public void GapProperties_InvalidateMeasure_AndRejectNonsense() {
+        var panel = LayOut(StandardPanel(), 1150);
+        Assert.That(panel.IsMeasureValid, Is.True);
+
+        panel.ItemGap = 20;
+        // Fails if the DPs were registered with plain PropertyMetadata: the change would not repaint until
+        // something else happened to dirty layout.
+        Assert.That(panel.IsMeasureValid, Is.False);
+
+        Assert.Multiple(() => {
+            foreach (var bad in new[] { double.NaN, double.PositiveInfinity, -1.0 }) {
+                Assert.Throws<ArgumentException>(() => panel.ItemGap = bad, $"ItemGap accepted {bad}");
+                Assert.Throws<ArgumentException>(() => panel.LineGap = bad, $"LineGap accepted {bad}");
+            }
+        });
+    }
+
+    // The worst failure mode a custom Panel has is drawing outside its own bounds, because a Panel does not clip.
+    // Here the panel sits where it really ships: the Auto row under the "*" focus-chart row.
+    [Test]
+    public void InsideTheRealTwoRowGrid_TheFooterNeverDrawsOverTheChart() {
+        foreach (var w in new[] { 1150.0, 500, 400, 300, 230 }) {
+            var chart = new Border { Background = Brushes.Transparent };
+            var panel = StandardPanel();
+            panel.Margin = new Thickness(10, 15, 10, 5);
+
+            var grid = new Grid();
+            grid.RowDefinitions.Add(new RowDefinition { Height = new GridLength(1, GridUnitType.Star) });
+            grid.RowDefinitions.Add(new RowDefinition { Height = GridLength.Auto });
+            Grid.SetRow(chart, 0);
+            Grid.SetRow(panel, 1);
+            grid.Children.Add(chart);
+            grid.Children.Add(panel);
+
+            grid.Measure(new Size(w, 600));
+            grid.Arrange(new Rect(0, 0, w, 600));
+            grid.UpdateLayout();
+
+            var chartBottom = RectOf(chart, grid).Bottom;
+            foreach (var r in panel.Children.Cast<FrameworkElement>().Select(c => RectOf(c, grid))) {
+                Assert.That(r.Top, Is.GreaterThanOrEqualTo(chartBottom - 0.5), $"footer overlaps the chart at width {w}");
+                Assert.That(r.Bottom, Is.LessThanOrEqualTo(600.5), $"footer escapes the pane at width {w}");
+            }
+        }
+    }
+
+    [Test]
+    public void HorizontalAlignmentOtherThanStretch_DegradesQuietlyButStaysCorrect() {
+        var panel = StandardPanel();
+        panel.HorizontalAlignment = HorizontalAlignment.Left;
+        LayOut(panel, 1150);
+
+        // Documents the single easiest way to kill this feature with no error and no symptom beyond the group
+        // drifting off the right edge: a non-Stretch panel is arranged at its DesiredSize, so slack is always 0.
+        var r = RectsOf(panel);
+        Assert.Multiple(() => {
+            Assert.That(r[1].Left - r[0].Right, Is.EqualTo(ItemGap).Within(0.5), "no slack to justify with");
+            Assert.That(r[2].Right, Is.EqualTo(PackedWidth).Within(0.5));
+        });
+    }
+}
+
+/// <summary>
+/// Pure line-breaking table tests. No visual tree, so these carry the arithmetic cheaply and pin the exact
+/// one-line/wrap boundary that the STA fixture can only sample.
+/// </summary>
+[TestFixture]
+public class EdgeJustifiedWrapPanelComputeLinesTests {
+
+    private static readonly IReadOnlyList<Size> Standard = new[] {
+        new Size(130, 25), new Size(110, 25), new Size(195, 28),
+    };
+
+    private static (int lines, Size size) Break(double availableWidth, IReadOnlyList<Size> sizes = null) {
+        var runs = new List<EdgeJustifiedWrapPanel.LineRun>();
+        var size = EdgeJustifiedWrapPanel.ComputeLines(sizes ?? Standard, availableWidth, 12.0, 6.0, runs);
+        return (runs.Count, size);
+    }
+
+    // 459 is the packed width; FitEpsilon (0.5) is what keeps a line that fits to within a rounding error intact.
+    [TestCase(double.PositiveInfinity, 1)]
+    [TestCase(1150.0, 1)]
+    [TestCase(459.0, 1)]
+    [TestCase(458.5, 1)]
+    [TestCase(458.0, 2)]
+    [TestCase(400.0, 2)]
+    [TestCase(317.0, 2)]
+    [TestCase(316.0, 3)]
+    [TestCase(200.0, 3)]
+    [TestCase(0.0, 3)]
+    public void LineCountAcrossTheWidthRange(double availableWidth, int expected) {
+        Assert.That(Break(availableWidth).lines, Is.EqualTo(expected));
+    }
+
+    [Test]
+    public void OneLine_ReturnsThePackedSizeNotTheConstraint() {
+        var (lines, size) = Break(1150);
+        Assert.Multiple(() => {
+            Assert.That(lines, Is.EqualTo(1));
+            Assert.That(size.Width, Is.EqualTo(459.0).Within(0.001));
+            Assert.That(size.Height, Is.EqualTo(28.0).Within(0.001), "the tallest item on the line");
+        });
+    }
+
+    [Test]
+    public void TwoLines_CarryExactlyOneLineGap() {
+        var (lines, size) = Break(400);
+        Assert.Multiple(() => {
+            Assert.That(lines, Is.EqualTo(2));
+            Assert.That(size.Width, Is.EqualTo(317.0).Within(0.001), "the widest line, not the sum");
+            Assert.That(size.Height, Is.EqualTo(59.0).Within(0.001), "25 + 6 + 28 — n lines carry n-1 gaps");
+        });
+    }
+
+    [Test]
+    public void EmptyInput_IsZeroSizedAndProducesNoLines() {
+        var (lines, size) = Break(1150, Array.Empty<Size>());
+        Assert.Multiple(() => {
+            Assert.That(lines, Is.EqualTo(0));
+            Assert.That(size, Is.EqualTo(new Size(0, 0)));
+        });
+    }
+
+    [Test]
+    public void SingleOversizedItem_GetsOneLineAndItsOwnFullWidth() {
+        var (lines, size) = Break(100, new[] { new Size(5000, 25) });
+        Assert.Multiple(() => {
+            Assert.That(lines, Is.EqualTo(1), "the lone child must not also produce an empty trailing line");
+            Assert.That(size.Width, Is.EqualTo(5000.0).Within(0.001));
+            Assert.That(size.Height, Is.EqualTo(25.0).Within(0.001));
+        });
+    }
+
+    [Test]
+    public void Wrapping_PutsTheLeadingChildAloneAndKeepsTheTrailingGroupTogether() {
+        var runs = new List<EdgeJustifiedWrapPanel.LineRun>();
+        EdgeJustifiedWrapPanel.ComputeLines(Standard, 400, 12.0, 6.0, runs);
+
+        Assert.Multiple(() => {
+            Assert.That(runs[0].First, Is.EqualTo(0));
+            Assert.That(runs[0].Count, Is.EqualTo(1), "the leading child does not pair up with the trailing group");
+            Assert.That(runs[1].First, Is.EqualTo(1));
+            Assert.That(runs[1].Count, Is.EqualTo(2));
+            Assert.That(runs[1].Width, Is.EqualTo(317.0).Within(0.001), "110 + ItemGap + 195");
+        });
+    }
+}

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/Controls/EdgeJustifiedWrapPanelTests.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/Controls/EdgeJustifiedWrapPanelTests.cs
@@ -172,11 +172,16 @@ public class EdgeJustifiedWrapPanelTests {
             var height = panel.DesiredSize.Height;
 
             for (var i = 0; i < r.Count; ++i) {
-                // A Panel does NOT clip its children: a line drawn past the panel's own height renders over the
-                // focus chart in the star row above.
+                // A line past the panel's own reported height means the Auto row under-reserved: the footer then
+                // overflows the bottom of the pane and is silently layout-clipped.
                 Assert.That(r[i].Bottom, Is.LessThanOrEqualTo(height + 0.5), $"child {i} escapes the row at width {w}");
                 Assert.That(r[i].Top, Is.GreaterThanOrEqualTo(-0.5), $"child {i} above the row at width {w}");
                 Assert.That(r[i].Left, Is.GreaterThanOrEqualTo(-0.5), $"child {i} left of the row at width {w}");
+                // The right edge is the direction content actually escapes in, and the only one that catches a
+                // child measured against the constraint instead of at its natural width. RenderSize, not w:
+                // ArrangeCore legitimately enlarges the panel to its unclipped desired width.
+                Assert.That(r[i].Right, Is.LessThanOrEqualTo(panel.RenderSize.Width + 0.5),
+                    $"child {i} runs off the right edge at width {w}");
 
                 for (var j = i + 1; j < r.Count; ++j) {
                     var a = r[i];
@@ -281,17 +286,57 @@ public class EdgeJustifiedWrapPanelTests {
     }
 
     [Test]
-    public void ChildWiderThanTheConstraint_TerminatesWithOneItemPerLine() {
-        // The "a line always accepts at least one item" guard is the only thing standing between this and an
-        // infinite loop. NUnit's [Timeout] cannot guard it: that runs the body on a worker thread and defeats
-        // [Apartment(STA)]. Reaching the assertion at all is the proof.
+    public void ChildWiderThanTheConstraint_GetsALineToItselfRatherThanAnEmptyOne() {
+        // The oversized child is at index 1 ON PURPOSE: index 0 is placed by the leading-child special case and
+        // never reaches the "a line always accepts at least one item" guard, so an index-0 fixture would pass with
+        // the guard deleted. Here the guard is what stops the 5000px child from opening a phantom empty line.
         var panel = new EdgeJustifiedWrapPanel { ItemGap = ItemGap, LineGap = LineGap };
+        panel.Children.Add(Stub(130, 25));
         panel.Children.Add(Stub(5000, 25));
-        panel.Children.Add(Stub(110, 25));
+        panel.Children.Add(Stub(110, 28));
         panel.Measure(new Size(200, double.PositiveInfinity));
 
-        // Do not assert the width: MeasureCore clamps DesiredSize to the 200px constraint.
-        Assert.That(panel.DesiredSize.Height, Is.EqualTo(56).Within(0.5), "25 + LineGap + 25");
+        // Three lines of 25 / 25 / 28, two LineGaps. Do not assert the width: MeasureCore clamps DesiredSize to
+        // the 200px constraint even though the packed content is 5000 wide.
+        Assert.That(panel.DesiredSize.Height, Is.EqualTo(90).Within(0.5), "25 + 6 + 25 + 6 + 28, with no empty line");
+    }
+
+    // Children must be measured at their NATURAL width: measuring them against the constraint makes MeasureCore
+    // clamp each DesiredSize to the constraint, every child then "fits", and the panel stops wrapping at all —
+    // silently, since a clamped child still renders at its natural size and simply overhangs.
+    [Test]
+    public void ChildrenAreMeasuredAtTheirNaturalWidth_NotAgainstTheConstraint() {
+        var panel = StandardPanel();
+        panel.Measure(new Size(150, double.PositiveInfinity));
+
+        Assert.Multiple(() => {
+            Assert.That(((FrameworkElement)panel.Children[2]).DesiredSize.Width, Is.EqualTo(195).Within(0.5),
+                "the 195px child must not be clamped to the 150px constraint");
+            Assert.That(panel.DesiredSize.Height, Is.EqualTo(90).Within(0.5), "so the row still breaks to three lines");
+        });
+    }
+
+    // Non-monotonicity guard. A line's height is its tallest item, so re-breaking at a different width can shuffle
+    // which children share a line and need MORE height than a narrower break did. MeasureOverride therefore
+    // reserves height for the width ArrangeOverride will really be handed, which is the unclipped desired width
+    // whenever some child is wider than the constraint.
+    [Test]
+    public void WhenAChildOverflowsTheConstraint_TheReservedHeightMatchesWhatArrangeLaysOut() {
+        var panel = new EdgeJustifiedWrapPanel { ItemGap = ItemGap, LineGap = 0 };
+        panel.Children.Add(Stub(243, 29));
+        panel.Children.Add(Stub(93, 14));
+        panel.Children.Add(Stub(163, 3));
+        panel.Children.Add(Stub(21, 58));
+        panel.Children.Add(Stub(95, 39));
+
+        panel.Measure(new Size(136, double.PositiveInfinity));
+        var reserved = panel.DesiredSize.Height;
+        panel.Arrange(new Rect(0, 0, 136, reserved));
+
+        foreach (var r in RectsOf(panel)) {
+            Assert.That(r.Bottom, Is.LessThanOrEqualTo(reserved + 0.5),
+                "arrange laid out taller than measure reserved — the footer overflows the pane");
+        }
     }
 
     [Test]
@@ -335,10 +380,11 @@ public class EdgeJustifiedWrapPanelTests {
         });
     }
 
-    // The worst failure mode a custom Panel has is drawing outside its own bounds, because a Panel does not clip.
-    // Here the panel sits where it really ships: the Auto row under the "*" focus-chart row.
+    // The panel where it really ships: the Auto row under the "*" focus-chart row. The Auto row must reserve
+    // exactly what the footer then lays out — a footer that measures short and arranges tall spills past the pane,
+    // and a Panel does not clip its own children.
     [Test]
-    public void InsideTheRealTwoRowGrid_TheFooterNeverDrawsOverTheChart() {
+    public void InsideTheRealTwoRowGrid_TheAutoRowReservesExactlyWhatTheFooterLaysOut() {
         foreach (var w in new[] { 1150.0, 500, 400, 300, 230 }) {
             var chart = new Border { Background = Brushes.Transparent };
             var panel = StandardPanel();
@@ -356,10 +402,17 @@ public class EdgeJustifiedWrapPanelTests {
             grid.Arrange(new Rect(0, 0, w, 600));
             grid.UpdateLayout();
 
-            var chartBottom = RectOf(chart, grid).Bottom;
+            var footerRow = grid.RowDefinitions[1].ActualHeight;
+            Assert.That(grid.RowDefinitions[0].ActualHeight + footerRow, Is.EqualTo(600).Within(0.5),
+                $"the two rows do not account for the pane at width {w}");
+            // DesiredSize is margin-inclusive, so this is the footer's full 15 + content + 5.
+            Assert.That(footerRow, Is.EqualTo(panel.DesiredSize.Height).Within(0.5),
+                $"the Auto row does not reserve what the footer asked for at width {w}");
+
             foreach (var r in panel.Children.Cast<FrameworkElement>().Select(c => RectOf(c, grid))) {
-                Assert.That(r.Top, Is.GreaterThanOrEqualTo(chartBottom - 0.5), $"footer overlaps the chart at width {w}");
-                Assert.That(r.Bottom, Is.LessThanOrEqualTo(600.5), $"footer escapes the pane at width {w}");
+                // 5 is the panel's bottom margin: anything past that is height the Auto row never reserved.
+                Assert.That(r.Bottom, Is.LessThanOrEqualTo(600 - 5 + 0.5), $"footer spills past its row at width {w}");
+                Assert.That(r.Top, Is.GreaterThanOrEqualTo(600 - footerRow - 0.5), $"footer starts above its row at width {w}");
             }
         }
     }

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/AutoFocus/DataTemplates.xaml
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/AutoFocus/DataTemplates.xaml
@@ -695,7 +695,7 @@
     <!--  Implicit (by-type) template, used only when a HocusFocusVM is shown on its own — chiefly the "Run
           Autofocus" sequence item, which NINA hosts in a SizeToContent CustomWindow floored at just 350x300. It
           renders the shared CORE (chart + info) only: the Replay Saved AF / Review Frames row is deliberately
-          omitted here — those are pane-only controls, and sharing one grid cell they overlapped in the narrow popup.
+          omitted here — those are pane-only controls, and a sequence run has no kept frames to review.
           The docked AutoFocus pane resolves the keyed *_Dockable template above instead (via NINA's
           GenericTemplateSelector), which keeps that row. The Border's minimum size gives the chart a usable popup
           without constraining the dock; its Padding keeps the chart and info text off the window edge; Stretch makes

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/AutoFocus/DataTemplates.xaml
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/AutoFocus/DataTemplates.xaml
@@ -642,25 +642,34 @@
                 VerticalContentAlignment="Stretch"
                 Content="{Binding}"
                 ContentTemplate="{StaticResource NINA.Joko.Plugins.HocusFocus.AutoFocus.HocusFocusVM_Core}" />
-            <ninactrl:CancellableButton
+            <!--  These three used to be a left-aligned button and a right-aligned StackPanel sharing this one Auto
+                  row cell, so they OVERLAPPED as soon as the docked pane got narrow (~500px): a Grid cell gives
+                  every child the full cell, and nothing there yields. EdgeJustifiedWrapPanel keeps the wide look
+                  exactly (Replay flush left, Review Frames + toggle packed 12px apart flush right, all slack in the
+                  middle gap) and WRAPS instead of colliding once the three no longer fit — Replay onto a line of its
+                  own, then Review Frames and the toggle that enables it staying together on the next. The panel's
+                  Margin carries what were the children's outer margins, so wrapped lines start at the same inset as
+                  the first, and ItemGap replaces the toggle group's old 12px left margin. All three are separate
+                  children so the group can break further at very narrow widths; the checkbox and its label stay ONE
+                  child, because the themed ON/OFF pill must never be split from its text. Do not set
+                  HorizontalAlignment on the panel — Stretch is what gives it the full row width to justify
+                  against — and do not give the children horizontal margins, which would add to ItemGap rather than
+                  absorb into it.  -->
+            <controls:EdgeJustifiedWrapPanel
                 Grid.Row="1"
-                Height="25"
-                Margin="10,15,0,5"
-                Padding="5,0,5,0"
-                HorizontalAlignment="Left"
-                VerticalAlignment="Bottom"
-                ButtonText="Replay Saved AF"
-                CancelButtonImage="{StaticResource CancelSVG}"
-                CancelCommand="{Binding CancelLoadSavedAutoFocusRunCommand}"
-                CancelToolTip="{ns:Loc LblCancel}"
-                Command="{Binding LoadSavedAutoFocusRunCommand}"
-                ToolTip="Replays saved AutoFocus images (Save enabled in Hocus Focus -&gt; Auto Focus Options) to produce an auto focus curve using whatever the current star detection and fit settings are" />
-            <StackPanel
-                Grid.Row="1"
-                Margin="0,15,10,5"
-                HorizontalAlignment="Right"
-                VerticalAlignment="Bottom"
-                Orientation="Horizontal">
+                Margin="10,15,10,5"
+                ItemGap="12"
+                LineGap="6">
+                <ninactrl:CancellableButton
+                    Height="25"
+                    Padding="5,0,5,0"
+                    VerticalAlignment="Bottom"
+                    ButtonText="Replay Saved AF"
+                    CancelButtonImage="{StaticResource CancelSVG}"
+                    CancelCommand="{Binding CancelLoadSavedAutoFocusRunCommand}"
+                    CancelToolTip="{ns:Loc LblCancel}"
+                    Command="{Binding LoadSavedAutoFocusRunCommand}"
+                    ToolTip="Replays saved AutoFocus images (Save enabled in Hocus Focus -&gt; Auto Focus Options) to produce an auto focus curve using whatever the current star detection and fit settings are" />
                 <Button
                     Height="25"
                     VerticalAlignment="Center"
@@ -669,7 +678,6 @@
                     <TextBlock Margin="5,0,5,0" Text="Review Frames" />
                 </Button>
                 <StackPanel
-                    Margin="12,0,0,0"
                     VerticalAlignment="Center"
                     Orientation="Horizontal"
                     ToolTip="When on, the per-frame images from an auto-focus run started here in the AutoFocus pane — a live run or a Replay Saved AF — are kept in memory so the &quot;Review Frames&quot; button can show each frame with its detected stars and HFRs. Only applies to runs from this pane — auto-focus during an imaging sequence never keeps frames (it would use too much memory). The frames are released when you start a new run or close the review window. Off by default; saved in your profile.">
@@ -681,7 +689,7 @@
                         VerticalAlignment="Center"
                         Text="Keep frames for review" />
                 </StackPanel>
-            </StackPanel>
+            </controls:EdgeJustifiedWrapPanel>
         </Grid>
     </DataTemplate>
     <!--  Implicit (by-type) template, used only when a HocusFocusVM is shown on its own — chiefly the "Run

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/Controls/EdgeJustifiedWrapPanel.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/Controls/EdgeJustifiedWrapPanel.cs
@@ -40,6 +40,13 @@ namespace NINA.Joko.Plugins.HocusFocus.Controls {
     /// Group integrity is structural: anything that must never be split across lines (a themed ON/OFF toggle and
     /// its label, say) is passed as ONE child, typically a StackPanel, and this panel never looks inside it.
     /// No attached "keep together" property is needed, or offered.
+    ///
+    /// EVERY CHILD MUST BE CONTENT-SIZED. Children are measured at unbounded width and arranged at exactly that
+    /// desired width, so nothing inside one can reflow: a <c>TextWrapping="Wrap"</c> TextBlock never wraps and is
+    /// layout-clipped at its natural width, and a child with <c>HorizontalAlignment="Stretch"</c> and no width of
+    /// its own collapses to nothing. Both fail silently. That is the deliberate trade — the panel breaks BETWEEN
+    /// children so their text does not have to break inside them — but it means a nested WrapPanel is not a way to
+    /// subdivide a group further; give the panel more children instead.
     /// </summary>
     public class EdgeJustifiedWrapPanel : Panel {
 
@@ -112,7 +119,21 @@ namespace NINA.Joko.Plugins.HocusFocus.Controls {
             // availableSize.Width is only ever COMPARED against inside ComputeLines, never used in arithmetic,
             // so an infinite constraint (SizeToContent window, ScrollViewer, Auto grid column) just means "one
             // line" and can never leak Infinity or NaN into the DesiredSize we return.
-            return ComputeLines(sizes, availableSize.Width, ItemGap, LineGap, new List<LineRun>(sizes.Count));
+            var lines = new List<LineRun>(sizes.Count);
+            var packed = ComputeLines(sizes, availableSize.Width, ItemGap, LineGap, lines);
+
+            // Measure at the width ARRANGE will really see, so the height we reserve is the height we then use.
+            // A packed width above the constraint means some child is wider than the constraint on its own, and
+            // ArrangeCore responds by raising the arrange slot to this unclipped desired width — at which point
+            // the greedy break repacks, and because a line's height is its tallest item, repacking can need MORE
+            // height than the narrower break did. Recomputing here is a fixed point rather than the first step of
+            // a loop: the packed width can only exceed the constraint by being exactly the widest child's width,
+            // and re-breaking at that width cannot produce a line wider still.
+            if (packed.Width > availableSize.Width) {
+                packed = ComputeLines(sizes, packed.Width, ItemGap, LineGap, lines);
+            }
+
+            return packed;
         }
 
         protected override Size ArrangeOverride(Size finalSize) {
@@ -122,12 +143,12 @@ namespace NINA.Joko.Plugins.HocusFocus.Controls {
             var itemGap = ItemGap;
             var lineGap = LineGap;
 
-            // Re-break from finalSize.Width. finalSize is NOT the measured size: this panel's HorizontalAlignment
-            // is Stretch, so an Auto grid row arranges it at the FULL row width — which is precisely what makes
-            // the trailing group land flush right — and a Grid star column or a ScrollViewer can equally arrange
-            // it narrower than it measured, with no intervening measure pass. Caching measure-time breaks or x
-            // positions brings back the very overlap this panel exists to fix, and can push a line below
-            // finalSize.Height, where it draws over the chart above (a Panel does not clip its children).
+            // Re-break from finalSize.Width. finalSize is NOT the measure constraint: this panel's
+            // HorizontalAlignment is Stretch, so an Auto grid row arranges it at the FULL row width — which is
+            // precisely what makes the trailing group land flush right. Caching measure-time breaks or x positions
+            // would leave the trailing group stranded wherever the narrower measure pass put it, which is the very
+            // misplacement this panel exists to fix. Note that WPF never arranges us narrower than we measured:
+            // ArrangeCore raises the slot to our unclipped desired size and applies a layout clip instead.
             var lines = new List<LineRun>(sizes.Count);
             ComputeLines(sizes, finalSize.Width, itemGap, lineGap, lines);
 
@@ -157,10 +178,10 @@ namespace NINA.Joko.Plugins.HocusFocus.Controls {
                     x += size.Width;
                 }
 
-                // Top-down only; never compute y backwards from finalSize.Height. Re-breaking here can
-                // legitimately need more height than finalSize.Height because measure ran at a different width.
-                // Draw it anyway — the width change that caused it invalidates measure up the tree, so the next
-                // pass corrects the row height. Calling InvalidateMeasure from inside arrange risks a layout cycle.
+                // Top-down only; never compute y backwards from finalSize.Height. MeasureOverride reserves height
+                // for the break at this same width, so the lines fit — and if a future change ever breaks that
+                // agreement, the surplus overflows the BOTTOM of the pane (this row is the last one) rather than
+                // reaching the chart above. Calling InvalidateMeasure from inside arrange risks a layout cycle.
                 y += line.Height + lineGap;
             }
 

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/Controls/EdgeJustifiedWrapPanel.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/Controls/EdgeJustifiedWrapPanel.cs
@@ -1,0 +1,288 @@
+#region "copyright"
+
+/*
+    Copyright © 2021 - 2026 George Hilios <ghilios+NINA@googlemail.com>
+
+    This Source Code Form is subject to the terms of the Mozilla Public
+    License, v. 2.0. If a copy of the MPL was not distributed with this
+    file, You can obtain one at http://mozilla.org/MPL/2.0/.
+*/
+
+#endregion "copyright"
+
+using System;
+using System.Collections.Generic;
+using System.Windows;
+using System.Windows.Controls;
+
+namespace NINA.Joko.Plugins.HocusFocus.Controls {
+
+    /// <summary>
+    /// A horizontal panel that justifies its content to both edges while everything fits on one line, and wraps
+    /// to left-packed lines when it does not. No WPF built-in does both: DockPanel and Grid justify but then
+    /// shrink-and-clip instead of breaking, and WrapPanel breaks but always packs left, so the wide case loses
+    /// its flush-right group. There is no flexbox "space-between + wrap" and no adaptive trigger in WPF.
+    ///
+    /// Single-line layout: the FIRST visible child is flush left, and every child after it is packed together,
+    /// <see cref="ItemGap"/> apart, flush right. All slack lands in the one gap after the leading child, so a
+    /// trailing group of related controls stays cohesive instead of being spread evenly across the row (CSS
+    /// space-between), which is what a footer row of "one primary action, left | related actions, right" wants.
+    /// One visible child is simply flush left and never stretched; zero children measure to 0x0.
+    ///
+    /// Multi-line layout: the leading child keeps a line to itself and the trailing group wraps among itself,
+    /// every line packed left with <see cref="ItemGap"/> between items and <see cref="LineGap"/> between lines.
+    /// Nothing is justified once the row has broken — there is no single row left to justify against, and
+    /// flinging each line's items to opposite margins reads as an alignment bug. Wrapping this way rather than
+    /// greedily from the first child preserves the grouping the single-line case shows: the leading child is the
+    /// odd one out at both widths, instead of pairing up with the head of the trailing group and orphaning the
+    /// rest of that group beneath it.
+    ///
+    /// Group integrity is structural: anything that must never be split across lines (a themed ON/OFF toggle and
+    /// its label, say) is passed as ONE child, typically a StackPanel, and this panel never looks inside it.
+    /// No attached "keep together" property is needed, or offered.
+    /// </summary>
+    public class EdgeJustifiedWrapPanel : Panel {
+
+        // Fit-test tolerance, in device-independent pixels. UseLayoutRounding is an inherited property that a
+        // theme can switch on; when it is on, WPF rounds both DesiredSize and the arranged rect to whole device
+        // pixels AFTER this code runs, so an exact comparison can break a line that visually fits by a fraction
+        // of a pixel. Erring on the "still fits" side cannot produce an overlap: the slack clamp in
+        // ArrangeOverride floors the justified gap at ItemGap no matter how the comparison went.
+        private const double FitEpsilon = 0.5d;
+
+        public static readonly DependencyProperty ItemGapProperty = DependencyProperty.Register(
+            "ItemGap",
+            typeof(double),
+            typeof(EdgeJustifiedWrapPanel),
+            new FrameworkPropertyMetadata(
+                0.0d,
+                FrameworkPropertyMetadataOptions.AffectsMeasure | FrameworkPropertyMetadataOptions.AffectsArrange),
+            IsFiniteAndNonNegative);
+
+        public static readonly DependencyProperty LineGapProperty = DependencyProperty.Register(
+            "LineGap",
+            typeof(double),
+            typeof(EdgeJustifiedWrapPanel),
+            new FrameworkPropertyMetadata(
+                0.0d,
+                FrameworkPropertyMetadataOptions.AffectsMeasure | FrameworkPropertyMetadataOptions.AffectsArrange),
+            IsFiniteAndNonNegative);
+
+        /// <summary>
+        /// Minimum horizontal space between two items on the same line, and the floor on the justified gap.
+        /// Defaults to 0 so a caller can keep spacing items with their own margins instead — use one or the
+        /// other, never both: WPF margins do not collapse, so a 12px margin plus a 12px gap is 24px.
+        /// </summary>
+        public double ItemGap {
+            get { return (double)GetValue(ItemGapProperty); }
+            set { SetValue(ItemGapProperty, value); }
+        }
+
+        /// <summary>Vertical space between wrapped lines. Has no effect until the content wraps.</summary>
+        public double LineGap {
+            get { return (double)GetValue(LineGapProperty); }
+            set { SetValue(LineGapProperty, value); }
+        }
+
+        // Rejects NaN/Infinity/negative at the assignment site, where the stack trace names the culprit, rather
+        // than letting it surface as an opaque "should not return PositiveInfinity or NaN as its DesiredSize"
+        // failure inside the layout pass.
+        private static bool IsFiniteAndNonNegative(object value) {
+            return value is double d && !double.IsNaN(d) && !double.IsInfinity(d) && d >= 0.0d;
+        }
+
+        protected override Size MeasureOverride(Size availableSize) {
+            var children = InternalChildren;
+
+            // Measure at UNBOUNDED width. MeasureCore clamps a child's DesiredSize to whatever size it was
+            // handed, so measuring at the constraint reports an over-wide child as exactly available-wide and
+            // the fit test below can never fail. Nothing in this panel is allowed to reflow horizontally (the
+            // "Keep frames for review" label must not break mid-phrase), so natural width is the correct input —
+            // and it stays readable from DesiredSize during arrange, which is why this panel needs no cross-pass
+            // state whatsoever. availableSize.Height is passed through unchanged; under a Height="Auto" grid row
+            // that is PositiveInfinity, which is fine and expected.
+            var childConstraint = new Size(double.PositiveInfinity, availableSize.Height);
+            for (int i = 0; i < children.Count; ++i) {
+                children[i].Measure(childConstraint); // collapsed children included; Measure short-circuits them to 0x0
+            }
+
+            var visible = CollectVisible(children);
+            var sizes = DesiredSizesOf(children, visible);
+
+            // availableSize.Width is only ever COMPARED against inside ComputeLines, never used in arithmetic,
+            // so an infinite constraint (SizeToContent window, ScrollViewer, Auto grid column) just means "one
+            // line" and can never leak Infinity or NaN into the DesiredSize we return.
+            return ComputeLines(sizes, availableSize.Width, ItemGap, LineGap, new List<LineRun>(sizes.Count));
+        }
+
+        protected override Size ArrangeOverride(Size finalSize) {
+            var children = InternalChildren;
+            var visible = CollectVisible(children);
+            var sizes = DesiredSizesOf(children, visible);
+            var itemGap = ItemGap;
+            var lineGap = LineGap;
+
+            // Re-break from finalSize.Width. finalSize is NOT the measured size: this panel's HorizontalAlignment
+            // is Stretch, so an Auto grid row arranges it at the FULL row width — which is precisely what makes
+            // the trailing group land flush right — and a Grid star column or a ScrollViewer can equally arrange
+            // it narrower than it measured, with no intervening measure pass. Caching measure-time breaks or x
+            // positions brings back the very overlap this panel exists to fix, and can push a line below
+            // finalSize.Height, where it draws over the chart above (a Panel does not clip its children).
+            var lines = new List<LineRun>(sizes.Count);
+            ComputeLines(sizes, finalSize.Width, itemGap, lineGap, lines);
+
+            double y = 0.0d;
+            for (int l = 0; l < lines.Count; ++l) {
+                var line = lines[l];
+
+                // Justify only while the whole row is on one line and there is something to justify against.
+                // Math.Max keeps the gap at >= ItemGap when the parent arranges us narrower than we measured;
+                // a negative slack is the overlap bug, and Rect throws ArgumentException on a negative width.
+                double slack = lines.Count == 1 && line.Count > 1
+                    ? Math.Max(0.0d, finalSize.Width - line.Width)
+                    : 0.0d;
+
+                double x = 0.0d;
+                for (int k = 0; k < line.Count; ++k) {
+                    if (k > 0) {
+                        x += itemGap + (k == 1 ? slack : 0.0d); // the entire slack goes into the first gap
+                    }
+
+                    var size = sizes[line.First + k];
+
+                    // Arrange at the LINE height, not the child's own, so each child's VerticalAlignment still
+                    // positions it within the line (Bottom for the taller-row case, Center for the rest).
+                    children[visible[line.First + k]].Arrange(
+                        new Rect(x, y, Math.Max(0.0d, size.Width), Math.Max(0.0d, line.Height)));
+                    x += size.Width;
+                }
+
+                // Top-down only; never compute y backwards from finalSize.Height. Re-breaking here can
+                // legitimately need more height than finalSize.Height because measure ran at a different width.
+                // Draw it anyway — the width change that caused it invalidates measure up the tree, so the next
+                // pass corrects the row height. Calling InvalidateMeasure from inside arrange risks a layout cycle.
+                y += line.Height + lineGap;
+            }
+
+            // Every child must be arranged exactly once. A measured-but-never-arranged child keeps
+            // IsArrangeValid false and renders at its stale position.
+            for (int i = 0; i < children.Count; ++i) {
+                if (children[i].Visibility == Visibility.Collapsed) {
+                    children[i].Arrange(new Rect(0.0d, 0.0d, 0.0d, 0.0d));
+                }
+            }
+
+            return finalSize;
+        }
+
+        /// <summary>
+        /// Line breaking: everything on one line while it fits, otherwise the leading child alone on the first
+        /// line and the trailing group wrapped greedily among itself, at least one item per line. Fills
+        /// <paramref name="lines"/> and returns the PACKED content size — never the constraint. Pure, so both
+        /// layout overrides can call it and the interesting cases are unit testable with no visual tree.
+        /// </summary>
+        internal static Size ComputeLines(IReadOnlyList<Size> sizes, double availableWidth, double itemGap, double lineGap, List<LineRun> lines) {
+            lines.Clear();
+            if (sizes.Count == 0) {
+                return new Size(0.0d, 0.0d);
+            }
+
+            double packedWidth = 0.0d;
+            double packedHeight = 0.0d;
+            for (int k = 0; k < sizes.Count; ++k) {
+                packedWidth += (k > 0 ? itemGap : 0.0d) + sizes[k].Width;
+                packedHeight = Math.Max(packedHeight, sizes[k].Height);
+            }
+
+            // availableWidth is only ever COMPARED against, never used in arithmetic, so an infinite constraint
+            // takes this branch and no Infinity or NaN can reach the size we return.
+            if (packedWidth <= availableWidth + FitEpsilon) {
+                lines.Add(new LineRun(0, sizes.Count, packedWidth, packedHeight));
+                return new Size(packedWidth, packedHeight);
+            }
+
+            // Break at the leading/trailing boundary FIRST. Greedy breaking from index 0 would instead fill line 1
+            // with the leading child plus as much of the trailing group as fits, orphaning the remainder of that
+            // group on line 2 — directly beneath, and so read as belonging to, the one child it is unrelated to.
+            lines.Add(new LineRun(0, 1, sizes[0].Width, sizes[0].Height));
+            double totalWidth = sizes[0].Width;
+            double totalHeight = sizes[0].Height;
+
+            int first = 1;
+            int count = 0;
+            double lineWidth = 0.0d;
+            double lineHeight = 0.0d;
+
+            for (int k = 1; k < sizes.Count; ++k) {
+                var size = sizes[k];
+
+                // The count > 0 guard is the termination guarantee: a line ALWAYS accepts at least one item, so
+                // a child wider than the constraint — or a zero-width constraint, which a Grid legitimately
+                // passes — gets a line to itself instead of spinning here forever.
+                if (count > 0 && lineWidth + itemGap + size.Width > availableWidth + FitEpsilon) {
+                    lines.Add(new LineRun(first, count, lineWidth, lineHeight));
+                    totalWidth = Math.Max(totalWidth, lineWidth);
+                    totalHeight += lineGap + lineHeight;
+                    first = k;
+                    count = 0;
+                    lineWidth = 0.0d;
+                    lineHeight = 0.0d;
+                }
+
+                lineWidth += (count > 0 ? itemGap : 0.0d) + size.Width;
+                lineHeight = Math.Max(lineHeight, size.Height);
+                ++count;
+            }
+
+            // Empty only when a lone child did not fit, and that child already has its line above.
+            if (count > 0) {
+                lines.Add(new LineRun(first, count, lineWidth, lineHeight));
+                totalWidth = Math.Max(totalWidth, lineWidth);
+                totalHeight += lineGap + lineHeight; // n lines carry n-1 gaps: this one precedes the line it adds
+            }
+
+            return new Size(totalWidth, totalHeight);
+        }
+
+        // Indices of the non-collapsed children, in order. A collapsed child must contribute neither width nor a
+        // gap; walking a compacted list is what keeps the phantom-gap bug structurally impossible.
+        private static List<int> CollectVisible(UIElementCollection children) {
+            var visible = new List<int>(children.Count);
+            for (int i = 0; i < children.Count; ++i) {
+                if (children[i].Visibility != Visibility.Collapsed) {
+                    visible.Add(i);
+                }
+            }
+            return visible;
+        }
+
+        private static List<Size> DesiredSizesOf(UIElementCollection children, List<int> visible) {
+            var sizes = new List<Size>(visible.Count);
+            for (int k = 0; k < visible.Count; ++k) {
+                sizes.Add(children[visible[k]].DesiredSize);
+            }
+            return sizes;
+        }
+
+        /// <summary>One laid-out line: a run over the VISIBLE children, its packed width and its tallest item.</summary>
+        internal readonly struct LineRun {
+
+            public LineRun(int first, int count, double width, double height) {
+                First = first;
+                Count = count;
+                Width = width;
+                Height = height;
+            }
+
+            /// <summary>Index of the line's first item within the compacted list of visible children.</summary>
+            public int First { get; }
+
+            public int Count { get; }
+
+            /// <summary>Sum of the items' desired widths plus (Count - 1) ItemGaps.</summary>
+            public double Width { get; }
+
+            public double Height { get; }
+        }
+    }
+}


### PR DESCRIPTION
## The bug

In the docked AutoFocus pane, "Replay Saved AF" and the "Review Frames" + "Keep frames for review" group collided once the pane got narrow:

Narrow (~528px) — the controls overlap | Wide (~1150px) — correct
:---:|:---:
the Replay button and the toggle draw on top of each other | Replay flush left, Review Frames + toggle flush right

They were never laid out relative to each other. Both were children of a **single `Auto` grid-row cell**, one `HorizontalAlignment="Left"` and one `="Right"`. A Grid cell hands every child the full cell and nobody yields, so below roughly a 500px pane they simply drew on top of one another.

## The fix

A small custom panel, `Controls/EdgeJustifiedWrapPanel.cs`, holding the three controls as separate children.

- **On one line** it reproduces the wide layout exactly: leading child flush left, trailing group packed `ItemGap` apart flush right, all slack in the single gap between.
- **When they no longer fit** it breaks: "Replay Saved AF" onto a line of its own, then "Review Frames" and the toggle that enables it staying together on the next; at very narrow widths, one control per line.

No WPF built-in does both halves — DockPanel and Grid justify but then shrink and clip, WrapPanel breaks but always packs left, and there is no width-breakpoint trigger. So there is **no hardcoded threshold anywhere**: every break point falls out of the real measured widths under the live theme, font and DPI.

### One judgment call

Wrapping breaks at the leading/trailing boundary rather than greedily from the first child. A greedy break would put "Review Frames" beside "Replay Saved AF" and orphan the "Keep frames for review" toggle on the line below — directly under, and so reading as belonging to, the one control it has nothing to do with. The cost is one extra line in a narrow band around 270–340px of pane width.

## Verification

Full suite green: **4015 passed, 0 failed**.

The new fixture is mutation-tested rather than merely green — each invariant has a killer test:

| Mutation | Tests killed |
|---|---|
| Measure children against the constraint instead of at natural width | 3 |
| Drop the fixed-point height re-measure | 2 |
| Delete the "a line always accepts at least one item" guard | 2 |
| Revert to a greedy break from index 0 | 10 |
| Arrange children at their own height instead of the line height | 2 |

A structural test also pins the shipped markup (exactly one element in the footer's grid cell, the checkbox never split from its caption, no `TextWrapping` in an `Auto` row), since the real template cannot be loaded in a test host.

## Review follow-ups (second commit)

An adversarial review raised 11 candidate defects; 8 were refuted and 3 were real:

1. **Height was not monotone in width past three children.** A line is as tall as its tallest item, so re-breaking at a different width shuffles which children share a line and can need *more* height. When a child is wider than the constraint, `ArrangeCore` raises the arrange slot to the unclipped desired width, so arrange re-breaks at a width measure never saw and the last line is silently clipped away — permanently, since nothing re-dirties measure. `MeasureOverride` now measures at the width arrange will actually be handed. Not reachable with today's three children, but the panel is reusable.
2. **The regression sweep asserted three of four edges, never the right one** — the direction content actually escapes in — so measuring children against the constraint left all 40 tests green.
3. **The oversized-child test never reached the guard it claimed to cover** (its 5000px child sat at index 0, which the leading-child break places first).

Also corrected comments that had the geometry backwards (the chart is the row *above*, so overflow goes off the bottom of the pane, not over the chart) and one claiming WPF can arrange the panel narrower than it measured, which `ArrangeCore` prevents.

## Worth a manual check

Drag the docked pane from wide to narrow. The stub widths in the tests approximate the real themed controls but do not set the true break points.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LnfDSRS7zCFV5zuVAkJyvk