### PR TITLE
AF-bank cleanup: V-0 fired so F82's fix is void, MaxDistortion bounded at PI/4, A4 repaired

### DIFF
--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/Bank/CapSemanticsTests.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/Bank/CapSemanticsTests.cs
@@ -1,0 +1,166 @@
+#region "copyright"
+
+/*
+    Copyright © 2021 - 2026 George Hilios <ghilios+NINA@googlemail.com>
+
+    This Source Code Form is subject to the terms of the Mozilla Public
+    License, v. 2.0. If a copy of the MPL was not distributed with this
+    file, You can obtain one at http://mozilla.org/MPL/2.0/.
+*/
+
+#endregion "copyright"
+
+using NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization;
+using NUnit.Framework;
+using TestApp.SynthBank;
+
+namespace NINA.Joko.Plugins.HocusFocus.Tests.Bank;
+
+/// <summary>
+/// A4's cap-semantics rule. The two tests that matter are the two defects the rule carried: the boundary was
+/// rebuilt from the REQUESTED sweep while the product used the FITTED span, and only <c>WasCapped</c> was read
+/// when the band floor clamps to the same bound.
+/// </summary>
+[TestFixture]
+public class CapSemanticsTests {
+
+    private const double Mult = StepSizeRecommender.MaxHalfWidthSampledHalfSpanMultiple;   // 1.5
+
+    // ---- the boundary comes from the FITTED span, not the requested sweep ----
+
+    /// <summary>
+    /// D01 r1's shape, in the numbers the bank published: the sweep REQUESTED 2×4×3 = 24.0 but only 12.0 survived
+    /// into the fit, so the product's bound was 1.5 × 0.5 × 12.0 = 9.0 while A4 was asserting against
+    /// 1.5 × 0.5 × 24.0 = 18.0 — twice the bound the product ever applied.
+    /// </summary>
+    [Test]
+    public void Evaluate_UsesTheFittedSpan_NotTheRequestedSweep() {
+        var r = CapSemantics.Evaluate(
+            truthHalfWidth: 12.0, fittedSearchSpan: 12.0,
+            requestedOffsetSteps: 4, requestedStepSize: 3.0,
+            wasCapped: true, wasBandFloored: false);
+
+        Assert.Multiple(() => {
+            Assert.That(r.SpanSource, Is.EqualTo("fitted"));
+            Assert.That(r.CapBoundary, Is.EqualTo(Mult * 0.5 * 12.0).Within(1e-12), "boundary must come from the fitted span");
+            // truth 12.0 is above the real bound 9.0, and the round WAS capped -> the rule agrees.
+            Assert.That(r.PredictedBounded, Is.True);
+            Assert.That(r.Verdict, Is.EqualTo(CapSemanticsVerdict.Pass));
+        });
+    }
+
+    /// <summary>
+    /// The same round scored the old way: against the requested sweep the boundary is 18.0, truth 12.0 sits
+    /// below it, so the rule would have predicted "not bounded" while the product plainly capped — a FAIL
+    /// invented by the assertion. Pinned here so the regression is visible rather than argued.
+    /// </summary>
+    [Test]
+    public void Evaluate_AgainstTheRequestedSweep_WouldContradictACappedRound() {
+        var legacy = CapSemantics.Evaluate(
+            truthHalfWidth: 12.0, fittedSearchSpan: double.NaN,   // NaN => legacy fallback to the requested sweep
+            requestedOffsetSteps: 4, requestedStepSize: 3.0,
+            wasCapped: true, wasBandFloored: false);
+
+        Assert.Multiple(() => {
+            Assert.That(legacy.SpanSource, Is.EqualTo("requested"));
+            Assert.That(legacy.CapBoundary, Is.EqualTo(Mult * 4 * 3.0).Within(1e-12));
+            Assert.That(legacy.PredictedBounded, Is.False, "the requested-sweep boundary is 18.0, above truth 12.0");
+            Assert.That(legacy.ActualBounded, Is.True, "but the recommender did cap");
+            Assert.That(legacy.Verdict, Is.EqualTo(CapSemanticsVerdict.Fail));
+        });
+    }
+
+    /// <summary>
+    /// The compatibility guarantee: on the 36 of 37 bank rounds where nothing was dropped, fitted == requested
+    /// and the boundary is unchanged, so re-scoring an old artifact cannot move a verdict.
+    /// </summary>
+    [Test]
+    public void Evaluate_WhenFittedEqualsRequested_MatchesTheLegacyBoundaryExactly() {
+        // requested span = 2 × offsetSteps × stepSize = 2 × 4 × 2 = 16.0
+        var fitted = CapSemantics.Evaluate(20.0, 16.0, 4, 2.0, wasCapped: true, wasBandFloored: false);
+        var legacy = CapSemantics.Evaluate(20.0, double.NaN, 4, 2.0, wasCapped: true, wasBandFloored: false);
+
+        Assert.Multiple(() => {
+            Assert.That(fitted.CapBoundary, Is.EqualTo(legacy.CapBoundary).Within(1e-12));
+            Assert.That(fitted.Verdict, Is.EqualTo(legacy.Verdict));
+        });
+    }
+
+    [Test]
+    public void Evaluate_NonPositiveOrNonFiniteFittedSpan_FallsBackToTheRequestedSweep() {
+        foreach (var bad in new[] { double.NaN, 0.0, -3.0, double.PositiveInfinity }) {
+            var r = CapSemantics.Evaluate(20.0, bad, 4, 2.0, wasCapped: true, wasBandFloored: false);
+            Assert.That(r.SpanSource, Is.EqualTo("requested"), $"fittedSearchSpan={bad}");
+            Assert.That(r.CapBoundary, Is.EqualTo(Mult * 4 * 2.0).Within(1e-12), $"fittedSearchSpan={bad}");
+        }
+    }
+
+    // ---- BOTH bounding branches count, not just the cap ----
+
+    /// <summary>
+    /// The band floor clamps the half-width to the SAME maxHalfWidth the cap would have, so a truth curve that
+    /// says "this round had to be bounded" is satisfied by the floor. Reading <c>WasCapped</c> alone made every
+    /// floored round a FAIL — and the floor fires exactly on the shape that flips the branch without changing
+    /// the resulting half-width.
+    /// </summary>
+    [Test]
+    public void Evaluate_ABandFlooredRound_CountsAsBounded() {
+        var r = CapSemantics.Evaluate(
+            truthHalfWidth: 30.0, fittedSearchSpan: 16.0,
+            requestedOffsetSteps: 4, requestedStepSize: 2.0,
+            wasCapped: false, wasBandFloored: true);
+
+        Assert.Multiple(() => {
+            Assert.That(r.CapBoundary, Is.EqualTo(Mult * 0.5 * 16.0).Within(1e-12));   // 12.0
+            Assert.That(r.PredictedBounded, Is.True, "truth 30.0 is well above the 12.0 boundary");
+            Assert.That(r.ActualBounded, Is.True, "the floor bounded it, even though WasCapped is false");
+            Assert.That(r.Branch, Is.EqualTo("band-floored"));
+            Assert.That(r.Verdict, Is.EqualTo(CapSemanticsVerdict.Pass));
+        });
+    }
+
+    [Test]
+    public void Evaluate_AnUnboundedRoundBelowTheBoundary_Passes() {
+        var r = CapSemantics.Evaluate(5.0, 16.0, 4, 2.0, wasCapped: false, wasBandFloored: false);
+        Assert.Multiple(() => {
+            Assert.That(r.PredictedBounded, Is.False);
+            Assert.That(r.ActualBounded, Is.False);
+            Assert.That(r.Branch, Is.EqualTo("unbounded"));
+            Assert.That(r.Verdict, Is.EqualTo(CapSemanticsVerdict.Pass));
+        });
+    }
+
+    /// <summary>An unbounded round whose truth is far above the boundary is still a genuine FAIL — the fix must
+    /// not turn A4 into a rule that cannot fail.</summary>
+    [Test]
+    public void Evaluate_AnUnboundedRoundFarAboveTheBoundary_StillFails() {
+        var r = CapSemantics.Evaluate(30.0, 16.0, 4, 2.0, wasCapped: false, wasBandFloored: false);
+        Assert.Multiple(() => {
+            Assert.That(r.PredictedBounded, Is.True);
+            Assert.That(r.ActualBounded, Is.False);
+            Assert.That(r.Verdict, Is.EqualTo(CapSemanticsVerdict.Fail));
+        });
+    }
+
+    // ---- the near-boundary FLAG band survives the change ----
+
+    [Test]
+    public void Evaluate_JustAboveTheBoundary_IsAFlagNotAFail() {
+        // boundary = 1.5 × 0.5 × 16 = 12.0; truth 12.6 => ratio 1.05, inside the 0.15 band.
+        var r = CapSemantics.Evaluate(12.6, 16.0, 4, 2.0, wasCapped: false, wasBandFloored: false);
+        Assert.Multiple(() => {
+            Assert.That(r.Ratio, Is.EqualTo(1.05).Within(1e-12));
+            Assert.That(r.Verdict, Is.EqualTo(CapSemanticsVerdict.Flag));
+        });
+    }
+
+    [Test]
+    public void Evaluate_OutsideTheFlagBand_IsAFail() {
+        // ratio 1.20 is outside the 0.15 band.
+        var r = CapSemantics.Evaluate(14.4, 16.0, 4, 2.0, wasCapped: false, wasBandFloored: false);
+        Assert.Multiple(() => {
+            Assert.That(r.Ratio, Is.EqualTo(1.20).Within(1e-12));
+            Assert.That(r.Verdict, Is.EqualTo(CapSemanticsVerdict.Fail));
+        });
+    }
+}

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/Bank/CapSemanticsTests.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/Bank/CapSemanticsTests.cs
@@ -95,27 +95,47 @@ public class CapSemanticsTests {
         }
     }
 
-    // ---- BOTH bounding branches count, not just the cap ----
+    // ---- a band-floored round is EXEMPT, because the cap predicate does not describe it ----
 
     /// <summary>
-    /// The band floor clamps the half-width to the SAME maxHalfWidth the cap would have, so a truth curve that
-    /// says "this round had to be bounded" is satisfied by the floor. Reading <c>WasCapped</c> alone made every
-    /// floored round a FAIL — and the floor fires exactly on the shape that flips the branch without changing
-    /// the resulting half-width.
+    /// D03 r0's shape: the floor fired and truth (46.1) sits well ABOVE the boundary (24.0). The old rule read
+    /// that as "should have been capped, wasn't" and FAILED a round the floor had handled exactly as F81
+    /// designed. The cap clamps DOWN, the floor raises UP; "truth is above the boundary" predicts the cap and
+    /// says nothing about the floor.
     /// </summary>
     [Test]
-    public void Evaluate_ABandFlooredRound_CountsAsBounded() {
+    public void Evaluate_ABandFlooredRound_TruthAboveTheBoundary_IsNotApplicable() {
         var r = CapSemantics.Evaluate(
-            truthHalfWidth: 30.0, fittedSearchSpan: 16.0,
-            requestedOffsetSteps: 4, requestedStepSize: 2.0,
+            truthHalfWidth: 46.1, fittedSearchSpan: 32.0,
+            requestedOffsetSteps: 4, requestedStepSize: 4.0,
             wasCapped: false, wasBandFloored: true);
 
         Assert.Multiple(() => {
-            Assert.That(r.CapBoundary, Is.EqualTo(Mult * 0.5 * 16.0).Within(1e-12));   // 12.0
-            Assert.That(r.PredictedBounded, Is.True, "truth 30.0 is well above the 12.0 boundary");
-            Assert.That(r.ActualBounded, Is.True, "the floor bounded it, even though WasCapped is false");
+            Assert.That(r.CapBoundary, Is.EqualTo(Mult * 0.5 * 32.0).Within(1e-12));   // 24.0
+            Assert.That(r.PredictedBounded, Is.True, "truth 46.1 is above the 24.0 boundary");
             Assert.That(r.Branch, Is.EqualTo("band-floored"));
-            Assert.That(r.Verdict, Is.EqualTo(CapSemanticsVerdict.Pass));
+            Assert.That(r.Verdict, Is.EqualTo(CapSemanticsVerdict.NotApplicable));
+        });
+    }
+
+    /// <summary>
+    /// The mirror, and the reason "floored counts as bounded" was rejected: D01 r0 (ratio 0.87) and D02 r0
+    /// (ratio 0.70) are floored rounds whose truth sits BELOW the boundary. Under that alternative they would
+    /// have dropped PASS to FLAG and PASS to FAIL respectively, on rounds where the recommender did nothing
+    /// wrong. Exemption is the verdict that is right in BOTH directions.
+    /// </summary>
+    [Test]
+    public void Evaluate_ABandFlooredRound_TruthBelowTheBoundary_IsAlsoNotApplicable() {
+        // D01 r0: truth 10.4, fitted span 16.0 -> boundary 12.0, ratio 0.87
+        var d01 = CapSemantics.Evaluate(10.4, 16.0, 4, 2.0, wasCapped: false, wasBandFloored: true);
+        // D02 r0: truth 8.4, fitted span 16.0 -> boundary 12.0, ratio 0.70
+        var d02 = CapSemantics.Evaluate(8.4, 16.0, 4, 2.0, wasCapped: false, wasBandFloored: true);
+
+        Assert.Multiple(() => {
+            Assert.That(d01.PredictedBounded, Is.False);
+            Assert.That(d01.Verdict, Is.EqualTo(CapSemanticsVerdict.NotApplicable));
+            Assert.That(d02.PredictedBounded, Is.False);
+            Assert.That(d02.Verdict, Is.EqualTo(CapSemanticsVerdict.NotApplicable));
         });
     }
 

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/Joko.NINA.Plugins.HocusFocus.Tests.csproj
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/Joko.NINA.Plugins.HocusFocus.Tests.csproj
@@ -41,6 +41,10 @@
     <Compile Include="..\TestApp\SynthBank\TruthDisclosure.cs" Link="Golden\TruthDisclosure.cs" />
     <Compile Include="..\TestApp\SynthBank\ConvergenceBand.cs" Link="Bank\ConvergenceBand.cs" />
     <Compile Include="..\TestApp\SynthBank\ExposureClamp.cs" Link="Bank\ExposureClamp.cs" />
+    <!-- A4's cap-semantics rule. SynthValidateRunner renders frames and runs the optimizer and cannot be linked,
+         so the whole decision lives in this one pure file, which the runner only calls. Same shape as
+         TruthDisclosure above, and what makes the A4 mutants reachable from a unit test. -->
+    <Compile Include="..\TestApp\SynthBank\CapSemantics.cs" Link="Bank\CapSemantics.cs" />
     <!-- W24 P3: the synth-validate report SCHEMA (pure POCOs + Newtonsoft attributes, no NINA/OpenCV coupling), so
          SynthValidationReportSchemaTests can assert the JSON names every scorer reads by. -->
     <Compile Include="..\TestApp\SynthValidationReport.cs" Link="Bank\SynthValidationReport.cs" />

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/StarDetection/Optimization/OptimizerVariableTests.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/StarDetection/Optimization/OptimizerVariableTests.cs
@@ -10,6 +10,7 @@
 
 #endregion "copyright"
 
+using System;
 using System.Linq;
 using NINA.Joko.Plugins.HocusFocus.Interfaces;
 using NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization;
@@ -192,6 +193,63 @@ public class OptimizerVariableTests {
         Assert.That(set.Select(x => x.Name), Is.EquivalentTo(expected));
     }
 
+    // ---- MaxDistortion's searchable ceiling is GEOMETRY, not a tuning choice (F98) ----
+
+    /// <summary>
+    /// The axis ceiling has to be the fill ratio the detector's own metric assigns to a perfectly round star,
+    /// because the gate rejects when <c>(star pixels)/d² &lt; MaxDistortion</c>. Rasterise disks and confirm the
+    /// constant is that ratio rather than a number someone liked — the sequence converges to π/4 from below.
+    /// </summary>
+    [Test]
+    public void MaxDistortionSearchUpper_IsTheFillRatioOfARasterisedPerfectDisk() {
+        static double DiskFillRatio(int d) {
+            var r = d / 2.0;
+            var count = 0;
+            for (var y = 0; y < d; y++) {
+                for (var x = 0; x < d; x++) {
+                    var dx = x + 0.5 - r;
+                    var dy = y + 0.5 - r;
+                    if ((dx * dx) + (dy * dy) <= r * r) {
+                        count++;
+                    }
+                }
+            }
+            return count / (double)(d * d);
+        }
+
+        Assert.Multiple(() => {
+            Assert.That(DiskFillRatio(64), Is.EqualTo(OptimizerVariable.MaxDistortionSearchUpper).Within(0.01));
+            Assert.That(DiskFillRatio(512), Is.EqualTo(OptimizerVariable.MaxDistortionSearchUpper).Within(0.002));
+            // And it is genuinely below the old 1.0 ceiling, which is the whole point of the bound.
+            Assert.That(OptimizerVariable.MaxDistortionSearchUpper, Is.LessThan(1.0));
+        });
+    }
+
+    /// <summary>
+    /// The coarse grid samples <c>Lower + t·(Upper − Lower)</c> inclusive of BOTH bounds, so the ceiling is
+    /// itself evaluated. Under the old 1.0 upper the top level rejected every round star — one of this axis's
+    /// four levels spent on a setting that returns zero detections by construction.
+    /// </summary>
+    [Test]
+    public void MaxDistortionAxis_EveryCoarseGridLevel_IsSatisfiableByARoundStar() {
+        var v = OptimizerVariable.CreateCuratedSet().Single(x => x.Name == nameof(StarDetectorParams.MaxDistortion));
+        const int Levels = 4;   // StarDetectionOptimizer.CoarseGridLevels default
+        for (var i = 0; i < Levels; i++) {
+            var t = i / (double)(Levels - 1);
+            var value = v.Lower + (t * (v.Upper - v.Lower));
+            Assert.That(value, Is.LessThanOrEqualTo(Math.PI / 4.0),
+                $"coarse-grid level {i} of {Levels} sits above a perfect disk's fill ratio, so it rejects every round star");
+        }
+    }
+
+    [Test]
+    public void MaxDistortionAxis_WriteClampsAboveTheGeometricCeiling() {
+        var v = OptimizerVariable.CreateCuratedSet().Single(x => x.Name == nameof(StarDetectorParams.MaxDistortion));
+        var p = new StarDetectorParams();
+        v.Write(p, 1.0);
+        Assert.That(p.MaxDistortion, Is.EqualTo(Math.PI / 4.0).Within(1e-12));
+    }
+
     // ---- DefocusAwareGates combined switch (F3) ----
 
     [Test]
@@ -253,7 +311,7 @@ public class OptimizerVariableTests {
         Check(nameof(StarDetectorParams.StarClippingMultiplier), OptimizerVariableType.Continuous, 0.25, 10, 0.5);
         Check(nameof(StarDetectorParams.NoiseClippingMultiplier), OptimizerVariableType.Continuous, 1, 10, 0.5);
         Check(nameof(StarDetectorParams.PeakResponse), OptimizerVariableType.Continuous, 0.1, 1.0, 0.05);
-        Check(nameof(StarDetectorParams.MaxDistortion), OptimizerVariableType.Continuous, 0.1, 1.0, 0.1);
+        Check(nameof(StarDetectorParams.MaxDistortion), OptimizerVariableType.Continuous, 0.1, Math.PI / 4.0, 0.1);
         Check(nameof(StarDetectorParams.MinHFR), OptimizerVariableType.Continuous, 0.1, 5.0, 0.25);
         Check(nameof(StarDetectorParams.StarCenterTolerance), OptimizerVariableType.Continuous, 0.05, 1.0, 0.05);
         Check(nameof(StarDetectorParams.StructureLayers), OptimizerVariableType.Integer, 1, 8, 1);

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/StarDetection/Optimization/OptimizerVariableTests.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/StarDetection/Optimization/OptimizerVariableTests.cs
@@ -226,19 +226,21 @@ public class OptimizerVariableTests {
     }
 
     /// <summary>
-    /// The coarse grid samples <c>Lower + t·(Upper − Lower)</c> inclusive of BOTH bounds, so the ceiling is
-    /// itself evaluated. Under the old 1.0 upper the top level rejected every round star — one of this axis's
-    /// four levels spent on a setting that returns zero detections by construction.
+    /// The bound's actual job: no value the search can REACH on this axis rejects every round star. This axis is
+    /// not coarse-gridded (Phase A grids only Sensitivity × StarClippingMultiplier), so the pattern search is the
+    /// only thing that moves it — and every proposal goes through <c>Quantize</c>, which clamps to
+    /// <c>[Lower, Upper]</c>. Walking the axis in <c>InitialStep</c> increments from the seed must therefore
+    /// never land in the dead band, however far up it walks.
     /// </summary>
     [Test]
-    public void MaxDistortionAxis_EveryCoarseGridLevel_IsSatisfiableByARoundStar() {
+    public void MaxDistortionAxis_NoReachableValue_RejectsEveryRoundStar() {
         var v = OptimizerVariable.CreateCuratedSet().Single(x => x.Name == nameof(StarDetectorParams.MaxDistortion));
-        const int Levels = 4;   // StarDetectionOptimizer.CoarseGridLevels default
-        for (var i = 0; i < Levels; i++) {
-            var t = i / (double)(Levels - 1);
-            var value = v.Lower + (t * (v.Upper - v.Lower));
-            Assert.That(value, Is.LessThanOrEqualTo(Math.PI / 4.0),
-                $"coarse-grid level {i} of {Levels} sits above a perfect disk's fill ratio, so it rejects every round star");
+        var p = new StarDetectorParams();
+        // Walk well past the old 1.0 ceiling, in the axis's own step, exactly as an ascending pattern search would.
+        for (var proposal = v.Lower; proposal <= 2.0; proposal += v.InitialStep) {
+            v.Write(p, proposal);
+            Assert.That(p.MaxDistortion, Is.LessThanOrEqualTo(Math.PI / 4.0),
+                $"proposal {proposal} was stored as {p.MaxDistortion}, which rejects every round star");
         }
     }
 

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/Resources/OptionsDataTemplates.xaml
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/Resources/OptionsDataTemplates.xaml
@@ -450,7 +450,7 @@
         . The noise level<Bold>n</Bold>
         is measured on the image actually used for star measurement, so this value is an honest multiple of the real noise and means the same thing regardless of noise-reduction settings. The default of 2 works well; if you find a large number of rejections due to low sensitivity, smaller values increase sensitivity</TextBlock>
     <TextBlock x:Key="StarPeakResponse_Tooltip" Text="The ratio of the star median relative to the star peak. It provides a measure of flatness, since median values close to the peak indicate low dispersion. Consider increasing if too many stars are rejected with &quot;Too Flat&quot;" />
-    <TextBlock x:Key="MaxDistortion_Tooltip" Text="The ratio of star pixels to the size of a perfect square bounding box. A perfect circule has a distortion of PI/4, which is approximately 0.7. The default value of 0.5 allows for some distortion and measurement error and should work for most cases." />
+    <TextBlock x:Key="MaxDistortion_Tooltip" Text="A MINIMUM fill ratio, despite the name: the ratio of star pixels to the area of the bounding box, where a candidate is rejected as Too Distorted when its fill ratio falls BELOW this value. Raising it makes the gate stricter, not looser. A perfectly round star fills PI/4, approximately 0.785, so values above that reject every round star. The default of 0.5 allows for some distortion and measurement error and should work for most cases." />
     <TextBlock x:Key="DefocusAwareGates_Tooltip" Text="When enabled, both the Max Distortion and Star Center Tolerance gates are relaxed for large candidates (a proxy for large defocus). At large defocus a star becomes a hollow donut (the central-obstruction shadow): it has a big bounding box with a low pixel fill-ratio (which the strict Max Distortion would wrongly reject as too distorted) and a wobbly intensity-weighted center (which the strict centering test would wrongly reject as not centered). Small candidates (near focus) keep the strict thresholds, so junk is still rejected. Off by default; enable it if you collect autofocus frames far from focus and find defocused donut stars being dropped. The three Defocus-Aware tuning values below take effect only while this is enabled." />
     <TextBlock x:Key="DefocusDistortionSizeReference_Tooltip" Text="Tuning knob for the Defocus-Aware Gates (only used while they are enabled). The candidate bounding-box size (in pixels, the larger of width/height) at or below which the strict gate thresholds still apply; larger candidates get the relaxed thresholds. Shared by both the distortion and centering relaxations. Lower it to relax smaller stars; raise it to keep more of the strict behavior. Default 30." />
     <TextBlock x:Key="DefocusDistortionMinFactor_Tooltip" Text="Tuning knob for the Defocus-Aware Gates (only used while they are enabled). The floor multiplier applied to Max Distortion for very large (very defocused) candidates — the most permissive the distortion gate ever becomes. Must be greater than 0 and at most 1. Smaller values accept more heavily-distorted donuts. Default 0.25." />
@@ -1574,7 +1574,7 @@
                 Grid.Row="18"
                 Grid.Column="0"
                 VerticalAlignment="Center"
-                Text="Max Distortion"
+                Text="Max Distortion (min fill ratio)"
                 ToolTip="{StaticResource MaxDistortion_Tooltip}" />
             <ninactrl:UnitTextBox
                 Grid.Row="18"

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/OptimizerVariable.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/OptimizerVariable.cs
@@ -155,10 +155,18 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization {
         /// </para>
         /// <para>
         /// A perfectly round star therefore tops out at the fill ratio of a disk inscribed in its own bounding
-        /// box — <c>π/4 ≈ 0.785</c>. Any threshold above that rejects <b>every</b> round star, so the top of the
-        /// old 1.0 ceiling was a region the search could reach and never use: the coarse grid samples
-        /// <c>Lower + t·(Upper − Lower)</c> inclusive of both bounds, so at the default four levels the old range
-        /// spent one of its four levels (1.0) on a setting that returns zero detections by construction.
+        /// box — <c>π/4 ≈ 0.785</c>. Any threshold above that rejects <b>every</b> round star. The old 1.0
+        /// ceiling left roughly the top 21% of the axis reachable by the pattern search while returning zero
+        /// detections by construction; wave 29 measured that collapse directly at 0.9
+        /// (<c>TP=0 FP=0 FN=110384</c>, recall 0.000). Bounding the axis makes the dead band unreachable.
+        /// </para>
+        /// <para>
+        /// <b>Scope, stated precisely so it is not over-claimed.</b> This axis is NOT coarse-gridded:
+        /// <c>StarDetectionOptimizer</c>'s Phase A grids only Sensitivity × StarClippingMultiplier and holds
+        /// every other variable at the incumbent. <c>MaxDistortion</c> moves only under the pattern search, whose
+        /// proposals are clamped here by <c>Quantize</c>. So the bound is a <b>guard against a pathological
+        /// upward excursion</b>, and it is expected to be inert on any run that never walks above π/4 — measured
+        /// as bit-identical on all eight gate datasets, whose landings all sit at or below 0.6.
         /// </para>
         /// </summary>
         public const double MaxDistortionSearchUpper = Math.PI / 4.0;
@@ -193,7 +201,7 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization {
                 Continuous(nameof(StarDetectorParams.PeakResponse), 0.1, 1.0, 0.05,
                     p => p.PeakResponse, (p, v) => p.PeakResponse = v),
                 // Upper is MaxDistortionSearchUpper (π/4), not 1.0: see that constant for why the top of the old
-                // range could be searched but never used. The lower bound stays heuristic.
+                // range was reachable and useless. The lower bound stays heuristic.
                 Continuous(nameof(StarDetectorParams.MaxDistortion), 0.1, MaxDistortionSearchUpper, 0.1,
                     p => p.MaxDistortion, (p, v) => p.MaxDistortion = v),
                 Continuous(nameof(StarDetectorParams.MinHFR), MinHFRLower, MinHFRUpper, 0.25,

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/OptimizerVariable.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/OptimizerVariable.cs
@@ -144,6 +144,25 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization {
         /// </summary>
         public const double DefaultSensitivityLower = 0.0;
 
+        /// <summary>
+        /// The searchable ceiling for <see cref="StarDetectorParams.MaxDistortion"/>, and the one bound in the
+        /// curated set that is GEOMETRIC rather than heuristic.
+        /// <para>
+        /// Despite its name, <c>MaxDistortion</c> is a <b>minimum fill ratio</b>: the gate computes
+        /// <c>fillRatio = (star pixels) / d²</c> for a bounding-box max dimension <c>d</c> and <b>rejects</b> when
+        /// <c>fillRatio &lt; MaxDistortion</c> (<c>StarDetector.cs</c>, the <c>TooDistorted</c> gate). Raising the
+        /// value makes the gate <b>stricter</b>, not looser.
+        /// </para>
+        /// <para>
+        /// A perfectly round star therefore tops out at the fill ratio of a disk inscribed in its own bounding
+        /// box — <c>π/4 ≈ 0.785</c>. Any threshold above that rejects <b>every</b> round star, so the top of the
+        /// old 1.0 ceiling was a region the search could reach and never use: the coarse grid samples
+        /// <c>Lower + t·(Upper − Lower)</c> inclusive of both bounds, so at the default four levels the old range
+        /// spent one of its four levels (1.0) on a setting that returns zero detections by construction.
+        /// </para>
+        /// </summary>
+        public const double MaxDistortionSearchUpper = Math.PI / 4.0;
+
         private static IReadOnlyList<OptimizerVariable> CreateCuratedSet(
             bool includeDefocusAxes, double sensitivityLower = DefaultSensitivityLower) {
             // --- Heuristic bounds (no hard UI validation range; chosen pragmatically). Edit here to retune. ---
@@ -173,7 +192,9 @@ namespace NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization {
                     p => p.NoiseClippingMultiplier, (p, v) => p.NoiseClippingMultiplier = v),
                 Continuous(nameof(StarDetectorParams.PeakResponse), 0.1, 1.0, 0.05,
                     p => p.PeakResponse, (p, v) => p.PeakResponse = v),
-                Continuous(nameof(StarDetectorParams.MaxDistortion), 0.1, 1.0, 0.1,
+                // Upper is MaxDistortionSearchUpper (π/4), not 1.0: see that constant for why the top of the old
+                // range could be searched but never used. The lower bound stays heuristic.
+                Continuous(nameof(StarDetectorParams.MaxDistortion), 0.1, MaxDistortionSearchUpper, 0.1,
                     p => p.MaxDistortion, (p, v) => p.MaxDistortion = v),
                 Continuous(nameof(StarDetectorParams.MinHFR), MinHFRLower, MinHFRUpper, 0.25,
                     p => p.MinHFR, (p, v) => p.MinHFR = v),

--- a/Joko.NINA.Plugins/TestApp/SynthBank/CapSemantics.cs
+++ b/Joko.NINA.Plugins/TestApp/SynthBank/CapSemantics.cs
@@ -19,7 +19,10 @@ namespace TestApp.SynthBank {
     public enum CapSemanticsVerdict {
         Pass,
         Flag,
-        Fail
+        Fail,
+
+        /// <summary>The band floor fired, so the cap predicate does not describe this round.</summary>
+        NotApplicable
     }
 
     /// <summary>The full working of one <c>A4</c> decision, so the report can print what it compared.</summary>
@@ -63,13 +66,24 @@ namespace TestApp.SynthBank {
     ///     of two (requested 24.0, fitted 12.0), so A4 was scoring the product against a bound it never applied.
     ///   </description></item>
     ///   <item><description>
-    ///     It read <c>WasCapped</c> alone. F81 deliberately split <c>WasBandFloored</c> out as a separate signal,
-    ///     but the two branches are mutually exclusive and clamp the half-width to the <b>same</b>
-    ///     <c>maxHalfWidth</c> — so a truth curve predicting "this had to be bounded" is satisfied by either.
-    ///     Reading only the cap turned every floored round into a FAIL, and the floor fires precisely on the
-    ///     shape that flips the branch without changing the resulting half-width.
+    ///     It asserted the cap predicate on <b>band-floored</b> rounds, where it does not apply. The cap and the
+    ///     floor are mutually exclusive by construction, and they bound in <b>opposite directions</b>: the cap
+    ///     clamps a fitted crossing DOWN to <c>maxHalfWidth</c>, while the floor raises one UP to
+    ///     <c>maxHalfWidth</c> when the sweep's own HFRs prove the band was never sampled. So "truth is above the
+    ///     boundary" predicts the CAP and says nothing about the FLOOR — on <c>D03</c> r0 that produced a FAIL
+    ///     (<c>truth 46.1 vs boundary 24.0</c>) against a round the floor had handled exactly as F81 designed.
+    ///     A floored round is therefore reported <see cref="CapSemanticsVerdict.NotApplicable"/> and NAMED, not
+    ///     silently dropped.
     ///   </description></item>
     /// </list>
+    /// <para>
+    /// <b>What was considered and rejected:</b> treating the floor as satisfying the cap
+    /// (<c>bounded = capped || floored</c>). It looks right — both branches end at the same
+    /// <c>maxHalfWidth</c> — and it does repair <c>D03</c> r0. But it turns the two floored rounds whose truth
+    /// sits BELOW the boundary into failures: <c>D01</c> r0 (ratio 0.87) would drop PASS → FLAG and <c>D02</c>
+    /// r0 (ratio 0.70) PASS → FAIL, on rounds where the recommender did nothing wrong. Measured on the real
+    /// reports before it was adopted, which is why it was not.
+    /// </para>
     /// <para>
     /// Near the boundary a noisy fit can legitimately land on the other side, so a mismatch within
     /// <see cref="NearBoundaryFraction"/> is a FLAG rather than a FAIL.
@@ -100,11 +114,15 @@ namespace TestApp.SynthBank {
             var capBoundary = StepSizeRecommender.MaxHalfWidthSampledHalfSpanMultiple * sampledHalfSpan;
 
             var predictedBounded = capBoundary > 0.0 && truthHalfWidth > capBoundary;
-            var actualBounded = wasCapped || wasBandFloored;
+            var actualBounded = wasCapped;
             var ratio = capBoundary > 0.0 ? truthHalfWidth / capBoundary : double.PositiveInfinity;
 
             CapSemanticsVerdict verdict;
-            if (predictedBounded == actualBounded) {
+            if (wasBandFloored) {
+                // The floor and the cap are mutually exclusive and bound in opposite directions; the cap
+                // predicate simply does not describe this round. Named, not dropped.
+                verdict = CapSemanticsVerdict.NotApplicable;
+            } else if (predictedBounded == actualBounded) {
                 verdict = CapSemanticsVerdict.Pass;
             } else if (Math.Abs(ratio - 1.0) < NearBoundaryFraction) {
                 verdict = CapSemanticsVerdict.Flag;

--- a/Joko.NINA.Plugins/TestApp/SynthBank/CapSemantics.cs
+++ b/Joko.NINA.Plugins/TestApp/SynthBank/CapSemantics.cs
@@ -1,0 +1,126 @@
+#region "copyright"
+
+/*
+    Copyright © 2021 - 2026 George Hilios <ghilios+NINA@googlemail.com>
+
+    This Source Code Form is subject to the terms of the Mozilla Public
+    License, v. 2.0. If a copy of the MPL was not distributed with this
+    file, You can obtain one at http://mozilla.org/MPL/2.0/.
+*/
+
+#endregion "copyright"
+
+using NINA.Joko.Plugins.HocusFocus.StarDetection.Optimization;
+using System;
+
+namespace TestApp.SynthBank {
+
+    /// <summary>Which way <c>A4</c> came out for one round.</summary>
+    public enum CapSemanticsVerdict {
+        Pass,
+        Flag,
+        Fail
+    }
+
+    /// <summary>The full working of one <c>A4</c> decision, so the report can print what it compared.</summary>
+    public readonly struct CapSemanticsResult {
+        public CapSemanticsVerdict Verdict { get; init; }
+
+        /// <summary>True when the ANALYTIC truth curve says this round's half-width had to be bounded.</summary>
+        public bool PredictedBounded { get; init; }
+
+        /// <summary>True when the recommender actually bounded it — by EITHER branch.</summary>
+        public bool ActualBounded { get; init; }
+
+        public double CapBoundary { get; init; }
+
+        /// <summary>truthHalfWidth / capBoundary. 1.0 is exactly on the boundary.</summary>
+        public double Ratio { get; init; }
+
+        /// <summary>"fitted" when the product's own span was available, "requested" on the legacy fallback.</summary>
+        public string SpanSource { get; init; }
+
+        /// <summary>"capped", "band-floored" or "unbounded".</summary>
+        public string Branch { get; init; }
+    }
+
+    /// <summary>
+    /// The <c>A4</c> cap-semantics rule, extracted so it can be unit-tested without standing up the runner.
+    /// <para>
+    /// <b>What A4 asserts.</b> The recommender must bound a round's half-width exactly when the noiseless truth
+    /// curve says the 3× crossing lies outside what the sweep could support. The boundary is
+    /// <c>MaxHalfWidthSampledHalfSpanMultiple × (sampled half-span)</c>.
+    /// </para>
+    /// <para>
+    /// <b>Two things this rule used to get wrong, both on the assertion side.</b>
+    /// </para>
+    /// <list type="number">
+    ///   <item><description>
+    ///     It rebuilt the boundary from the <b>requested</b> sweep (<c>offsetSteps × stepSize</c>) while the
+    ///     product builds it from the <b>fitted</b> span — <c>max(x) − min(x)</c> over the points that survived
+    ///     into the fit, which is smaller whenever a position was dropped for a non-finite pooled HFR, held out
+    ///     as a recovery frame, or rejected as a consensus outlier. On the bank's <c>D01</c> r1 that is a factor
+    ///     of two (requested 24.0, fitted 12.0), so A4 was scoring the product against a bound it never applied.
+    ///   </description></item>
+    ///   <item><description>
+    ///     It read <c>WasCapped</c> alone. F81 deliberately split <c>WasBandFloored</c> out as a separate signal,
+    ///     but the two branches are mutually exclusive and clamp the half-width to the <b>same</b>
+    ///     <c>maxHalfWidth</c> — so a truth curve predicting "this had to be bounded" is satisfied by either.
+    ///     Reading only the cap turned every floored round into a FAIL, and the floor fires precisely on the
+    ///     shape that flips the branch without changing the resulting half-width.
+    ///   </description></item>
+    /// </list>
+    /// <para>
+    /// Near the boundary a noisy fit can legitimately land on the other side, so a mismatch within
+    /// <see cref="NearBoundaryFraction"/> is a FLAG rather than a FAIL.
+    /// </para>
+    /// </summary>
+    public static class CapSemantics {
+
+        /// <summary>Mismatches within this fraction of the boundary are FLAG, not FAIL — a noisy fit's coin-flip.</summary>
+        public const double NearBoundaryFraction = 0.15;
+
+        /// <summary>
+        /// Scores one round. <paramref name="fittedSearchSpan"/> is the product's own span; pass
+        /// <see cref="double.NaN"/> (as reports written before it was recorded do) to fall back to the requested
+        /// sweep, which reproduces the historical boundary exactly.
+        /// </summary>
+        public static CapSemanticsResult Evaluate(
+            double truthHalfWidth,
+            double fittedSearchSpan,
+            int requestedOffsetSteps,
+            double requestedStepSize,
+            bool wasCapped,
+            bool wasBandFloored) {
+
+            var useFitted = double.IsFinite(fittedSearchSpan) && fittedSearchSpan > 0.0;
+            var sampledHalfSpan = useFitted
+                ? 0.5 * fittedSearchSpan
+                : requestedOffsetSteps * requestedStepSize;
+            var capBoundary = StepSizeRecommender.MaxHalfWidthSampledHalfSpanMultiple * sampledHalfSpan;
+
+            var predictedBounded = capBoundary > 0.0 && truthHalfWidth > capBoundary;
+            var actualBounded = wasCapped || wasBandFloored;
+            var ratio = capBoundary > 0.0 ? truthHalfWidth / capBoundary : double.PositiveInfinity;
+
+            CapSemanticsVerdict verdict;
+            if (predictedBounded == actualBounded) {
+                verdict = CapSemanticsVerdict.Pass;
+            } else if (Math.Abs(ratio - 1.0) < NearBoundaryFraction) {
+                verdict = CapSemanticsVerdict.Flag;
+            } else {
+                verdict = CapSemanticsVerdict.Fail;
+            }
+
+            return new CapSemanticsResult {
+                Verdict = verdict,
+                PredictedBounded = predictedBounded,
+                ActualBounded = actualBounded,
+                CapBoundary = capBoundary,
+                Ratio = ratio,
+                SpanSource = useFitted ? "fitted" : "requested",
+                Branch = wasCapped ? "capped" : wasBandFloored ? "band-floored" : "unbounded"
+            };
+        }
+    }
+}

--- a/Joko.NINA.Plugins/TestApp/SynthBank/synthetic-bank-spec.json
+++ b/Joko.NINA.Plugins/TestApp/SynthBank/synthetic-bank-spec.json
@@ -377,6 +377,42 @@
       "optimalFocuserPosition": 8000,
       "focuserStepSizeMicrons": 3.469548,
       "datasetSeed": 20
+    },
+    {
+      "id": "D21_widefield_60mm",
+      "description": "60mm f/4.0 astrograph, unobstructed, IMX571 bin1 -- 12.93 arcsec/px. FILLS THE WIDE-FIELD COVERAGE HOLE. The bank's plate scales jump 3.38x from D02 (5.745) straight to D01 (19.389), and D01 is BURNED (F97), which is the mechanical reason c_blind = 0 for F82: there is no BLIND wide-field cell. D21 and D22 land at 12.93 and 7.76, splitting that jump into ~1.5x steps. Monoceros Milky Way, chosen because its nearest existing bank field is 21.3 deg away (D03) while this rig's FOV radius is 13.2 deg -- so it CONTAINS no existing dataset. D01/D02/D03 are the burned cells and the whole point of D21/D22 is a population uncorrelated with them; an earlier draft sat 0.3 deg from D03 and would have swallowed its field whole. Capped at mag<=10.5 like D01 because the ~26.6deg diagonal FOV makes the catalog query expensive (design risk R5).",
+      "focalLengthMm": 60.0,
+      "focalRatio": 4.0,
+      "centralObstructionFraction": 0.0,
+      "sensorModel": "IMX571",
+      "captureBinning": 1,
+      "raDegrees": 105.0,
+      "decDegrees": -5.0,
+      "rotationDegrees": 0.0,
+      "limitingMagnitude": 10.5,
+      "skyBrightnessMagPerArcsec2": 21.0,
+      "seeingArcsec": 2.5,
+      "optimalFocuserPosition": 6000,
+      "focuserStepSizeMicrons": 2.707200,
+      "datasetSeed": 21
+    },
+    {
+      "id": "D22_widefield_100mm",
+      "description": "100mm f/5.6 astrograph, unobstructed, IMX533 bin1 -- 7.76 arcsec/px, the second of the two cells filling the D02->D01 wide-field hole (see D21). Square 9MP sensor gives a ~9.1deg diagonal FOV, tractable enough for a mag<=12.0 catalog query. Aquila Milky Way, 17.2 deg from its nearest existing field (D04) against a 4.6 deg FOV radius -- again containing no existing dataset, and distinct from D21's Monoceros.",
+      "focalLengthMm": 100.0,
+      "focalRatio": 5.6,
+      "centralObstructionFraction": 0.0,
+      "sensorModel": "IMX533",
+      "captureBinning": 1,
+      "raDegrees": 285.0,
+      "decDegrees": -5.0,
+      "rotationDegrees": 0.0,
+      "limitingMagnitude": 12.0,
+      "skyBrightnessMagPerArcsec2": 21.0,
+      "seeingArcsec": 2.5,
+      "optimalFocuserPosition": 6000,
+      "focuserStepSizeMicrons": 3.790080,
+      "datasetSeed": 22
     }
   ]
 }

--- a/Joko.NINA.Plugins/TestApp/SynthValidateRunner.cs
+++ b/Joko.NINA.Plugins/TestApp/SynthValidateRunner.cs
@@ -951,9 +951,12 @@ namespace TestApp.SynthBank {
                     round.StepRecommendation.WasCapped,
                     round.StepRecommendation.WasBandFloored);
 
-                var detail = $"bounded={cap.ActualBounded} ({cap.Branch}), halfWidth={truthHalfWidth:0.#} vs "
+                var detail = $"WasCapped={cap.ActualBounded} ({cap.Branch}), halfWidth={truthHalfWidth:0.#} vs "
                     + $"{cap.SpanSource} cap boundary {cap.CapBoundary:0.#}, ratio {cap.Ratio:0.00}";
-                if (cap.Verdict == CapSemanticsVerdict.Pass) {
+                if (cap.Verdict == CapSemanticsVerdict.NotApplicable) {
+                    findings.Add(NotApplicable("A4", "the band floor fired, and the floor bounds UPWARD where the cap "
+                        + $"bounds DOWNWARD -- the cap predicate does not describe this round; {detail}"));
+                } else if (cap.Verdict == CapSemanticsVerdict.Pass) {
                     findings.Add(Pass("A4", $"matches truth -- {detail}"));
                 } else if (cap.Verdict == CapSemanticsVerdict.Flag) {
                     findings.Add(Flag("A4", $"truth predicts {cap.PredictedBounded} -- near the cap boundary, noise-sensitive on a real fit; {detail}"));
@@ -1193,6 +1196,10 @@ namespace TestApp.SynthBank {
         private static AssertionFinding Pass(string id, string detail) => new AssertionFinding { Id = id, Verdict = SynthValidationVerdict.Pass, Detail = detail };
         private static AssertionFinding Flag(string id, string detail) => new AssertionFinding { Id = id, Verdict = SynthValidationVerdict.Flag, Detail = detail };
         private static AssertionFinding Fail(string id, string detail) => new AssertionFinding { Id = id, Verdict = SynthValidationVerdict.Fail, Detail = detail };
+
+        /// <summary>The assertion's predicate does not describe this round. Emitted rather than omitted so the
+        /// exemption is NAMED instead of quietly shrinking the denominator.</summary>
+        private static AssertionFinding NotApplicable(string id, string detail) => new AssertionFinding { Id = id, Verdict = SynthValidationVerdict.NotApplicable, Detail = detail };
 
         private static SynthValidationVerdict Worst(IEnumerable<AssertionFinding> findings) {
             var v = SynthValidationVerdict.Pass;

--- a/Joko.NINA.Plugins/TestApp/SynthValidateRunner.cs
+++ b/Joko.NINA.Plugins/TestApp/SynthValidateRunner.cs
@@ -798,6 +798,10 @@ namespace TestApp.SynthBank {
                 DetectHalfWidth = stepRec.DetectHalfWidth, MaxUsefulHalfSpan = stepRec.MaxUsefulHalfSpan,
                 WasDetectBounded = stepRec.WasDetectBounded,
                 SampledHfrRange = stepRec.SampledHfrRange, CappedGrowthRatio = stepRec.CappedGrowthRatio,
+                // The span the product's own bound was computed from. Mirrors StepSizeRecommender.SearchSpan,
+                // which is private -- so it is recomputed here from the same array rather than exposed, keeping
+                // this an assertion-side record and the product untouched.
+                FittedSearchSpan = FittedSearchSpanOf(bestFit),
                 // P1: non-null exactly when the recommender HELD the current step instead of measuring one.
                 DegenerateReason = stepRec.DegenerateReason
             };
@@ -934,17 +938,27 @@ namespace TestApp.SynthBank {
             // not a FAIL; far from the boundary it is a genuine invariant violation.
             {
                 var truthHalfWidth = Math.Sqrt(8.0) * model.HfrMinPixels / model.KappaPixelsPerStep;
-                var sampledHalfSpan = defaults.OffsetSteps * round.Bootstrap.StepSize;
-                var capBoundary = StepSizeRecommender.MaxHalfWidthSampledHalfSpanMultiple * sampledHalfSpan;
-                var predictedCapped = capBoundary > 0 && truthHalfWidth > capBoundary;
-                var actualCapped = round.StepRecommendation.WasCapped;
-                var ratio = capBoundary > 0 ? truthHalfWidth / capBoundary : double.PositiveInfinity;
-                if (predictedCapped == actualCapped) {
-                    findings.Add(Pass("A4", $"WasCapped={actualCapped} matches truth (halfWidth={truthHalfWidth:0.#} vs cap boundary {capBoundary:0.#}, ratio {ratio:0.00})"));
-                } else if (Math.Abs(ratio - 1.0) < 0.15) {
-                    findings.Add(Flag("A4", $"WasCapped={actualCapped} but truth predicts {predictedCapped} -- near the cap boundary (ratio {ratio:0.00}), noise-sensitive on a real fit"));
+
+                // The whole decision lives in CapSemantics.Evaluate so it can be unit-tested without the runner;
+                // see that type for why the boundary comes from the FITTED span and why BOTH bounding branches
+                // count. Reports written before fittedSearchSpan existed carry NaN and fall back to the requested
+                // sweep, which is exactly the historical boundary, so old artifacts re-score identically.
+                var cap = CapSemantics.Evaluate(
+                    truthHalfWidth,
+                    round.StepRecommendation.FittedSearchSpan,
+                    defaults.OffsetSteps,
+                    round.Bootstrap.StepSize,
+                    round.StepRecommendation.WasCapped,
+                    round.StepRecommendation.WasBandFloored);
+
+                var detail = $"bounded={cap.ActualBounded} ({cap.Branch}), halfWidth={truthHalfWidth:0.#} vs "
+                    + $"{cap.SpanSource} cap boundary {cap.CapBoundary:0.#}, ratio {cap.Ratio:0.00}";
+                if (cap.Verdict == CapSemanticsVerdict.Pass) {
+                    findings.Add(Pass("A4", $"matches truth -- {detail}"));
+                } else if (cap.Verdict == CapSemanticsVerdict.Flag) {
+                    findings.Add(Flag("A4", $"truth predicts {cap.PredictedBounded} -- near the cap boundary, noise-sensitive on a real fit; {detail}"));
                 } else {
-                    findings.Add(Fail("A4", $"WasCapped={actualCapped} but truth predicts {predictedCapped} (halfWidth={truthHalfWidth:0.#} vs cap boundary {capBoundary:0.#}, ratio {ratio:0.00})"));
+                    findings.Add(Fail("A4", $"truth predicts {cap.PredictedBounded} -- {detail}"));
                 }
             }
 
@@ -1282,6 +1296,34 @@ namespace TestApp.SynthBank {
                 }
                 return (int)hash;
             }
+        }
+
+        /// <summary>
+        /// The sampled-X span of the points that survived into the fit — <c>max(x) − min(x)</c> over
+        /// <c>bestFit.Inputs</c>. Deliberately mirrors <c>StepSizeRecommender.SearchSpan</c>, which is private, so
+        /// that <c>A4</c> can rebuild the product's cap boundary from the same quantity the product used.
+        /// <para>
+        /// It does NOT reproduce that method's degenerate fallback (a span keyed off the step size when the inputs
+        /// are empty). Here the honest answer for "what span was sampled" is <c>NaN</c>, and <c>A4</c> falls back
+        /// to the requested sweep — its historical behaviour — rather than asserting against a synthetic number.
+        /// </para>
+        /// </summary>
+        private static double FittedSearchSpanOf(AlglibHyperbolicFitting bestFit) {
+            var inputs = bestFit?.Inputs;
+            if (inputs == null || inputs.Length == 0) {
+                return double.NaN;
+            }
+            double minX = double.PositiveInfinity, maxX = double.NegativeInfinity;
+            foreach (var row in inputs) {
+                if (row == null || row.Length == 0) {
+                    continue;
+                }
+                var x = row[0];
+                if (x < minX) { minX = x; }
+                if (x > maxX) { maxX = x; }
+            }
+            var span = maxX - minX;
+            return span > 0.0 ? span : double.NaN;
         }
 
         private static bool IsInsideOrEqual(string candidate, string root) {

--- a/Joko.NINA.Plugins/TestApp/SynthValidationReport.cs
+++ b/Joko.NINA.Plugins/TestApp/SynthValidationReport.cs
@@ -90,6 +90,15 @@ namespace TestApp.SynthBank {
         [JsonProperty("sampledHfrRange")] public double SampledHfrRange { get; set; } = double.NaN;
         [JsonProperty("cappedGrowthRatio")] public double CappedGrowthRatio { get; set; } = double.NaN;
 
+        // The span the recommender's bound was ACTUALLY computed from: max(x) - min(x) over the points that
+        // survived into the fit. It is NOT the requested sweep. RunEvaluationData drops a position whose pooled
+        // HFR is non-finite, keeps recovery positions out of the un-weighted path entirely, and SelectBestModel
+        // removes consensus outliers -- so a round can request 2*offsetSteps*stepSize and fit far less. A4 used to
+        // rebuild the cap boundary from the REQUESTED sweep while the product built it from this, which on
+        // D01 r1 is a factor of two (requested 24.0, fitted 12.0). Recorded so the assertion can compare like
+        // with like instead of re-deriving a quantity it does not have. NaN on reports written before this field.
+        [JsonProperty("fittedSearchSpan")] public double FittedSearchSpan { get; set; } = double.NaN;
+
         // P1. Non-null exactly when the recommender could NOT measure a step size and held the current one --
         // "no-fit", "non-finite-vertex" or "half-width-unresolved". Without it a held step and a measured step
         // that happens to agree are byte-identical in this report, which is how a whole wave of trajectories

--- a/Joko.NINA.Plugins/TestApp/SynthValidationReport.cs
+++ b/Joko.NINA.Plugins/TestApp/SynthValidationReport.cs
@@ -25,7 +25,14 @@ namespace TestApp.SynthBank {
     /// code. <see cref="Flag"/> is a recorded-but-non-fatal finding (e.g. an F18-attributable step_behavioral vs
     /// step_theory divergence, or an at-floor exposure miss per the "F8 discipline" note).
     /// </summary>
-    public enum SynthValidationVerdict { Pass, Flag, Fail }
+    /// <para>
+    /// <see cref="NotApplicable"/> is appended LAST so Pass/Flag/Fail keep their existing ordinals 0/1/2 and no
+    /// artifact written before it existed changes meaning. It says the assertion's predicate does not describe
+    /// this round at all — which is different from passing, and is emitted rather than silently dropped so the
+    /// exemption is NAMED instead of shrinking a denominator. <see cref="Pass"/>-only filters treat it as
+    /// non-Pass, so it appears in the report's findings list.
+    /// </para>
+    public enum SynthValidationVerdict { Pass, Flag, Fail, NotApplicable }
 
     /// <summary>One A1-A7 (or scenario-specific) assertion instance, attached either to a round or to a scenario's
     /// terminal block.</summary>

--- a/docs/af-bank-cleanup-results.md
+++ b/docs/af-bank-cleanup-results.md
@@ -516,7 +516,12 @@ The bank is measured out. Of the five items:
 | 2 — implement `(3′)` | **VOID**, by item 1, before any code was written. |
 | 3 — the `ACCEPTED-elsewhere` residual | **RESOLVED** as a scorer-side matching artifact. Wave 30 row 7 discharged. |
 | 4 — bound + rename `MaxDistortion` | **SHIPPED** (axis bound + label + tooltip). Persisted-key rename named as a debt. |
-| 5 — the `A4` truth-model gap | **FIXED**, harness-side, no gate owed — and my own first fix corrected before it shipped. |
+| 5 — the `A4` truth-model gap | **FIXED**, harness-side, no gate owed. Two failures were the assertion's own; **one survives and is real**. |
+
+**Three self-corrections, all made before the thing being corrected could mislead anyone.** The
+`MaxDistortion` coarse-grid justification (caught by a refuted prediction), the first A4 fix (caught by
+re-scoring real reports), and the A4 before/after table (caught by re-running instead of predicting). Each is
+recorded where the claim it replaces was made, in the commit that made it and in this document.
 
 **Three of the five closed by measurement rather than by construction**, which is the pattern the wave series was
 stopped for: the remaining questions were not answerable with another arm on this bank, and two of them turned

--- a/docs/af-bank-cleanup-results.md
+++ b/docs/af-bank-cleanup-results.md
@@ -599,6 +599,45 @@ severity, not rate — which is exactly where the F82 decision document's §7 cl
 recall, precision, exposure and binning, none of which this arm read as a thresholded quantity. Recorded so a
 later reader does not have to reconstruct it.
 
+### The `K` column — paid, and it refused first, which is the good outcome
+
+Wave 30 §10 **row 3** withdrew the results-table `K` column after three unpaid waves, noting *"`kcol_w30.py`
+stays on disk (self-test `21 of 21`); any later ship can run it in ~2 m."* **This is a later ship.** Self-test
+re-run: `SELFTEST W30K 21 of 21`. Then the real pass:
+
+```
+K-0 datasets in the bank   candidates: 22   findings: 2   pre-registered population 20
+>>> RULE W30-K = K-UNEVALUATED   (K-0 False, K-1 True)
+    "the bank carries 22 dataset(s) against a pre-registered 20 … NO COLUMN IS EMITTED --
+     a short column pasted into the results table would silently drop rows."
+```
+
+**It refused because I had just added two datasets, and refusing was correct.** A scorer with a pinned
+population noticed that the population moved and declined to emit a 20-row column for a 22-row bank. That is
+the discipline this series spent thirty waves building, catching a change made ten minutes earlier by the same
+run — and it is worth more than the column.
+
+The floors themselves read cleanly on all 22 (`K-1`: 22 candidates, **0 unreadable**), so the content is
+available even though the pinned rule declines to publish it:
+
+| ″/px | dataset | `hfrMin` | `hfrMinEffective` | **K** |
+|---|---|---|---|---|
+| 19.389 | `D01_ultrawide_40mm` | 0.2307 | 0.7 | **0.700** |
+| **12.926** | **`D21_widefield_60mm`** | 0.3310 | 0.7 | **0.700** |
+| **7.756** | **`D22_widefield_100mm`** | 0.4727 | 0.7 | **0.700** |
+| 5.745 | `D02_rich_135mm` | 0.2800 | 0.7 | **0.700** |
+| 3.102 | `D03_redcat_250mm` | 0.5766 | 0.7 | **0.700** |
+| 1.410 | `D04`/`D18`/`D20` | 1.038 | 1.038 | 1.038 |
+| … | (long focal length) | native | native | 1.08 – 10.20 |
+
+**The five datasets the generator floors at K = 0.700 are exactly the five at ≥ 3.1 ″/px** — and the two new
+cells are two of them. That is the "severely oversampled R2" class the spec describes, and it **corroborates
+the assumption `P1` rested on**: `D21`/`D22` really are in `D01`'s regime, measured rather than asserted from
+their focal lengths. It is also why `D21` reproduced the shrink and `D22` did not have to.
+
+**Row 3 is discharged**, with the honest note that `kcol_w30.py` needs its pre-registered population updated
+from 20 to 22 before it can emit — a one-line change owed to whoever next wants the column in the table.
+
 ---
 
 ## What was NOT run

--- a/docs/af-bank-cleanup-results.md
+++ b/docs/af-bank-cleanup-results.md
@@ -1,0 +1,531 @@
+# The synthetic-AF-bank cleanup — a SHIP run, and the end of the thread
+
+**Run window.** `T0 = 2026-08-14T00:00:31Z`, stop `T0 + 6 h = 2026-08-14T06:00:31Z` (the invoking message named no
+duration). PR #196 verified `MERGED` at `2026-08-13T22:56:58Z` before anything else ran.
+
+**Suite baseline, by COUNT out of the log (F37), re-established on `develop @ 2ebbd43` after the merge:**
+
+```
+Passed!  - Failed: 0, Passed: 4039, Skipped: 0, Total: 4039, Duration: 5 m 52 s
+```
+
+**4039 survived the merge**, so 4039 is this run's baseline and every count below is relative to it.
+
+**Branch:** `ghilios/af-bank-cleanup`, one branch and one PR, base `2ebbd43`.
+
+---
+
+## THE HEADLINE
+
+**`V-0` fired, and item 2 is VOID — the pre-registration did exactly the job it was written for.** The F82 fix
+`(3′)` cannot change a single recommended step on `D01` in the configuration the product actually runs, and this
+was established *before* any code was written, at a cost of 26 minutes of bank time instead of the 2 h 25 m –
+3 h 10 m the decision document priced.
+
+It is stronger than the gate required. `V-0` asked about `D01`. Measured on all three published cells, in the
+product's configuration, `(3′)` is inert on every one of them — twice because F18's detectability bound clamps
+far below `(3′)`'s floor, and once because the round already sits exactly on that floor.
+
+---
+
+## Item 1 — `V-0`, the validity gate. **FIRES. Item 2 is VOID.**
+
+### The check, first
+
+[F110](followups.md)'s claim verified before acting on it:
+
+```
+$ grep -c 'maxUsefulHalfSpan.*NaN' /mnt/d/hf_w25/after/D01_ultrawide_40mm__S1/synth_validate_report.json
+2
+```
+
+Both of `D01`'s published rounds carry `maxUsefulHalfSpan: NaN`. The harness builds `stepDetectability` only
+when `--step-detect-bound` or `--step-size-for-executed-sweep` was passed (`SynthValidateRunner.cs:783-793`,
+read at `HEAD`), and wave 25's S1 arm passed neither.
+
+### The arm
+
+Run on **B15** (`/mnt/d/hf_w25/exe`) — no build. DLL hashes asserted against `binary_provenance_w25.txt` before
+the loop, and they matched exactly (`TestApp.dll 2fb0c8fd…`, `NINA.Joko.Plugins.HocusFocus.dll 3fd1fc4b…`);
+`TestApp.exe` itself was **not** hashed as the decision criterion (F66 — the apphost is byte-identical across
+seven distinct binaries). Driver: `/mnt/d/hf_ship1/v0_arm.sh`, log `/mnt/d/hf_ship1/v0_arm.log`,
+`V0_ARM_START … V0_ARM_END … manifest rows: 6 of 6 scheduled`, one `TestApp.exe` at a time.
+
+**Both arms were run on the same binary** — `off` (no flag) and `on` (`--step-detect-bound`) — so that any
+difference is attributable to the flag rather than to a re-run. The `off` arm **reproduces wave 25's published
+`D01` report bit-identically**: `halfWidth` 12.0 / 9.0, steps 3 / 3, `sampledHfrRange` matching to all 16
+printed digits. That is what licenses reading the `on`/`off` delta as the flag's effect.
+
+### The result
+
+`(3′)`'s floor is `MaxHalfWidthSampledHalfSpanMultiple × 0.5 × requestedSpan = 1.5 × 0.5 × (2·offsetSteps·stepSize)`.
+
+| cell | round | requested span | `(3′)` floor | detect bound ON | `halfWidth` ON | step ON | step OFF |
+|---|---|---|---|---|---|---|---|
+| `D01` | r1 | 24.0 | **18.00** | **yes**, `maxUsefulHalfSpan = 7.789` | **7.789** | **2** | 3 |
+| `D02` | r1 | 24.0 | **18.00** | **yes**, `maxUsefulHalfSpan = 15.130` | **15.130** | **4** | 5 |
+| `D03` | r1 | 56.0 | **42.00** | no (`NaN`) | 42.0 | 12 | 12 |
+
+**`D01` r1 — the exact round `(3′)` was designed to move from step 3 to step 5 — is detect-bounded to 7.789,
+which is 10.2 below `(3′)`'s floor of 18.0.**
+
+### Why that is decisive, from the source rather than by inference
+
+`StepSizeRecommender.Recommend`, read at `HEAD` (`:320-379`), applies its bounds in this order:
+
+1. `maxHalfWidth = MaxHalfWidthSampledHalfSpanMultiple × 0.5 × searchSpan` (`:320`);
+2. the **cap** — clamp down to `maxHalfWidth` (`:346-350`);
+3. the **`BandDemonstrablyUnsampled` floor** — raise up to `maxHalfWidth` (`:363-366`);
+4. **F18's detectability bound** (`:368-379`), whose comment reads *"Only ever tightens"*:
+   `detectHalfWidth = Math.Max(maxUsefulHalfSpan, minHalfWidth)`, and `if (detectHalfWidth < halfWidth)` then
+   `halfWidth = detectHalfWidth`.
+
+`(3′)` inserts `maxHalfWidth = Math.Max(maxHalfWidth, 1.5 × 0.5 × requestedSpan)` at step 1. On `D01` r1 that
+raises `maxHalfWidth` to 18.0 and step 2 or 3 sets `halfWidth = 18.0` — and then **step 4 clamps it straight
+back to 7.789**, because `(3′)` does not touch `searchSpan` and therefore does not move `minHalfWidth`
+(`0.5 × 0.5 × 12.0 = 3.0`, and `max(7.789, 3.0) = 7.789` either way). `round(7.789 / 3.5) = 2` — the step the
+run already produces. **`(3′)` changes zero recommended steps on `D01` in the product's configuration.**
+
+This is precisely the pre-registered void condition, decision document §6 row `V-0` and §7 clause 1: *"if the
+detect bound already clamps `D01` below the requested-span floor, `(3′)` cannot fix `D01` in the product and the
+finding is an F18-vs-F81 conflict, not F82. Then this decision is void and the entry is re-scoped."*
+
+### Two things the arm found that nobody asked it for
+
+- **The product's configuration does not reproduce F82's stall at all.** With the detect bound supplied, `D01`
+  does not go 3 → 3; it goes **3 → 2 → 3 → 3** and runs the full four rounds instead of stopping at two. The
+  behaviour is an **oscillation**, not the monotone stall F82 describes. F82's published two-round table is an
+  artifact of the harness configuration, which is the register delta the decision document's §8 already
+  anticipated ("F82's published evidence was produced in a harness configuration the product does not run") —
+  now measured rather than argued.
+- **The detect bound moves the step in the opposite direction from `(3′)`.** On `D01` and `D02` it *tightens*
+  (3 → 2 and 5 → 4). Whatever the right answer for a star-poor shallow sweep is, `(3′)` was pushing against
+  F18, not with it.
+
+### What this run did **not** do, and why
+
+`(3′)` was **not implemented**: `V-0` is a stop condition, not a warning, and the prompt's instruction on a fire
+is to say so and skip to item 3. The 42 m `optimize` gate that `(3′)` would have owed was therefore never owed.
+`StepSizeRecommender.cs` is **unmodified on this branch** — confirmed by the diff in the closing section.
+
+**F82's correct entry is now "the F18-vs-F81 ordering conflict", not a requested-span bound.** The open question
+it leaves is a real one and it is *not* what F82 says: on a shallow, star-poor sweep, F18's measured
+detectability bound and F81's band floor disagree about which way to move, and F18 wins by being applied last.
+That deserves its own decision, and it needs the blind wide-field data that §3 puts out of scope.
+
+---
+
+## Item 3 — the `ACCEPTED-elsewhere` residual. **RESOLVED: a matching artifact. Not a precision risk.**
+
+Zero TestApp minutes: everything below is computed from artifacts already on disk.
+
+### The check, first
+
+```
+$ grep -n 'ACCEPTED-elsewhere' /mnt/d/hf_w30/g/out/M{1,3,4}/attempt01/golden_eval.txt
+M1: 3141 (all tiers) / 1031 (high)    M3: 3417 / 1106    M4: 3333 / 1091
+```
+
+### The mechanism, which is not what the framing assumes
+
+The two numbers in wave 30 §4.5's table are produced by **two different predicates**, and they are not the same
+strictness:
+
+| | predicate | source |
+|---|---|---|
+| the **matcher**, which decides TP/FN | `centerIn(D.center, G.box) OR dist(D.center, G.center) ≤ 12 px`, then greedy 1:1 by IoU desc / distance asc | `GoldenGeometry.cs:202-256`, mode `Center` |
+| the **FN attribution**, which prints `ACCEPTED-elsewhere` | `IoU(G.box, D.box) > 0.0` — **any** overlap, however small | `BoxMatcher.cs:96-150` via `GoldenEvalRunner.cs:355-360` |
+
+So a golden star can be labelled `ACCEPTED-elsewhere` while being unmatchable to every accepted detection on the
+frame. That is a third possibility the binary question omits, and it is decidable on disk.
+
+### The measurement, with its self-test stated first
+
+`/mnt/d/hf_ship1/item3_accepted_elsewhere.py` rebuilds the matcher offline from `golden.json` +
+`detected_f*.csv` and **reproduces the run's own per-frame `TP`, `FN` and `accepted` counts exactly on every
+frame of all seven cells**, and the published `ACCEPTED-elsewhere` totals exactly (1740, 3141, 3333, 3417, 1869,
+1769, 1740). Without that the rest would be worthless, so it runs first and exits non-zero on a mismatch.
+
+| cell | gate | accepted | AE | unmatchable (graze) | competing | `d(G,G′) ≤ 12 px` | `> 12 px` |
+|---|---|---|---|---|---|---|---|
+| `M0` | baseline, `MaxDistortion` 0.5 | 20 831 | 1 740 | 55 (3.2 %) | 1 685 | 1 660 (**98.5 %**) | 25 (1.5 %) |
+| `M1` | `MaxDistortion` 0.3 | 22 756 | 3 141 | 169 (5.4 %) | 2 972 | 2 790 (**93.9 %**) | 182 (6.1 %) |
+| `M4` | `MaxDistortion` 0.2 | 22 933 | 3 333 | 228 (6.8 %) | 3 105 | 2 895 (**93.2 %**) | 210 (6.8 %) |
+| `M2` | `Sensitivity` 32.333 | 23 635 | 1 869 | 56 (3.0 %) | 1 813 | 1 787 (98.6 %) | 26 (1.4 %) |
+| `L3` | `Sensitivity` 35.333 | 21 505 | 1 769 | 55 (3.1 %) | 1 714 | 1 688 (98.5 %) | 26 (1.5 %) |
+
+`d(G,G′)` is the distance from the `ACCEPTED-elsewhere` golden star to **the golden star that actually won its
+nearest qualifying detection**. The median **winning detection box** contains **exactly 2.0 golden centres**
+(the median is over those winning boxes, not over all accepted detections).
+
+**My "instrumentation artifact" hypothesis was mostly wrong and is recorded as such:** only 3–7 % are grazes.
+The dominant mechanism is the *other* one.
+
+### The answer
+
+**It is real stars matched to a neighbour, and it is harmless to precision.** In 93–99 % of the competing cases
+the `ACCEPTED-elsewhere` star and the star that won its detection are **themselves closer together than the
+match radius** (median separation 7–8 px against a 12 px radius, and a median of 2.0 golden centres inside the
+winning detection box). A
+greedy 1:1 matcher **cannot** pair both, whatever the detector does: the loser is a false negative by
+construction of the *scorer*, not by any behaviour of the *detector*.
+
+The distortion-linked component is real but bounded, and it is the same mechanism at a wider scale, not a
+different one. The `d(G,G′) > 12 px` bucket rises 4× from the baseline and sensitivity arms (1.4–1.5 %) to the
+distortion arms (6.1–6.8 %) — 25 → 210 stars. Characterised
+(`/mnt/d/hf_ship1/item3c_far.py`): **100 % of those cases have `d(G,G′) ≤ 2R = 24 px`** (max 22.8 px at `M4`,
+14.6 px at `M0`), with **no tail**, and the winning detections are larger than typical (median box area 513 px²
+against 182 px² for all accepted). That is one relaxed-gate blob spanning a close pair — blending — which costs
+**recall**, cannot cost precision, and is bounded at twice the match radius by construction.
+
+Consistent with the direct measurement wave 30 already had and did not connect to it: precision is **1.000 with
+`FP = 0`** at `MaxDistortion` 0.5 / 0.3 / 0.2 (`/mnt/d/hf_w30/row7_precision_rescore.txt`).
+
+**Wave 30 §10 row 7 — "precision at the opened `MaxDistortion` settings", `OWED by any ship that lowers
+MaxDistortion` — is discharged.** The residual it was created for is a scorer-side 1:1 matching consequence of
+golden crowding below the match radius. It is not evidence of a precision risk, and there is no precision
+number left to go and get.
+
+---
+
+## Item 4 — bound and rename the `MaxDistortion` axis
+
+### The check, first
+
+```
+$ grep -n 'fillRatio' …/StarDetection/StarDetector.cs
+1802:  var fillRatio = (starPoints.Count + donutHoleArea) / d / d;
+1804:  if (fillRatio < effectiveMaxDistortion) {   → RejectionGate.TooDistorted
+```
+
+[F98](followups.md) confirmed at `HEAD`: the gate **rejects when the fill ratio falls below the value**, so
+`MaxDistortion` is a **minimum fill ratio** and raising it makes the gate *stricter*. A perfectly round star
+tops out at `π/4 ≈ 0.785`.
+
+### The bound — shipped
+
+The axis was `Continuous(MaxDistortion, 0.1, 1.0, 0.1)` (`OptimizerVariable.cs:176`). Shipped as a named
+constant with the geometry in its doc comment, matching the file's existing style — and called out as the one
+bound in the curated set that is **geometric rather than heuristic**:
+
+```csharp
+public const double MaxDistortionSearchUpper = Math.PI / 4.0;
+```
+
+> **CORRECTION, made mid-run against the source, and the wrong version is printed here so the correction is
+> legible.** I first justified this as a coarse-grid saving: *"the coarse grid samples `Lower + t·(Upper − Lower)`
+> inclusive of both bounds at `CoarseGridLevels = 4`, so the old four levels were 0.1 / 0.4 / 0.7 / 1.0 and one
+> of them was spent on a guaranteed-empty setting."* **That is false. `MaxDistortion` is never coarse-gridded.**
+> `StarDetectionOptimizer`'s Phase A grids **only** `Sensitivity × StarClippingMultiplier` (`:764-789`) and holds
+> every other variable at the incumbent; `GridValue` is called on exactly those two axes and nowhere else.
+>
+> I caught it because the false premise produced a **falsifiable prediction that the gate then refuted** — which
+> is the entire argument for writing predictions down before running the instrument. It also propagated into the
+> first commit message and the F98 register entry; both are corrected, and the correction says what it replaces.
+
+**The true mechanism, narrower and still worth shipping.** `MaxDistortion` moves only under the **pattern
+search**, whose proposals are clamped by `Quantize` to `[Lower, Upper]`. The old ceiling left roughly the
+**top 21 % of the axis reachable** while returning zero detections for a round star by construction — the
+collapse wave 29 measured directly at 0.9 (`TP=0 FP=0 FN=110384`, recall 0.000 on both `L2` and `L4`). The bound
+makes that band **unreachable**: a guard against a pathological upward excursion, and therefore **expected to be
+inert on any run that never walks up there**.
+
+That reframing changes what the test should assert, so the test changed with it: instead of enumerating
+coarse-grid levels that do not exist, it walks the axis in its own `InitialStep` past the old 1.0 ceiling and
+asserts that **no reachable stored value** ever lands in the dead band.
+
+### The rename — what applies, stated rather than assumed
+
+**`MaxDistortion` is both user-visible and persisted**, so a rename of the knob itself is a settings migration:
+
+- persisted under the literal key `"MaxDistortion"` (`StarDetectionOptions.cs:276,764`), default 0.5;
+- it **already has** its control in `Resources/OptionsDataTemplates.xaml` (label + tooltip + validated binding
+  at `:1573-1595`), so `CLAUDE.md`'s options-owe-XAML invariant is satisfied and no new control is owed;
+- the name reaches 11 C# files, the replay snapshot, the diff, `OptimizedStarDetectionSettings`, `TestApp`, and
+  ~12 references in the user manual, which documents it correctly as *"Min fill ratio of the bounding box"*.
+
+**So I bounded the axis and renamed the label, and did not rename the persisted key.** Renaming a persisted
+key under a stop clock risks silently resetting every user's tuned value, and it buys nothing a user can see
+that the label does not. The label is where a user actually reads the name, and it now states the direction:
+
+- label `"Max Distortion"` → **`"Max Distortion (min fill ratio)"`** — states the direction, keeps the
+  documented name findable;
+- the tooltip now leads with *"A MINIMUM fill ratio, despite the name … rejected as Too Distorted when its fill
+  ratio falls BELOW this value. Raising it makes the gate stricter, not looser"*, and states the π/4 ceiling.
+  It also fixes two errors it has carried: `"circule"`, and `"PI/4, which is approximately 0.7"` (it is 0.785 —
+  the old text understated the ceiling by 0.085, which is most of a coarse-grid step).
+
+**The persisted-key rename is left as a named, unpaid debt** — it is a migration, and it deserves its own
+decision rather than a corner of a cleanup run.
+
+### The bottom of the axis — unchanged, and now with a reason
+
+Item 3 gates it, and item 3 resolved as *no precision risk*. That licenses the bottom of the axis but does not
+motivate a change to it: the floor is already 0.1, wave 30 measured 0.5 / 0.3 / 0.2 at `FP = 0`, and nothing in
+this run says the search is being kept out of a region it needs. **No change, deliberately.**
+
+### Shown RED against a named mutant
+
+`M-OLD-CEILING` — the one constant the change introduced, reverted to exactly the value it replaced
+(`Math.PI / 4.0 → 1.0`). Driver: `mutant_M-OLD-CEILING.sh`; byte backup, `trap`-restore, `touch` after restore
+(F89), sha256 re-verified identical afterwards.
+
+```
+MUTATED: MaxDistortionSearchUpper = Math.PI / 4.0  ->  1.0
+  Failed CreateCuratedSet_BoundsAndStepsMatchSpec
+  Failed MaxDistortionAxis_NoReachableValue_RejectsEveryRoundStar
+  Failed MaxDistortionAxis_WriteClampsAboveTheGeometricCeiling
+  Failed MaxDistortionSearchUpper_IsTheFillRatioOfARasterisedPerfectDisk
+Failed!  - Failed: 4, Passed: 23, Skipped: 0, Total: 27
+restored ok sha256(after) = 5770c214…c91bd06   (identical)
+```
+
+(Re-run after the correction above, against the corrected tests — the mutant kills the reachability test just as
+it killed the coarse-grid one it replaced, because the constant is what both depend on.)
+
+**Final suite, by COUNT: `Passed! - Failed: 0, Passed: 4052, Skipped: 0, Total: 4052`** = 4039 + 3 (item 4) +
+10 (item 5). Zero failures, zero skips, and no test was marked expected-to-fail.
+
+---
+
+## Item 5 — the `A4` truth-model gap. **FIXED, harness-side, and it carries no gate.**
+
+### The check, first
+
+`grep -rn 'truthModel' Joko.NINA.Plugins/TestApp/SynthBank/` returns the spec's truth-model block, and `A4`
+itself lives at `SynthValidateRunner.cs:930-948`. Still owed, and [F96](followups.md) makes it more urgent:
+`stepBehavioral` is `StepSizeRecommender.Recommend` iterated to a fixed point (`:1213-1270`), so the harness
+scores the recommender against a fixed point of itself.
+
+### Two defects, both on the assertion side, and the product is untouched
+
+1. **The boundary came from the wrong span.** `A4` built it as `1.5 × (offsetSteps × stepSize)` — the
+   **requested** sweep. The product builds `maxHalfWidth = 1.5 × 0.5 × SearchSpan(bestFit)`, and `SearchSpan` is
+   `max(x) − min(x)` over the points that **survived into the fit** — smaller whenever a position was dropped
+   for a non-finite pooled HFR, held out as a recovery frame, or removed as a consensus outlier. On `D01` r1
+   that is requested 24.0 against fitted 12.0: **`A4` was asserting against 18.0 while the product applied 9.0.**
+2. **It asserted the cap predicate on band-floored rounds, where it does not apply.** The cap and the floor are
+   mutually exclusive and bound in **opposite directions**: the cap clamps a fitted crossing *down* to
+   `maxHalfWidth`, the floor raises one *up* to it when the sweep's own HFRs prove the band was never sampled.
+   "Truth is above the boundary" predicts the **cap** and says nothing about the **floor** — so on `D03` r0 the
+   rule FAILed (`truth 46.1 vs boundary 24.0`) a round the floor had handled exactly as F81 designed. A floored
+   round is now reported **`NotApplicable`** and named, not silently dropped.
+
+> **A correction to my own first attempt at this, made before it shipped and recorded because the record is
+> better for it.** I first wrote defect 2 as *"reading `WasCapped` alone; the two branches clamp to the same
+> `maxHalfWidth`, so `bounded = WasCapped || WasBandFloored`."* That is wrong, and re-scoring the real reports
+> is what showed it. It does repair `D03` r0 — but it breaks the two floored rounds whose truth sits **below**
+> the boundary: `D01` r0 (ratio 0.87) would drop **PASS → FLAG** and `D02` r0 (ratio 0.70) **PASS → FAIL**, on
+> rounds where the recommender did nothing wrong. The outcome-level claim ("the half-width ended at
+> `maxHalfWidth`") is true of both branches; the truth-level claim ("the model wanted to go further than the
+> data supports") is only about the cap. Conflating them trades one wrong verdict for two. **Exemption is the
+> verdict that is right in both directions**, and both directions are now pinned by tests.
+>
+> `SynthValidationVerdict` gains a fourth value, `NotApplicable`, appended **last** so `Pass`/`Flag`/`Fail` keep
+> ordinals 0/1/2 and no existing artifact changes meaning. `Worst()` already treats anything that is not
+> `Fail`/`Flag` as passing, so an exemption cannot fail a scenario; and because the report lists every non-`Pass`
+> finding, the exemption is *visible* rather than a silently missing row.
+
+`SynthValidateRunner` now records `fittedSearchSpan` (recomputed from `bestFit.Inputs`, mirroring the private
+`SearchSpan` rather than exposing it), and the decision moved into `TestApp/SynthBank/CapSemantics.cs` — the
+same shape as `TruthDisclosure`, because the runner renders frames and runs the optimizer and cannot be linked
+into the test project.
+
+**Backward compatibility is a property, not a hope:** reports written before `fittedSearchSpan` existed carry
+`NaN` and fall back to the requested sweep, which is *exactly* the historical boundary — and on the 36 of 37
+bank rounds where nothing was dropped the two spans are equal anyway, so re-scoring old artifacts cannot move a
+verdict. Both are pinned by tests.
+
+**No product file is touched**, deliberately — so this change carries **no `optimize` gate** and cannot be
+confused with a behaviour change. It is committed separately from item 4 for the same reason.
+
+### What A4 actually said on real reports, before and after
+
+Read out of the V-0 arm's own reports — this is the fix's motivating evidence, not a constructed fixture:
+
+| cell | round | branch | old A4 | old boundary | new A4 | why |
+|---|---|---|---|---|---|---|
+| `D01` | r1 | capped | **FAIL** | 18.0 (requested) | **PASS** | fitted boundary is 9.0; truth 10.4 **is** above it |
+| `D01` | r3 | capped | **FAIL** | 18.0 | **PASS** | same |
+| `D02` | r1 | capped | **FAIL** | 18.0 | **PASS** | same |
+| `D03` | r0 | floored | **FAIL** | 24.0 | **N/A** | the cap predicate does not describe a floored round |
+| `D01` | r0 | floored | PASS | 12.0 | **N/A** | exempt in the other direction too |
+| `D02` | r0 | floored | PASS | 12.0 | **N/A** | " |
+| `D03` | r1 | capped | PASS | 42.0 | **PASS** | fitted == requested; unchanged |
+
+**Four of the ten A4 verdicts on these three cells were failures, and none of them was a product defect.**
+
+### Shown RED against three named mutants
+
+Two are the repaired defects; the third is the alternative that was **considered and rejected**, so the suite
+records *why* it was rejected instead of merely asserting the choice.
+
+```
+M-A4-REQUESTED-SPAN       (useFitted := false)
+  Failed Evaluate_UsesTheFittedSpan_NotTheRequestedSweep
+  Failed! - Failed: 1, Passed: 9, Total: 10
+
+M-A4-NO-FLOOR-EXEMPTION   (the old behaviour: floored rounds fall through to the cap assertion)
+  Failed Evaluate_ABandFlooredRound_TruthAboveTheBoundary_IsNotApplicable
+  Failed Evaluate_ABandFlooredRound_TruthBelowTheBoundary_IsAlsoNotApplicable
+  Failed! - Failed: 2, Passed: 8, Total: 10
+
+M-A4-FLOOR-COUNTS-AS-CAP  (the rejected alternative: no exemption AND floor satisfies the cap)
+  Failed Evaluate_ABandFlooredRound_TruthAboveTheBoundary_IsNotApplicable
+  Failed Evaluate_ABandFlooredRound_TruthBelowTheBoundary_IsAlsoNotApplicable
+  Failed! - Failed: 2, Passed: 8, Total: 10
+
+restored ok sha256(after) = 6296d26a…06279b   (identical)
+```
+
+**Stated rather than glossed:** the last two mutants are killed by the **same pair** of tests, so the suite
+*excludes* both alternatives without *distinguishing* between them. That is honest coverage of the decision —
+neither alternative survives — but it is not three independently-discriminated mutants, and reporting it as
+three would overstate what the suite proves.
+
+---
+
+## THE 42-MINUTE `optimize` GATE — owed, and run as a PAIRED arm
+
+### It is owed, and the predicate was run rather than asserted
+
+`Q27-V1`'s reachable set, quoted verbatim from `/mnt/d/hf_w27/q27_v1.txt`, intersected against the change set
+(tracked diff **unioned with untracked**, F88), against the BEFORE binary's tree read out of **its own
+provenance file** (`/mnt/d/hf_w25/binary_provenance_w25.txt` → `29665a62…`), never an assumed previous HEAD:
+
+```
+>>> intersection size = 4  =>  GATE IS OWED
+    …/HocusFocus/StarDetection/Optimization/OptimizerVariable.cs      <-- this branch
+    …/HocusFocus/Controls/EdgeJustifiedWrapPanel.cs                   <-- merged since B15, not this branch
+    …/HocusFocus/Properties/AssemblyInfo.cs                           <-- "
+    …/HocusFocus/Utility/DetectionBinningResolver.cs                  <-- "
+```
+
+### Why one arm was not enough — a confound found before it could mislead
+
+**The B15 → B17 diff spans everything merged to `develop` since wave 25, not just this branch.** One of those
+files, `DetectionBinningResolver.cs`, changed **+76/−14** and is referenced by `OptimizationDiagnosticRunner.cs`
+— *the gate's own path*. So a single arm against K8 cannot separate "the axis bound moved it" from "someone
+else's merge moved it". **Both arms were run:** `BASE` = `develop @ 2ebbd43` (this branch's own base) and
+`BRANCH` = this branch. **`BRANCH` vs `BASE` is the only comparison that isolates this change**, and it is the
+one the clause is read on.
+
+### The prediction, written before the gate ran
+
+Recorded in full at `/mnt/d/hf_ship1/gate_prediction.txt`, before the binary was laid out. In short: this is
+**not** the believed-inert shape waves 20/21/25/27 used, where `G-PASS` *is* the inertness measurement. Bounding
+the axis **deliberately changes the search space** — three of this axis's four coarse-grid levels move — so
+`8 of 8 bit-identical` was *not* predicted, and would not have been evidence of correctness if it happened.
+
+- **P1** — fewer than 8 of 8 bit-identical to K8. Sharpened from the BEFORE landings: `D20_m24_bright_control`
+  and `muggsie` both landed at exactly **0.4**, an old coarse-grid level that no longer exists, so they are the
+  likeliest to move; `CWhiteFocus` never left the 0.5 seed on this axis, so it is the likeliest to be identical.
+- **P2** — no dataset materially worse (> 1e-3). Every BEFORE landing is ≤ 0.6, well under π/4, so **no viable
+  optimum lived in the excised band**.
+- **P3** — every landed `MaxDistortion` ≤ π/4, by construction.
+- **Refutation condition, fixed in advance:** any dataset's `BestJ` falling more than 1e-3 below its reference
+  means the bound removed something the search was using, and **the change does not ship in this form**.
+
+### The result — `G-PASS`, 8 of 8 bit-identical, and **my prediction P1 was REFUTED**
+
+`GATE_branch_DONE 2026-08-14T01:36:29Z`, `[COUNT] aggregate_summary.json produced: 8 expected: 8`, marker
+written. 49 m 32 s wall (wave 25's was 42 m 42 s on the same eight).
+
+| dataset | B15 `BestJ` | BRANCH `BestJ` | bit-identical | landed `MaxDistortion` B15 → BRANCH |
+|---|---|---|---|---|
+| `toml999` | 0.9957838768299878 | 0.9957838768299878 | **YES** | 0.4500 → 0.4500 |
+| `CWhiteFocus` | 0.9960675916058808 | 0.9960675916058808 | **YES** | seed → seed |
+| `uneven` | 0.9963677194179505 | 0.9963677194179505 | **YES** | 0.6000 → 0.6000 |
+| `muggsie` | 0.9971948738498605 | 0.9971948738498605 | **YES** | 0.4000 → 0.4000 |
+| `mccomiskey` | 0.9767460801208465 | 0.9767460801208465 | **YES** | 0.4125 → 0.4125 |
+| `D18_m24_deep_shed` | 0.9998815090506263 | 0.9998815090506263 | **YES** | 0.1000 → 0.1000 |
+| `D19_cygnus_deep_shed` | 0.9994870586135448 | 0.9994870586135448 | **YES** | 0.5375 → 0.5375 |
+| `D20_m24_bright_control` | 0.9997378027339423 | 0.9997378027339423 | **YES** | 0.4000 → 0.4000 |
+
+**`BestJ` bit-identical to B15: 8 of 8. Landed `MaxDistortion` identical: 8 of 8. `P2` HOLDS, `P3` HOLDS.**
+This is K8's thirteenth consecutive reproduction.
+
+**`P1` — "fewer than 8 of 8 will be bit-identical" — is REFUTED, and that refutation is the most useful thing
+the gate produced.** `muggsie` and `D20`, which I named in advance as the likeliest to move because they land on
+0.4, did not move. The prediction was wrong because its **premise** was wrong: I believed `MaxDistortion` was
+coarse-gridded, and it is not. Reading the source after the refutation is what found it (see the correction in
+item 4). **A prediction with a false premise is still doing its job when the instrument contradicts it** — that
+is the whole reason for writing it down first, and it is why this gate was worth its 49 minutes even though it
+"only" reproduced the baseline.
+
+Once the mechanism is corrected, `8 of 8` is exactly what the change predicts: the bound only removes a region
+the pattern search never visited on these eight runs — every landing sits at or below 0.6.
+
+### The paired BASE arm was prepared and NOT run, with a reason
+
+`develop @ 2ebbd43` was built and laid out (`/mnt/d/hf_ship1/exe_base`, `TestApp.dll 617513d9…`, a different
+binary from the branch's `51daec0c…`), ready to run. **It was not run, because the confound it exists to resolve
+did not arise.** The base arm separates "the axis bound moved it" from "a merge since B15 moved it" — but
+**nothing moved**: the branch reproduces B15 bit-identically on all eight, so both candidate causes are inert on
+this population and there is nothing left to attribute. Running it would have cost 42 minutes to partition zero
+difference. The binary is on disk if a later run wants it.
+
+---
+
+## What was NOT run
+
+- **`(3′)`, and its 42 m gate** — voided by `V-0`. Not a debt: there is nothing left to ship for F82 in that
+  shape.
+- **The four withdrawn wave-30 ledger rows** (§10 rows 3–6) — not re-listed, per §3 of the prompt.
+- **Rendering datasets at 1.4–19.4 ″/px** — out of scope by instruction, and still the only route to a blind
+  wide-field population. It is now *more* clearly the next decision, because `V-0` retired the last product
+  question this bank could answer with another arm.
+- **The `MaxDistortion` persisted-key rename** — a settings migration, named as an unpaid debt rather than
+  attempted under a stop clock. See item 4.
+
+---
+
+## THE HONEST ENDING
+
+**This run ends the synthetic-AF-bank thread, and it ends it on a real result rather than by running out of
+things to do.**
+
+The bank is measured out. Of the five items:
+
+| item | outcome |
+|---|---|
+| 1 — `V-0` | **FIRED.** `(3′)` cannot change a step in the product's configuration. Item 2 is void. |
+| 2 — implement `(3′)` | **VOID**, by item 1, before any code was written. |
+| 3 — the `ACCEPTED-elsewhere` residual | **RESOLVED** as a scorer-side matching artifact. Wave 30 row 7 discharged. |
+| 4 — bound + rename `MaxDistortion` | **SHIPPED** (axis bound + label + tooltip). Persisted-key rename named as a debt. |
+| 5 — the `A4` truth-model gap | **FIXED**, harness-side, no gate owed — and my own first fix corrected before it shipped. |
+
+**Three of the five closed by measurement rather than by construction**, which is the pattern the wave series was
+stopped for: the remaining questions were not answerable with another arm on this bank, and two of them turned
+out not to be product questions at all.
+
+**What is genuinely left is new data, and it is the owner's decision.** `V-0` retired the last product question
+this bank could answer, and it did so by showing that F82's live entry — the F18-vs-F81 ordering conflict — needs
+a **blind** wide-field population that does not exist here (`c_blind = 0`, F97). The 1.4–19.4 ″/px render is the
+only route to one. It has been open twelve waves, it is ≥ 1 h of render, and it was explicitly out of scope for
+this run. **Render it, or stop.** Nothing else on the backlog is blocked on anything but that.
+
+---
+
+## EVIDENCE INDEX
+
+Everything below is on disk and re-runnable.
+
+| what | where |
+|---|---|
+| `V-0` driver + log (`V0_ARM_START`/`_END`, 6 of 6 rows) | `/mnt/d/hf_ship1/v0_arm.sh`, `v0_arm.log` |
+| `V-0` reports, both arms | `/mnt/d/hf_ship1/v0/{off,on}/D0{1,2,3}_*__S1/synth_validate_report.json` |
+| `V-0` scorer | `/mnt/d/hf_ship1/v0_compare.py` |
+| item 3 — reproduction + self-test | `/mnt/d/hf_ship1/item3_accepted_elsewhere.py` |
+| item 3 — the decisive split | `/mnt/d/hf_ship1/item3b_resolve.py` |
+| item 3 — the far-group characterisation | `/mnt/d/hf_ship1/item3c_far.py` |
+| gate prediction, written first | `/mnt/d/hf_ship1/gate_prediction.txt` |
+| gate change set + intersection | `/mnt/d/hf_ship1/gate_changeset.txt`, `gate_intersection.txt` |
+| gate driver, both arms | `/mnt/d/hf_ship1/gate_ship1.sh`, `gate_branch.log`, `gate_base.log` |
+| gate scorer | `/mnt/d/hf_ship1/score_gate_ship1.py` |
+| B17 provenance (dll sha256, two-binary diff) | `/mnt/d/hf_ship1/binary_provenance_ship1.txt` |
+| mutants | `mutant_M-OLD-CEILING.sh`, `mutant_A4.sh` (job tmp dir) |
+
+**One incidental confirmation of [F66](followups.md), measured rather than quoted:** B17's `TestApp.exe` hashes
+`dd7103c2…` — **byte-identical to B15's apphost**, across two binaries whose DLLs plainly differ. Hashing the
+apphost as a binary identity would have reported these two builds as the same build.

--- a/docs/af-bank-cleanup-results.md
+++ b/docs/af-bank-cleanup-results.md
@@ -627,6 +627,50 @@ exemption's evidence remains what it was: the three burned cells (where it conve
 `D01`/`D02` r0's PASSes into N/A) plus two unit tests and two mutants. **Reporting this as an unqualified
 "do-no-harm holds" would overstate it by half**, which is why the split is written out.
 
+### What the two new cells measure — and the wide-field recall story is NOT a clean gradient
+
+`optimize --per-run --max-evals 250` then `golden eval --params optimized`, both pinned to the same settings and
+profile as every other arm. Four steps, **5 m 45 s total** (`/mnt/d/hf_ship1/wf_driver.log`).
+
+> **[F22](followups.md) FENCE, inline and mandatory.** `D21` and `D22` have native `hfrMin` of **0.331 px** and
+> **0.473 px** — both far below the ~1.1 px point where the detector's measured HFR over-reads badly, the same
+> regime that fences `D01`. **No recall count below may be quoted as a recall figure for a user.** The frame in
+> which they may be read is **goal 3** — *is a landed knob sitting at an extreme against the physics?*
+
+| ″/px | dataset | prec | `recall@high` | `recall@all` | `BestJ` (from Baseline) | σ Best (from Baseline) | Sensitivity |
+|---|---|---|---|---|---|---|---|
+| 19.389 | `D01_ultrawide_40mm` | 1.000 | 0.183 | 0.123 | 0.994825 (0.000000) | 0.1514 (0.6145) | 36.333 |
+| **12.926** | **`D21_widefield_60mm`** | **1.000** | **0.103** | **0.061** | 0.993161 (0.000000) | 0.2084 (0.6122) | 35.333 |
+| **7.756** | **`D22_widefield_100mm`** | **1.000** | **0.235** | **0.079** | 0.995044 (0.000000) | 0.1468 (0.7701) | 34.583 |
+| 5.745 | `D02_rich_135mm` | 1.000 | 0.446 | 0.377 | 0.996558 (0.000000) | 0.0991 (0.2321) | 33.333 |
+| 3.102 | `D03_redcat_250mm` | 1.000 | 0.365 | 0.238 | 0.995494 (0.712458) | 0.2698 (1.2397) | 31.583 |
+
+**Three readings, in increasing order of confidence.**
+
+1. **Precision is 1.000 with `FP = 0` on both new cells**, matching 19 of the existing 20. Nothing about the
+   wide-field regime costs precision.
+2. **`recall@high` is NOT monotone in plate scale.** 0.183 → **0.103** → 0.235 → 0.446 → 0.365. `D21` at
+   12.9 ″/px is the **worst** of the wide-field set — worse than `D01` at 19.4. So the table's implied reading,
+   that recall degrades smoothly as the plate scale coarsens, does not survive two new points. **Confounded and
+   labelled as such:** these cells differ in field, limiting magnitude (10.5 / 12.0) and f-ratio as well as in
+   plate scale, so this refutes the *clean gradient*, it does not establish a new law.
+3. **Every one of the five has `BaselineJ = 0.000000` except `D03`.** On wide-field rigs the *default* detection
+   settings score **zero**, and the optimizer recovers to 0.993–0.995. That is the strongest goal-1 statement in
+   the set and the two new cells reproduce it independently.
+
+**And a goal-3 reading that lands squarely on this PR's own change:** the landed `MaxDistortion` on the new
+cells is **0.20** and **0.40** — both far below the π/4 ceiling item 4 introduced, and `D21`'s is near the
+axis's *bottom*. Every landed value now known across the bank spans **0.1 – 0.6**. **Two fresh datapoints,
+gathered after the bound shipped, confirm it removes nothing the search uses**, and that the pressure on that
+axis is downward.
+
+**Not pasted into `docs/synthetic-af-bank-results-table.md`, deliberately.** That table's header pins its
+provenance — *"Optimize columns from wave 18's pinned seedA0 arm … on B15 (BuildId d79dae73); all 20 verified
+against each log's own snapshot-source line."* These rows come from a **different binary and a different
+optimize arm**, so pasting them in would quietly break the claim the header makes. Adding them properly means
+re-running them under the table's own conventions — named here as the owed work, in the same spirit as the `K`
+column refusing rather than emitting a short column.
+
 ### The `K` column — paid, and it refused first, which is the good outcome
 
 Wave 30 §10 **row 3** withdrew the results-table `K` column after three unpaid waves, noting *"`kcol_w30.py`

--- a/docs/af-bank-cleanup-results.md
+++ b/docs/af-bank-cleanup-results.md
@@ -490,6 +490,105 @@ difference. The binary is on disk if a later run wants it.
 
 ---
 
+## SCOPE EXPANSION (owner-authorised, after the first report)
+
+### The twelve-wave coverage-hole row is FALSE, and its own search path could never have caught that
+
+Wave 30 §10 **row 10** reads: *"new datasets between 1.4 and 19.4 ″/px … `ls -d /mnt/d/SyntheticAutofocusBank/D*`
+→ **20, none in the band** … OPEN, twelve waves."*
+
+**Seven of the twenty are in that band.** Computed (`/mnt/d/hf_ship1/coverage_band.py`) as
+`206.265 × pixelSizeMicrons × captureBinning / focalLengthMm`, with pixel sizes read out of
+`SensorRegistry.cs` rather than from memory:
+
+| ″/px | dataset |
+|---|---|
+| 19.389 | `D01_ultrawide_40mm` |
+| 5.745 | `D02_rich_135mm` |
+| 3.102 | `D03_redcat_250mm` |
+| 1.410 | `D04` / `D16` / `D18` / `D20` (550 mm, IMX571) |
+
+**The row's search path counts directories.** `ls -d D*` returns 20 whatever the plate scales are; it cannot
+evaluate the predicate it is attached to. Wave 30 §10's whole point was that *"every row below carries a literal
+search path that returns the answer"* — this row carries one that returns a **different** answer, and being
+checkable-looking is what let it ride for twelve waves.
+
+### The real hole, and it is a different band
+
+| ratio gap | from | to |
+|---|---|---|
+| **× 3.38** | 19.389 (`D01`) | 5.745 (`D02`) |
+| × 2.20 | 3.102 (`D03`) | 1.410 (`D20`) |
+| × 1.85 | 5.745 (`D02`) | 3.102 (`D03`) |
+
+**Exactly one dataset sits above 5.75 ″/px, and it is `D01` — the cell F97 records as burned.** That is the
+mechanical reason `c_blind = 0`: not that wide-field data is missing, but that *all* of it is one burned cell.
+So a blind wide-field population needs **≈ 5.7 – 19.4 ″/px**, not "1.4 – 19.4", which is covered seven times
+over. **A render aimed at the row as written would have added cells the bank already had.**
+
+### Two datasets added to close it
+
+Appended to the checked-in spec (`TestApp/SynthBank/synthetic-bank-spec.json`), with fresh `datasetSeed`s so
+the existing twenty are untouched:
+
+| new | rig | ″/px | field |
+|---|---|---|---|
+| `D21_widefield_60mm` | 60 mm f/4.0, IMX571 bin1 | **12.926** | Orion belt/sword |
+| `D22_widefield_100mm` | 100 mm f/5.6, IMX533 bin1 | **7.756** | Perseus/Auriga |
+
+Fields are chosen so that **neither new cell CONTAINS any existing dataset**: `D21`'s nearest is 21.3° away
+against a 13.2° FOV radius, `D22`'s is 17.2° against 4.6°. An earlier draft put `D21` in Orion **0.3° from
+`D03`** — a 26.5° field that would have swallowed a burned cell whole, which is precisely the correlation the
+new cells exist to avoid. Caught by computing separations rather than eyeballing constellations. The wide-field
+ladder becomes 19.389 → 12.926 → 7.756 → 5.745, every step ≤ 1.67×.
+
+### The render cost 43 seconds, not "≥ 1 h"
+
+```
+RENDER_render_START 2026-08-14T04:13:13Z … synth-bank: 2 generated, 0 skipped, 0 failed
+RENDER_verify_END   2026-08-14T04:13:56Z
+```
+
+9 FITS + 9 `golden.json` + `synthetic_meta.json` per cell, `--verify` clean, 532 MB + 184 MB. **Both halves of
+the row that blocked this for twelve waves were wrong: the band, and the price.** `--dry-run` first (a habit
+worth keeping — it exercises the kernel-cap guard, which is what would actually have wasted render time);
+both cells came back `withinCap=YES` at 0.7 % utilization, identical to `D01`/`D02`/`D03`.
+
+### And then the thing the whole series wanted: `c_blind` is no longer 0
+
+Pre-registered before the arm ran (`/mnt/d/hf_ship1/blind_widefield_prereg.txt`), because these are the first
+genuinely blind wide-field cells the series has had.
+
+| arm | cell | r | requested | **fitted** | `halfWidth` | step | branch | detect-bound |
+|---|---|---|---|---|---|---|---|---|
+| off | `D21` | 2 | 40.0 | **30.0** | 22.5 | 6 | capped | — |
+| on | `D21` | 2 | 40.0 | **30.0** | **19.384** | 6 | capped | **binds** |
+| off/on | `D22` | 0–2 | 16/24/40 | 16/24/40 | — | 3/5/9 | — | — |
+
+**`P1` CONFIRMED.** `D21` r2 requested a span of 40.0 and the fit came back spanning **30.0** — the sweep was
+widened and the outer frames stopped yielding usable HFR points. **That is F82's shrink-while-widening
+transition, on a cell nothing has ever been tuned against.** [F97](followups.md)'s `c_blind = 0` was an artifact
+of the coverage hole, not a fact about rarity: the very first blind wide-field cell rendered exhibits it.
+
+**`P2` CONFIRMED.** On the one round where the product's detectability bound binds, `maxUsefulHalfSpan = 19.384`
+against a requested-span floor of **30.0** — F18 clamps **below** F81's floor, exactly as on `D01` r1 and `D02`
+r1. **The F18-vs-F81 ordering conflict reproduces off `D01`**, which is what F82's re-scoped entry needed and
+could not previously get.
+
+**`P3` CONFIRMED, but narrowly, and the narrowness matters.** The arms differ on `D21` r2 — `halfWidth` 22.5 vs
+19.384 — but **the recommended step is 6 either way** (`round(22.5/3.5) = round(19.384/3.5) = 6`). On `D01` the
+same conflict moved the step (3 → 2). So the ordering conflict is **real and general, while its consequence is
+not**: it changes the half-width on both cells and the recommended step on only one. Any fix must be argued on
+severity, not rate — which is exactly where the F82 decision document's §7 clause 5 already landed.
+
+`D22` shows neither: fitted == requested on all three rounds, no detect bound. **1 of 2.**
+
+**What this burns:** `D21`/`D22` are no longer blind *for the F82 / F18-vs-F81 question*. They remain blind for
+recall, precision, exposure and binning, none of which this arm read as a thresholded quantity. Recorded so a
+later reader does not have to reconstruct it.
+
+---
+
 ## What was NOT run
 
 - **`(3′)`, and its 42 m gate** — voided by `V-0`. Not a debt: there is nothing left to ship for F82 in that

--- a/docs/af-bank-cleanup-results.md
+++ b/docs/af-bank-cleanup-results.md
@@ -712,6 +712,60 @@ from 20 to 22 before it can emit — a one-line change owed to whoever next want
 
 ---
 
+## F49 / F51 — asked for as remaining work, and mostly already done
+
+**I got this wrong first and the correction is the point.** Asked what followups remained, I named F49 and F51
+as *"the highest-value cluster — the only entries with a real user hitting them on shipped defaults."* I had
+read their **`**Status:** Open`** lines and their opening paragraphs. I had not read their bodies.
+
+| entry | what the status said | what the body says |
+|---|---|---|
+| **F51** | `Open` | **all three parts (a)(b)(c) SHIPPED 2026-08-07 (wave 9)**, with a correction caught by an existing test |
+| **F49** | `Open` | **(a) SHIPPED wave 9**, **(c) SHIPPED wave 10**; only **(b)** — a *decision* — remained |
+
+Both status lines are now corrected, and **F51's residual is not F51's**: its own closing line redirects it to
+`F21`/F49(c), and F49(c) shipped the copy that quotes the exact convergence ratio plus a test asserting the cap
+releases.
+
+**This is [F106](followups.md)'s class — "a hand-carried debt ledger rots in BOTH directions" — rotting toward
+OVERSTATING what is left**, and it is the same failure as F112's row 10: a field that *looks* checkable, is read
+as authoritative, and is not maintained. A scan of all 113 entries finds **12 whose status says `Open` while
+their body says `SHIPPED`/`DONE`**. Two are fixed here. **The other ten are named, not bulk-edited**, because
+deciding what genuinely remains in each requires reading it — which is the mistake being corrected, not a
+licence to repeat it at scale:
+
+> `F18` `F25` `F53` `F55` `F58` `F63` `F69` `F70` `F79` `F80`
+
+Two of those (`F79`, `F80`) are already honest — their statuses say *"fix identified and priced; deliberately
+not shipped"* — so the flag is a false positive there, which is itself why a regex must not drive the edit.
+
+### F49(b), decided: **won't fix as asked**
+
+Full argument in **`docs/f49b-lever-choice-decision.md`**. F49(b) asked whether to expose a user-facing floor on
+the search's Sensitivity, or F32's keep fraction. **Neither faces the pathology.**
+
+The premise was re-verified at `HEAD`: `MinDetectionKeepFraction` still has **no XAML binding anywhere**, and
+the search's Sensitivity lower bound (`OptimizerVariable.DefaultSensitivityLower = 0.0`) is not user-exposed
+either — so it is true that today there is no lever.
+
+But F49's landing **kept 7× MORE stars than its seed** (834 → 5 766), and both candidates guard the *shedding*
+end:
+
+- **F32's keep fraction** *"rejects a candidate keeping less than φ of the SEED's accepted stars"* — it could
+  not have bound. It is also retired *"permanently"* as *"the wrong instrument"*. Exposing it would ship a
+  control whose honest tooltip is *"this does not apply to your situation."*
+- **A Sensitivity floor** is defeatable through the other half of F6's inseparable pair — this very run moved
+  `StarClippingMultiplier` 6.750 → 0.250 alongside the gate — and it would forbid a **real optimum**: F83 shows
+  `J` has no precision term on an unlabelled run and `sStars` rewards star count, and F84 measured **22 of 24**
+  pinned instances *driven* to the bound rather than never-moved. F84 says outright: *"Do NOT propose a floor on
+  the Sensitivity axis as the fix."*
+
+**The user's complaint is not "I cannot set a floor" — it is "I cannot tell whether this landing is good."** The
+number that would tell them does not exist on an unlabelled run, and that is **F83**, whose two exits (a
+precision term, or labelling the bank) are now also F49's. **F49(b) resolves into F83 and F49 is closed.**
+
+---
+
 ## What was NOT run
 
 - **`(3′)`, and its 42 m gate** — voided by `V-0`. Not a debt: there is nothing left to ship for F82 in that

--- a/docs/af-bank-cleanup-results.md
+++ b/docs/af-bank-cleanup-results.md
@@ -3,6 +3,11 @@
 **Run window.** `T0 = 2026-08-14T00:00:31Z`, stop `T0 + 6 h = 2026-08-14T06:00:31Z` (the invoking message named no
 duration). PR #196 verified `MERGED` at `2026-08-13T22:56:58Z` before anything else ran.
 
+**The prompt's five items were complete and reported at 02:55Z, inside that window.** Everything under
+**SCOPE EXPANSION** below was authorised by the owner afterwards ("*I don't mind expanding scope. I want to get
+this done*") and runs past the original stop by permission, not by overrun. The sections above it are the run as
+the prompt scoped it.
+
 **Suite baseline, by COUNT out of the log (F37), re-established on `develop @ 2ebbd43` after the merge:**
 
 ```
@@ -549,10 +554,17 @@ RENDER_render_START 2026-08-14T04:13:13Z … synth-bank: 2 generated, 0 skipped,
 RENDER_verify_END   2026-08-14T04:13:56Z
 ```
 
-9 FITS + 9 `golden.json` + `synthetic_meta.json` per cell, `--verify` clean, 532 MB + 184 MB. **Both halves of
-the row that blocked this for twelve waves were wrong: the band, and the price.** `--dry-run` first (a habit
-worth keeping — it exercises the kernel-cap guard, which is what would actually have wasted render time);
-both cells came back `withinCap=YES` at 0.7 % utilization, identical to `D01`/`D02`/`D03`.
+9 FITS + 9 `golden.json` + `synthetic_meta.json` per cell, `--verify` clean, 532 MB + 184 MB. `--dry-run`
+first (a habit worth keeping — it exercises the kernel-cap guard, which is what would actually have wasted
+render time); both cells came back `withinCap=YES` at 0.7 % utilization, identical to `D01`/`D02`/`D03`.
+
+**Stated fairly, because the row's price deserves a fair reading.** Row 10 priced the item at *"≥ 1 h render"*
+**and** *"≥ 1 h compute"* (§12.1). **The compute half was about right** — this run's blind arm was 27 minutes
+for four `synth-validate` runs, and the table arm below adds more. **It is the RENDER half that was never
+grounded in a measurement:** wave 12 recorded *"Render + 15 optimizes: 13 m 51 s total"* for three datasets, so
+rendering was always a small fraction of any arm. Nobody re-derived the render price; it was inherited. So the
+row was not blocked by an hour of rendering — it was blocked by an unexamined number sitting next to an
+unfalsifiable check.
 
 ### And then the thing the whole series wanted: `c_blind` is no longer 0
 

--- a/docs/af-bank-cleanup-results.md
+++ b/docs/af-bank-cleanup-results.md
@@ -739,6 +739,44 @@ licence to repeat it at scale:
 Two of those (`F79`, `F80`) are already honest — their statuses say *"fix identified and priced; deliberately
 not shipped"* — so the flag is a false positive there, which is itself why a regex must not drive the edit.
 
+### The full audit of the twelve — and I made the same mistake again, one message later
+
+All twelve were read. **Five were genuinely stale, four were false positives, one was internally
+contradictory, and two were F49/F51.** After the corrections, a scan for *"an entry whose own part shipped while
+its status says nothing about it"* returns **zero**.
+
+| entry | status said | reality | action |
+|---|---|---|---|
+| **F79** | *"deliberately **not** shipped in wave 23"* | its own body: ***"SHIPPED IN WAVE 23"*** | **corrected** — status directly contradicted the entry |
+| **F80** | *"remedy specified and priced"* | the `--verify-derivation` pre-flight **shipped** (wave 25) | **corrected** — open as the *class*, not the remedy |
+| **F25** | bare *"Open"* | the **narrow half** of its gate shipped (wave 25, P4) | **corrected** — the wide half really is unmeasured |
+| **F53** | bare *"Open"* | **(a) shipped** wave 10 | **corrected** — open as (b), a standing rule |
+| **F58** | mechanism only | **(d) DONE** 2026-08-09 | **corrected** |
+| **F69** | *"**Open** · … · **CLOSED** 2026-08-11"* | closed | **corrected** — it opened with the word it then contradicted |
+| F18, F55, F70 | already disclose what shipped, in the status | accurate | no change |
+| F63 | bare *"Open"* | the `SHIPPED` in its body refers to *another* change's default, not F63's own work | no change — **true false positive** |
+
+**The part worth writing down: I repeated the exact error while reporting on it.** In the message proposing this
+audit I wrote that *"two of those (F79, F80) are already honest — their statuses say 'fix identified and priced;
+deliberately not shipped'"*. **I had read their status lines and taken them at face value** — the identical
+mistake that produced the F49/F51 misdirection two messages earlier. F79 was the *worst* case in the set: its
+status and its own body contradict each other outright.
+
+**So the mechanism is not carelessness about one field; it is that a status line reads as an authority and a
+body reads as history, and nobody re-reads history.** That is why the fix here is not "be more careful" but the
+scan itself, which is now cheap to re-run:
+
+```python
+# an entry whose OWN part shipped, while its status stays silent about it
+own = re.findall(r'(?m)^>?\s*#{2,4} .*\bSHIPPED\b.*$', body) \
+    + re.findall(r'~~[^~]{5,90}~~\s*[—-]+\s*\*\*DONE', body)
+flag = own and not re.search(r'SHIPPED|DONE|CLOSED', status_block)
+```
+
+It keys on the entry's **own** parts — a sub-heading declaring a ship, or a struck-through part marked `DONE` —
+so it does not fire on prose like *"the shipped `Default` profile"*. A looser scan over the same register
+returns 23 candidates, almost all noise; this one returns the 5 that were real and now returns **0**.
+
 ### F49(b), decided: **won't fix as asked**
 
 Full argument in **`docs/f49b-lever-choice-decision.md`**. F49(b) asked whether to expose a user-facing floor on

--- a/docs/af-bank-cleanup-results.md
+++ b/docs/af-bank-cleanup-results.md
@@ -11,7 +11,11 @@ Passed!  - Failed: 0, Passed: 4039, Skipped: 0, Total: 4039, Duration: 5 m 52 s
 
 **4039 survived the merge**, so 4039 is this run's baseline and every count below is relative to it.
 
-**Branch:** `ghilios/af-bank-cleanup`, one branch and one PR, base `2ebbd43`.
+**Final suite: 4052 = 4039 + 3 + 10, zero failures, zero skips.** CI agrees, read out of the run log rather
+than off the tick — `gh run view 31761696772 --log` →
+`Passed! - Failed: 0, Passed: 4052, Skipped: 0, Total: 4052`, run conclusion **success**.
+
+**Branch:** `ghilios/af-bank-cleanup`, one branch and one PR (**#200**), base `2ebbd43`.
 
 ---
 
@@ -339,21 +343,40 @@ verdict. Both are pinned by tests.
 **No product file is touched**, deliberately — so this change carries **no `optimize` gate** and cannot be
 confused with a behaviour change. It is committed separately from item 4 for the same reason.
 
-### What A4 actually said on real reports, before and after
+### What A4 actually says on real reports, before and after — MEASURED, not predicted
 
-Read out of the V-0 arm's own reports — this is the fix's motivating evidence, not a constructed fixture:
+The three published cells re-run on the **new binary** (`/mnt/d/hf_ship1/a4_recheck.sh`, `a4/`, TestApp.dll
+`a1dca0ae…`), same pinned inputs, same no-flag configuration wave 25 published. `fittedSearchSpan` is read out
+of the new reports rather than inferred:
 
-| cell | round | branch | old A4 | old boundary | new A4 | why |
-|---|---|---|---|---|---|---|
-| `D01` | r1 | capped | **FAIL** | 18.0 (requested) | **PASS** | fitted boundary is 9.0; truth 10.4 **is** above it |
-| `D01` | r3 | capped | **FAIL** | 18.0 | **PASS** | same |
-| `D02` | r1 | capped | **FAIL** | 18.0 | **PASS** | same |
-| `D03` | r0 | floored | **FAIL** | 24.0 | **N/A** | the cap predicate does not describe a floored round |
-| `D01` | r0 | floored | PASS | 12.0 | **N/A** | exempt in the other direction too |
-| `D02` | r0 | floored | PASS | 12.0 | **N/A** | " |
-| `D03` | r1 | capped | PASS | 42.0 | **PASS** | fitted == requested; unchanged |
+| cell | round | branch | fitted span | old A4 (boundary) | **new A4 (boundary)** |
+|---|---|---|---|---|---|
+| `D01` | r0 | floored | 16.0 | PASS (12.0) | **N/A** |
+| `D01` | r1 | capped | **12.0** | **FAIL** (18.0) | **PASS** (9.0, ratio 1.15) |
+| `D02` | r0 | floored | 16.0 | PASS (12.0) | **N/A** |
+| `D02` | r1 | capped | **24.0** | **FAIL** (18.0) | **FAIL** (18.0, ratio 0.47) |
+| `D03` | r0 | floored | 32.0 | **FAIL** (24.0) | **N/A** |
+| `D03` | r1 | capped | 56.0 | PASS (42.0) | **PASS** (42.0, ratio 1.10) |
 
-**Four of the ten A4 verdicts on these three cells were failures, and none of them was a product defect.**
+**Three of six A4 verdicts were failures; after the repair, one is.** Two were assertion artifacts. The
+survivor is the point.
+
+> **A second correction to my own write-up, and this one the re-run caught.** I had listed `D02` r1 as
+> FAIL → PASS, by assuming its fitted span matched `D01` r1's. **It does not: `D02` r1's fitted span is 24.0,
+> exactly its requested span**, so the boundary is 18.0 under either rule and the verdict is unchanged. It was
+> derivable from the published report all along — `halfWidth 18.0` on a capped round inverts to
+> `18.0 / 0.75 = 24.0` — and I did not derive it. I had also listed `D01` r3, whose fitted span is **not**
+> recoverable from a B15 report at all (it is capped *and* detect-bounded, so `halfWidth` is the detect bound,
+> not `maxHalfWidth`). Re-running with the new binary replaced both guesses with measurements.
+
+**`D02` r1's surviving FAIL is a real signal, not residual noise.** The round was capped — the fitted crossing
+exceeded `maxHalfWidth = 18.0` — while the analytic truth half-width is **8.4**. The model wanted to extrapolate
+past twice the truth. That is a fit-quality observation about `D02`'s round 1, and it is exactly the kind of
+thing A4 exists to catch; it was previously buried among two failures the assertion was manufacturing itself.
+
+It also demonstrates the property the fix most needed: **the repaired A4 still fails when it should.** A repair
+that made every round pass would have been the easier bug to ship, and this is the real-data evidence that it
+was not shipped.
 
 ### Shown RED against three named mutants
 
@@ -524,6 +547,8 @@ Everything below is on disk and re-runnable.
 | gate driver, both arms | `/mnt/d/hf_ship1/gate_ship1.sh`, `gate_branch.log`, `gate_base.log` |
 | gate scorer | `/mnt/d/hf_ship1/score_gate_ship1.py` |
 | B17 provenance (dll sha256, two-binary diff) | `/mnt/d/hf_ship1/binary_provenance_ship1.txt` |
+| A4 re-check on the new binary (measured verdicts) | `/mnt/d/hf_ship1/a4_recheck.sh`, `a4_recheck.log`, `a4/` |
+| the base gate binary, built and not run | `/mnt/d/hf_ship1/exe_base` (`TestApp.dll 617513d9…`) |
 | mutants | `mutant_M-OLD-CEILING.sh`, `mutant_A4.sh` (job tmp dir) |
 
 **One incidental confirmation of [F66](followups.md), measured rather than quoted:** B17's `TestApp.exe` hashes

--- a/docs/af-bank-cleanup-results.md
+++ b/docs/af-bank-cleanup-results.md
@@ -599,6 +599,34 @@ severity, not rate — which is exactly where the F82 decision document's §7 cl
 recall, precision, exposure and binning, none of which this arm read as a thresholded quantity. Recorded so a
 later reader does not have to reconstruct it.
 
+### A4 do-no-harm on the seventeen NON-burned cells — holds, and half of it was never exercised
+
+The A4 repair was measured on `D01`/`D02`/`D03`, which are exactly the cells it was designed against
+(F14 / `S16` / `D20`). This arm runs the **other seventeen** S1 cells on the new binary and compares A4's
+verdicts against wave 25's published ones, round by round. Prediction fixed before it ran: *a verdict changes
+if and only if the round is band-floored (→ N/A), or capped with fitted ≠ requested (the boundary moves).*
+
+```
+A4_DONOHARM_END 2026-08-14T06:13:02Z   manifest rows: 15 of 17
+  rounds compared: 31      verdicts changed: 0      UNEXPLAINED (refuting): 0
+  verdict mix BEFORE: {PASS: 31}       AFTER: {PASS: 31}
+```
+
+**Population, stated rather than shrunk.** `D05_tec140_1000mm` and `D19_cygnus_deep_shed` both hit the 900 s
+timeout, got **no manifest row, and are NAMED** — and they are precisely the two cells wave 23 lost to
+`timeout 600` and wave 25's driver carried as *"the two NAMED timeout risks"*. A reproduction of a known risk,
+not a new failure.
+
+**The result, and the honest half of it.** All 31 rounds are **`capped` with `fitted == requested`** — so the
+boundary is identical under either rule and the repair is confirmed **inert on 31 rounds it could have moved
+and did not**. That is a real do-no-harm measurement for the **fitted-span** half.
+
+**It is not one for the exemption half.** The population contains **zero band-floored rounds**, so the branch
+that turns a floored round into `NotApplicable` was never entered. This arm says nothing about it. The
+exemption's evidence remains what it was: the three burned cells (where it converts `D03` r0's FAIL and
+`D01`/`D02` r0's PASSes into N/A) plus two unit tests and two mutants. **Reporting this as an unqualified
+"do-no-harm holds" would overstate it by half**, which is why the split is written out.
+
 ### The `K` column — paid, and it refused first, which is the good outcome
 
 Wave 30 §10 **row 3** withdrew the results-table `K` column after three unpaid waves, noting *"`kcol_w30.py`

--- a/docs/f49b-lever-choice-decision.md
+++ b/docs/f49b-lever-choice-decision.md
@@ -1,0 +1,155 @@
+# F49(b) — the "user-facing lever" question, decided
+
+**DECISION: WON'T FIX AS ASKED. Neither candidate lever addresses the pathology F49 observed, and one of them
+has already been retired for this exact reason. The lever F49(b) is reaching for is [F83](followups.md)'s —
+the objective's missing precision term — and that is a different entry with a different price.**
+
+One-sentence reason: F49's landing kept **seven times more** stars than its seed, and both candidate levers act
+on the *shedding* end of the same axis — so neither would have bound on the run that motivated the question.
+
+This document commits a decision and **ships no code**, so it owes no gate.
+
+---
+
+## 1. What F49(b) asks
+
+Verbatim from the register's *Next step*:
+
+> **(b)** Decide whether a user-facing floor on the search's Sensitivity (or F32's keep fraction, exposed) is the
+> right lever, since today there is none.
+
+**The premise is true and was re-verified at `HEAD` for this document, not inherited:**
+
+- `OptimizerSettings.MinDetectionKeepFraction` (`StarDetectionOptimizer.cs:89`) has **no XAML binding anywhere**
+  — `grep -rn 'MinDetectionKeepFraction' --include=*.xaml .` returns nothing. It is `--keep-floor` on the harness
+  only.
+- The search's Sensitivity lower bound is `OptimizerVariable.DefaultSensitivityLower = 0.0`, reachable only
+  through the `sensitivityLower` parameter. **It is not exposed to a user either.**
+- `ExposureRecommender.SensitivityFloorThreshold = 1.0` is **not** a search floor — it is the predicate for
+  *"did the landing come back at the floor"*, and its own doc comment warns against confusing the two.
+
+So: today there is no user lever. The question is whether adding one is right.
+
+---
+
+## 2. The pathology, stated precisely — it is ADMISSION, not shedding
+
+F49's field session, second landing on the shipped `Default` profile:
+
+| quantity | before | after |
+|---|---|---|
+| `BrightnessSensitivity` | 15.667 | **0.000** |
+| `StarClippingMultiplier` | 6.750 | **0.250** |
+| stars per frame | 834 | **5 766** (≈ **7×**) |
+| σ_focus | 6.12 | 0.55 |
+
+**The landing admitted seven times more candidates.** That direction matters, because it is the direction both
+candidate levers do not face.
+
+---
+
+## 3. Candidate 1 — expose F32's keep fraction. **REFUTED, and already retired.**
+
+`MinDetectionKeepFraction` *"rejects a candidate keeping **less than** φ of the SEED's accepted stars"*
+([F32](followups.md), quoted from the entry). It is a guard against the search **shedding** detections.
+
+**On F49's run the landing kept ~7× MORE than the seed, so the constraint is not merely unhelpful — it cannot
+bind at all.** F49's own body already says this in parentheses; this document promotes it to the decision,
+because a lever that cannot fire on the motivating case is not a candidate.
+
+**And it is retired independently.** F32's status reads:
+
+> *"`MinDetectionKeepFraction` stays default OFF **permanently**. The greedy trap itself is confirmed and stands;
+> the floor is simply the **wrong instrument** for it."*
+
+Exposing a control that is permanently-off-by-decision, to address a case it structurally cannot reach, would be
+worse than leaving it hidden: it would put a knob in the options page whose honest tooltip is *"this does not
+apply to your situation."*
+
+---
+
+## 4. Candidate 2 — a user-facing floor on the search's Sensitivity. **REFUTED on three independent grounds.**
+
+### 4.1 It is defeatable by construction, because the axis is half of an inseparable pair
+
+[F6](followups.md): *Sensitivity and star-clip act only in combination.* [F84](followups.md) measured the
+consequence on the at-floor landings — the three with sub-1.5 combined gates are **exactly** the three where the
+search **also** drove `StarClippingMultiplier` down, twice to its own 0.25 floor. F49's own run is a fourth
+instance: Sensitivity 15.667 → 0.000 **and** StarClip 6.750 → 0.250, together.
+
+**So a floor on one member of the pair does not close the admission path; it redirects it to the other member.**
+The search would land at (floor, lower StarClip) and admit approximately what it admits today, while the user is
+shown a control that appears to have worked.
+
+### 4.2 It fights the objective's own gradient, so it is a floor against a real optimum
+
+[F83](followups.md), structural and source-derived: on an **unlabelled** run — which is every run a user makes —
+`OptimizationObjective.cs:484-491` composes `J = Wf·sFocus + Ws·sStars + Wc·sFit` with **no label term**, and the
+one label-free false-positive cost, `SMarginalSnr`, **ships disabled** at `MarginalSnrStrength = 0.0`. `sStars`
+**rewards star count.**
+
+**Driving the gate down buys stars for free.** [F84](followups.md) measured the signature: of 24 pinned
+axis-instances, **0 were never-moved and 22 were DRIVEN to the bound.** These are search outcomes, not seed
+artifacts. Wave 26 then measured `Q-PIN-COSTED` / `A-RESPONSIVE` with **0 flat of 8** — the pin is a **real
+optimum of an objective that cannot see precision.**
+
+A floor therefore does not correct a mistake; it forbids the answer the objective actually prefers, while
+leaving the objective unchanged. The search will sit on the floor and the landing will still be the best point
+the objective can see.
+
+### 4.3 The register has already ruled on floors of this shape
+
+[F84](followups.md) states it directly — *"Do NOT propose a floor on the Sensitivity axis as the fix"* — on the
+evidence that all 8 of 8 at-floor landings are `GateIsProvablyInert` with **zero** low-sensitivity rejections on
+every frame. A gate that rejects nothing is not the thing costing the user anything, so flooring it buys nothing
+measurable.
+
+---
+
+## 5. What the honest lever is, and why it is a different entry
+
+**The user's complaint is not "I cannot set a floor." It is "I cannot tell whether this landing is good."** The
+copy F49(a) shipped is truthful about the mechanism — the gate was lowered to admit more candidates, brightness
+was not what was missing — and it names the one control that exists and works today
+(`StarDetectionOptions.BrightnessSensitivity`, set by hand, then re-run in *use current settings* mode to
+compare two landings).
+
+What is missing underneath is **a number that says the admission cost something**, and on an unlabelled run
+**no such number exists**: precision is unmeasured, so `J` cannot charge for it and the UI cannot report it.
+That is [F83](followups.md), whose two exits are stated there and are both real work:
+
+1. **give `J` a precision term on unlabelled runs** — a coordinate-system move that owes a fresh 42 m baseline;
+   or
+2. **label the bank**, activating the existing `Wl·sLabel` path.
+
+**Neither is a lever on an options page, and neither is F49.** F49(b) asked which knob to expose; the answer is
+that the knob is not the missing piece.
+
+---
+
+## 6. What would change this decision
+
+Stated now, so it cannot be written after the data:
+
+1. **A measured case where the pathology is SHEDDING rather than admission** — a landing that keeps materially
+   *fewer* stars than its seed and that a user calls bad. Then F32's keep fraction is facing the right
+   direction and the exposure question re-opens on its own merits. Nothing in the register records one:
+   F32 measured the constraint IMPROVING `J` on most binding runs, and F49's case is 7× the other way.
+2. **A floor that is shown NOT to be defeatable via `StarClippingMultiplier`** — i.e. a measurement where
+   flooring Sensitivity alone materially reduces admission. §4.1 predicts it will not, and F6/F84 are the
+   evidence; a paired arm at a pinned floor would settle it and has never been run.
+3. **`J` gains a precision term (F83).** Then the landing at the floor stops being optimal, and the question
+   becomes moot rather than answered — which is the outcome this document expects.
+
+---
+
+## 7. Register deltas this document owes
+
+- **F49** — status → *(a) and (c) SHIPPED; **(b) decided: won't fix as asked**, see this document*. The entry is
+  then **closed**.
+- **F51** — status → *all three parts SHIPPED (wave 9); the residual is **not F51's** and is redirected to
+  [F21](followups.md)/F49(c)*. The entry is then **closed**.
+- **F83** — append: F49(b) resolves *into* this entry. The user-visible symptom of the missing precision term is
+  a wizard landing the user cannot evaluate, and a floor is not a substitute for the term.
+- **F32** — append: asked again by F49(b) and refused again, for a new reason — the motivating case is on the
+  admission end, which the keep fraction does not face.

--- a/docs/f83-precision-term-design.md
+++ b/docs/f83-precision-term-design.md
@@ -1,0 +1,205 @@
+# F83 — giving `J` a false-positive cost: what is actually available, and what is actually blocking
+
+**This is a design spec. It ships no code and owes no gate.** It exists because F83's two stated exits are not
+what they appear to be: **one is refuted outright**, and the other is a term that **already exists and already
+ships**, blocked by a precondition that is **not the one the register thinks**.
+
+**HEADLINE — three findings, all source-derived, zero compute:**
+
+1. **"Label the bank" cannot deliver precision.** With the shipped schema, `precision = 1.0` whenever the
+   `ShouldReject` list is empty, and the bank's golden sidecars are **positive-only**. Feeding them in would add
+   **recall** weight at `Wl = 0.25` — pushing the search *further* toward admission. It makes F83 worse.
+2. **The precision term already exists, ships, and is off:** `SMarginalSnr`, *"the objective's only
+   false-positive cost"*. Its source names **two** preconditions for revival. **The first — "fix the metric
+   (score against truth)" — has been satisfied since 2026-08-03 and nobody noticed**, because the repair
+   (`TruthProtection`) and the entry recording it (F85) landed in a different part of the register from the
+   comment stating the precondition.
+3. **The second precondition is the real blocker, and it is the SAME structural escape that killed
+   [F49](followups.md)(b)'s floor**: the search reaches a low admission threshold through
+   `PeakResponse × StarClippingMultiplier`, so any remedy keyed to the Sensitivity axis — a hard floor, or a
+   statistic left-censored at the effective gate — is lifted out of its own range. **Any successor needs a
+   signal the search cannot lift.**
+
+---
+
+## 1. What is settled and is not re-opened
+
+- **`J` has no false-positive cost on an unlabelled run.** `OptimizationObjective.cs:483-491`, verified at `HEAD`:
+  the `Wl · sLabel` term is reached only when `effRecall.HasValue && effPrecision.HasValue`. Otherwise
+  `J = (Wf·sFocus + Ws·sStars + Wc·sFit) / (Wf + Ws + Wc)` and `sStars` **counts stars, not correct stars.**
+- **Every user run is unlabelled**, and so is the whole bank.
+- **The pin is load-bearing in `J`'s terms** — `Q26-B`, 4 of 4 costed — so this is not a search artifact to be
+  fenced off. It is the objective preferring what the objective was told to prefer.
+- **A floor on the Sensitivity axis is not the answer** ([F84](followups.md), and
+  `docs/f49b-lever-choice-decision.md` §4).
+
+---
+
+## 2. Exit 2 — "label the bank to activate `Wl·sLabel`" — **REFUTED**
+
+### 2.1 Precision in this schema is not precision
+
+`OptimizationObjective.ComputeLabelScores` (`:1022-1043`), read at `HEAD`:
+
+```csharp
+double precision;
+if (labeledShouldReject == null || labeledShouldReject.Count == 0) {
+    precision = 1.0;                       // nothing that should be rejected
+} else {
+    var correctlyExcluded = labeledShouldReject.Count(box => !ContainsAnyCenter(acceptedCenters, box));
+    precision = (double)correctlyExcluded / labeledShouldReject.Count;
+}
+```
+
+**This is not `TP / (TP + FP)`.** It is *"what fraction of a curated list of junk locations did you avoid"* — a
+**recall of rejections**. It can only ever charge for junk somebody enumerated in advance, box by box.
+
+### 2.2 The bank's labels would be positive-only, so the term would be a recall term
+
+The bank's truth artifacts are `*.golden.json` — **stars that exist**. They map onto `Missed` (recall targets).
+Nothing in them enumerates *places a detection would be wrong*, and there is no such thing to enumerate on a
+complete-truth dataset: the complement of the golden set is the rest of the frame, not a box list.
+
+So a "labelled" bank run gets `ShouldReject = []`, hence `precision = 1.0` identically, hence
+
+```
+sLabel = 0.5·recall + 0.5·1.0
+```
+
+**at `Wl = 0.25`. That is a recall term wearing a precision term's name, and it points the wrong way** — it adds
+weight to the very axis (more detections recovered) whose pursuit F83 is about.
+
+### 2.3 And the label path is a human flow, not a truth flow
+
+Labels are produced by `StarReviewVM` / `StarReviewLabels` — a review UI where a person marks boxes `Missed`,
+`WronglyRejected`, `ShouldReject`, converted by `LabelConverter`. **Labelling 22 datasets × 9 frames by hand to
+supply negative boxes for a *synthetic* bank whose truth is already known exactly** is the wrong instrument by
+construction.
+
+> **Conclusion: exit 2 is withdrawn.** It cannot produce a precision signal, and attempting it would bias the
+> objective toward admission. Any future work here must change the *schema*, not the *data*.
+
+---
+
+## 3. Exit 1 — the term already exists: `SMarginalSnr`
+
+`OptimizationObjective.SMarginalSnr` (`:805+`), gated by `MarginalSnrStrength` (default **`0.0`**, `:238`), with
+`MarginalSnrFloor = 6.0` (`:204`) and `MarginalSnrMinFactor = 0.5` (`:241`).
+
+**It is designed for exactly F83's situation**, and its design notes (`:150-168`) are worth quoting because they
+answer objections a fresh proposal would have to re-derive:
+
+- **The signal is absolutely scaled.** `Star.MeasuredSensitivity = NormalizedBrightness / noiseSigma` — a peak
+  SNR in σ units, *"comparable across rigs in a way a count or a ratio would not be."*
+- **It is a soft, data-adaptive floor, not a hard one** — *"a dataset can still buy its way below the floor if
+  the recall gain is worth it"*; it charges for **admitted marginal detections**, not for a knob's value.
+- **It is knob-agnostic below the floor** — *"it charges regardless of WHICH knob opened the door (NoiseClip,
+  StructureLayers), not only the Sensitivity axis."*
+- **It is near-focus only**, because far from focus a real star's per-pixel peak SNR legitimately falls.
+
+**So the shape F83 wants is already built, tested, and flag-selectable (`--marginal-snr-strength`).** The
+question is not "what term?" but "why is it off, and is that still true?"
+
+---
+
+## 4. The two preconditions in the source — one is met, and has been for months
+
+The comment at `:232-237` states them:
+
+> *"Before reviving it: **(1) fix the metric (score against truth)**, then re-establish whether F23 is real at
+> all. Also note **(2) the term is structurally escapable** … any successor needs a signal the search cannot
+> lift."*
+
+### 4.1 Precondition (1) — **SATISFIED since 2026-08-03**, and the register never joined the two facts
+
+`SMarginalSnr` was turned off because [F31](followups.md) voided the metric [F23](followups.md) was built
+against: precision on real data was only ever a **lower bound**, so *"the optimizer trades away half the
+precision"* rested on a number that was not measuring precision.
+
+**That is fixed.** `TruthProtection` shipped **2026-08-03** (`aaf26e8`) into both `GoldenEvalRunner` and
+`BankVerifyRunner`, and [F85](followups.md) records the consequence: **precision is truth-corrected, and 1.000
+is a ceiling rather than a floor.** Wave 26's "150 FPs, 137 real" was a pre-repair quantity; `golden eval`
+reported `FP = 11`.
+
+**F83 was written 2026-08-13 and cites F31's void as current.** F85 corrected that void in the *same wave*. The
+two entries sit ~1 500 lines apart and neither points at the other. **This is F106's class again** — the same
+failure that made F49 look untouched — and here it left a shipped, tested term switched off on a reason that had
+already expired.
+
+### 4.2 Precondition (2) — **NOT satisfied, and it is the real blocker**
+
+The accepted-SNR sample is **left-censored at the gate the search is tuning**. The effective gate is
+
+```
+EffectiveSensitivityGate = max(Sensitivity, PeakResponse × StarClippingMultiplier)      (StarDetector.cs:1532-1533)
+```
+
+so the search can hold `Sensitivity = 0` — free stars, no `sStars` penalty — while keeping the **clip-derived**
+term at or above `MarginalSnrFloor = 6.0`. Then **no accepted star can be below the floor, the marginal fraction
+is identically 0, and the penalty returns exactly 1.0.** The source names two landings that already sit there:
+`D12` at `1.0 × 6.25` and `D15` at `1.0 × 6.75`.
+
+**This is the same escape that defeats a Sensitivity floor** (`f49b-lever-choice-decision.md` §4.1, F6's
+inseparable pair, F84's three landings that drove `StarClippingMultiplier` down alongside the gate). One
+structural fact defeats both remedies:
+
+> **Any signal whose range is bounded by a searchable gate can be lifted out of its own range by the search.**
+
+---
+
+## 5. What a successor needs, and which candidates survive that test
+
+**The requirement, stated as a test:** *is the statistic's support controlled by any searchable axis?* If yes, it
+is escapable and must be rejected without further measurement.
+
+| candidate | escapable? | verdict |
+|---|---|---|
+| Raise `OptimizerVariable`'s Sensitivity lower bound | **Yes** — via `StarClippingMultiplier` (F6/F84) | rejected (F49(b)) |
+| `SMarginalSnr` as shipped (accepted-SNR below an absolute floor) | **Yes** — support is left-censored at the effective gate | rejected as-is |
+| Expose F32's keep fraction | Faces the **shedding** end; cannot bind on an admission pathology | rejected (F49(b) §3) |
+| **Statistic on the IMAGE, not on the accepted set** — e.g. accepted-star count against the frame's own measured background σ and structure-map candidate count | **No** — the denominators are properties of the frame, which no knob changes | **survives; needs specification** |
+| **Truth-scored precision (synthetic only)** | No | survives, but **helps the bank, not users** — it cannot ship in `J` |
+| **Cross-frame consistency** — a real star appears at the same sky position across the sweep; junk does not | **No** — the search cannot make noise repeat across frames | **survives; the strongest candidate, and the most work** |
+
+The last row is the interesting one and it is **not** in the register today: the bank and every user sweep
+already contain 9–11 frames of the same field, and a detection that appears on one frame and nowhere else is
+false-positive-like **without any truth, any labels, or any knob-derived threshold.** Its cost is that it needs
+frame-to-frame registration, which the optimizer does not currently do.
+
+---
+
+## 6. What to do next — smallest discriminating step first
+
+**Do NOT enable `MarginalSnrStrength` and re-baseline.** §4.2 predicts the search escapes, and an arm that
+measures "the term changed nothing" would burn a 42 m gate to confirm an escape the source already names.
+
+**Step 1 — measure whether the escape actually happens (a paired arm, and it is pre-registerable).**
+The flag exists, so this is cheap:
+
+- population: the 8 gate datasets, or a 6-cell subset; `optimize --per-run --max-evals 250`, paired
+  `--marginal-snr-strength 0` vs `> 0`;
+- the statistic is **not** `BestJ`. It is **`PeakResponse × StarClippingMultiplier` at the landing**, and
+  whether it rises to `≥ MarginalSnrFloor` when the term is on;
+- **prediction, fixed now: it rises on a majority of cells, and truth-corrected precision does not improve.**
+  Refuted if precision improves materially with the clip-derived gate staying below 6.0 — in which case the
+  term works and §4.2 is wrong.
+
+**Step 2, only if step 1 refutes the escape:** re-run F23's question with the now-truth-corrected metric, and
+`SMarginalSnr` becomes a shipping decision with a fresh baseline and the 42 m gate.
+
+**Step 2′, if step 1 confirms the escape:** specify the cross-frame-consistency signal (§5, last row). That is a
+new detector-side quantity, not an objective tweak, and it deserves its own spec.
+
+---
+
+## 7. Register deltas this document owes
+
+- **F83** — append: exit 2 is **refuted** (§2, with the `precision = 1.0` code path); exit 1 is `SMarginalSnr`,
+  which already exists; precondition (1) has been satisfied since 2026-08-03 and the register did not join the
+  facts; precondition (2) is the blocker and is the **same escape** as F49(b)'s.
+- **F23** — append: its successor term is off on a reason that expired when `TruthProtection` shipped; the live
+  objection is escapability, not the metric.
+- **F31 / F85** — append a pointer: the repair recorded there **unblocked a precondition in a different file**,
+  and nothing propagated it.
+- **F6** — append: the inseparable pair is now the named mechanism defeating **three** distinct remedies
+  (a Sensitivity floor, `SMarginalSnr`'s censored support, and F49(b)'s lever question).

--- a/docs/followups.md
+++ b/docs/followups.md
@@ -431,8 +431,34 @@ shape for this space.
 
 ### F110 — F82's entire evidence was taken with the detectability bound OFF, while the product supplies it unconditionally
 
-**Status:** **Open — source-derived, zero compute, and it can VOID F82's fix decision** (2026-08-13, found while
-deciding F82's fix) · bounds [F82](#f82) · a validity precondition, not a defect in the fix
+**Status:** **CLOSED — `V-0` was RUN, and it FIRED. F82's fix decision is VOID** (2026-08-14, af-bank-cleanup
+run) · bounds [F82](#f82) · a validity precondition, not a defect in the fix ·
+`docs/af-bank-cleanup-results.md`, `/mnt/d/hf_ship1/v0_arm.log`
+
+> #### `V-0` RAN, ON THE PRODUCT'S CONFIGURATION, AND THE RISK BELOW WAS REAL
+>
+> `D01`/S1 re-run on B15 with `--step-detect-bound`, alongside a no-flag control on the **same binary** that
+> reproduces wave 25's published report bit-identically (`halfWidth` 12.0 / 9.0, steps 3 / 3,
+> `sampledHfrRange` to all 16 printed digits) — so the delta is the flag's.
+>
+> | cell | round | requested span | `(3′)` floor | detect bound | `halfWidth` | step ON | step OFF |
+> |---|---|---|---|---|---|---|---|
+> | `D01` | r1 | 24.0 | **18.00** | **binds**, `maxUsefulHalfSpan = 7.789` | **7.789** | **2** | 3 |
+> | `D02` | r1 | 24.0 | **18.00** | **binds**, `maxUsefulHalfSpan = 15.130` | **15.130** | **4** | 5 |
+> | `D03` | r1 | 56.0 | 42.00 | does not bind (`NaN`) | 42.0 | 12 | 12 |
+>
+> **`D01` r1 — the exact round `(3′)` was designed to move 3 → 5 — is clamped to 7.789, which is 10.2 BELOW
+> `(3′)`'s floor of 18.0.** `Recommend` applies the F18 bound last (`:368-379`, *"Only ever tightens"*), after
+> both cap and floor, and `(3′)` does not touch `searchSpan` and so does not move `minHalfWidth`. So `(3′)`
+> would raise `maxHalfWidth` to 18.0 and have it clamped straight back to 7.789: **zero recommended steps
+> change.** Inert on all three published cells — twice by the detect bound, once because the round already sits
+> exactly on the floor.
+>
+> **Two things the arm found that were not asked of it.** (a) In the product's configuration `D01` does not
+> stall at all: it goes **3 → 2 → 3 → 3** over four rounds — an *oscillation*, not the monotone stall F82
+> describes, so F82's published two-round table is itself a harness artifact. (b) The detect bound moves the
+> step in the **opposite** direction from `(3′)` on both `D01` and `D02`. Whatever the right answer is for a
+> shallow star-poor sweep, `(3′)` was pushing against F18, not with it.
 
 `--step-detect-bound` is **opt-in** in the harness (`TestApp/SynthValidateRunner.cs:783-793`), and `D01`'s
 published rounds carry **`maxUsefulHalfSpan: NaN`** — the bound was never applied to any cell of the evidence
@@ -452,6 +478,59 @@ inert there and the fix decision is void. That is why the decision document make
 exists is not establishing that the product path was measured.* A harness flag that defaults off, against a
 product that supplies the value unconditionally, is a silent divergence between the thing measured and the thing
 shipped — and nothing in this series' controls looks for one.
+
+### F111 — `ACCEPTED-elsewhere` is a 1:1-matching consequence of golden crowding, not a detector defect, and the FN attribution uses a far looser predicate than the matcher
+
+**Status:** **Closed — resolved from artifacts already on disk, zero TestApp minutes** · 2026-08-14,
+af-bank-cleanup run · discharges wave 30 §10 **row 7** ("precision at the opened `MaxDistortion` settings",
+`OWED by any ship that lowers MaxDistortion`) · `docs/af-bank-cleanup-results.md`,
+`/mnt/d/hf_ship1/item3_accepted_elsewhere.py`, `item3b_resolve.py`, `item3c_far.py`
+
+Wave 30 §4.5 recorded that **23–25 % of the distortion gate's acceptances were `ACCEPTED-elsewhere`** — two to
+five times the sensitivity gate's share — and correctly called it *"a signal, not a measurement"*. This entry
+measures it.
+
+**The two numbers come from two different predicates, and that is most of the story.**
+
+| | predicate | source |
+|---|---|---|
+| the **matcher** (decides TP/FN) | `centerIn(D.center, G.box) OR dist ≤ 12 px`, then greedy 1:1 by IoU desc / distance asc | `GoldenGeometry.cs:202-256`, mode `Center` |
+| the **FN attribution** (prints `ACCEPTED-elsewhere`) | `IoU(G.box, D.box) > 0.0` — **any** overlap at all | `BoxMatcher.cs:96-150` via `GoldenEvalRunner.cs:355-360` |
+
+So a golden star can be labelled `ACCEPTED-elsewhere` while being unmatchable to every accepted detection on
+the frame. **That hypothesis was tested and is mostly WRONG, and is recorded as such: only 3–7 % are such
+grazes.** The dominant mechanism is the other one.
+
+**The measurement** (self-test first: an offline rebuild of the matcher reproduces the run's own per-frame
+`TP`/`FN`/`accepted` on every frame of all seven cells, and the published `ACCEPTED-elsewhere` totals exactly —
+1740 / 3141 / 3333 / 3417 / 1869 / 1769 / 1740):
+
+| cell | gate | AE | graze | competing | `d(G,G′) ≤ 12 px` | `> 12 px` |
+|---|---|---|---|---|---|---|
+| `M0` | baseline 0.5 | 1 740 | 3.2 % | 1 685 | **98.5 %** | 1.5 % |
+| `M1` | `MaxDistortion` 0.3 | 3 141 | 5.4 % | 2 972 | **93.9 %** | 6.1 % |
+| `M4` | `MaxDistortion` 0.2 | 3 333 | 6.8 % | 3 105 | **93.2 %** | 6.8 % |
+| `M2` | `Sensitivity` 32.333 | 1 869 | 3.0 % | 1 813 | 98.6 % | 1.4 % |
+| `L3` | `Sensitivity` 35.333 | 1 769 | 3.1 % | 1 714 | 98.5 % | 1.5 % |
+
+`d(G,G′)` is the distance to the golden star that actually won the detection. **In 93–99 % of competing cases
+the two golden stars are themselves closer together than the match radius** (median 7–8 px against a 12 px
+radius; the median **winning detection box** contains **exactly 2.0 golden centres**). A greedy 1:1 matcher **cannot** pair
+both, whatever the detector does — the loser is a false negative by construction of the **scorer**.
+
+**The distortion-linked component is real, bounded, and costs recall rather than precision.** The `> 12 px`
+bucket rises 4× (1.4–1.5 % → 6.1–6.8 %; 25 → 210 stars), but **100 % of those cases have `d(G,G′) ≤ 2R = 24 px`**
+(max 22.8 px at `M4`) with **no tail**, and their winning detections are larger than typical (median box area
+513 px² vs 182 px²). That is one relaxed-gate blob spanning a close pair — blending — bounded at twice the
+match radius by construction, and it cannot manufacture a false positive. Consistent with the direct
+measurement wave 30 already had and did not connect to this: precision **1.000, `FP = 0`** at `MaxDistortion`
+0.5 / 0.3 / 0.2 (`/mnt/d/hf_w30/row7_precision_rescore.txt`).
+
+**Consequence:** the `ACCEPTED-elsewhere` share is **not** evidence of a precision risk from opening
+`MaxDistortion`, and there is no precision number left to go and get. Wave 30's row 7 is discharged rather than
+carried. **The general lesson:** when a diagnostic column and the statistic it is meant to explain are computed
+by *different predicates*, the column measures the predicate gap before it measures anything about the product —
+so check the two predicates before reading the column as a signal.
 
 ### F104 — `D01`'s two candidate gates release 36 660 high-tier candidates and re-capture takes 92 %: the joint is material and ADDITIVE, so F99's joint-recovery claim is refuted at a pre-registered bar
 
@@ -820,6 +899,15 @@ waves 20–29 that quotes `stepBehavioral` as truth, is a self-consistency check
 harness cannot tell. **The remedy is a spec-derived truth model** — backlog item 4's `A4` gap, priced at 20 m
 of code **+ 42 m of gate** because it rebuilds `TestApp`.
 
+> **`A4`'s own arithmetic was repaired on 2026-08-14 (af-bank-cleanup run) and THAT DOES NOT CLOSE THIS ENTRY.**
+> Two different problems live near each other and should not be confused. `A4` was rebuilding the cap boundary
+> from the **requested** sweep while the product used the **fitted** span, and was asserting the cap predicate
+> on band-floored rounds; both are repaired, harness-side, and no product file was touched — so the 42 m gate
+> that a truth-model rebuild would owe was **not** owed by that repair. But `A4` compares against an **analytic
+> truth curve** (`sqrt(8)·HfrMin/Kappa`), which was never the fixed point; the fixed point is `A3`'s
+> `stepBehavioral`. **This entry is about `A3`'s bar and is untouched.** If anything the repair sharpens it: `A4`
+> is now a working independent instrument, which makes it clearer that `A3` still has none.
+
 **Note on scope.** Design §14 pre-registered F96 as a two-part entry — the truth-model coupling **and** "F82's
 fix has no product carrier" — to be **withdrawn in place** on `S-CARRIER-EXISTS`. The verdict was
 `S-CARRIER-EXISTS`, so **the carrier half is withdrawn and is not registered.** The coupling half is `S-a`,
@@ -860,8 +948,41 @@ formerly-blind cells' `halfWidth`/`bootstrap`/implied-span values are now read. 
 
 ### F98 — `MaxDistortion` is a MINIMUM fill-ratio despite its name, and 0.9 is above the ~0.79 ceiling of a perfect disk, so a whole arm cell was dead before it ran
 
-**Status:** Open — **candidate goal-3 product finding** · found 2026-08-13, wave 29, `RULE W29-L` =
-**`L-UNEVALUATED`** · `/mnt/d/hf_w29/w29l_score.txt`, `/mnt/d/hf_w29/l/out/L{0,2,4}.log`
+**Status:** **FIXED (axis bound + label), 2026-08-14, af-bank-cleanup run** · found 2026-08-13, wave 29,
+`RULE W29-L` = **`L-UNEVALUATED`** · `/mnt/d/hf_w29/w29l_score.txt`, `/mnt/d/hf_w29/l/out/L{0,2,4}.log` ·
+`docs/af-bank-cleanup-results.md`
+
+> #### SHIPPED: the axis is bounded at π/4, and the label now states the direction (2026-08-14)
+>
+> Shipped as `OptimizerVariable.MaxDistortionSearchUpper = Math.PI / 4.0`, documented as the one bound in the
+> curated set that is **geometric rather than heuristic**, and pinned by a test that rasterises disks and
+> confirms the constant *is* that fill ratio rather than a number someone liked.
+>
+> **What the bound does, corrected mid-run against the source — my first justification was WRONG and the wrong
+> version is stated here so the correction is legible.** I first wrote that the saving was a coarse-grid level:
+> *"the coarse grid samples `Lower + t·(Upper − Lower)` inclusive of both bounds at `CoarseGridLevels = 4`, so
+> the old four levels were 0.1 / 0.4 / 0.7 / 1.0 and one of them was spent on a guaranteed-empty setting."*
+> **`MaxDistortion` is not coarse-gridded at all.** `StarDetectionOptimizer`'s Phase A grids **only**
+> Sensitivity × StarClippingMultiplier (`:764-789`) and holds every other variable at the incumbent; `GridValue`
+> is called on exactly those two axes. The false claim was caught because it produced a **prediction that the
+> gate then refuted** — see below.
+>
+> **The true mechanism is narrower and still worth the change.** `MaxDistortion` moves only under the pattern
+> search, whose proposals are clamped by `Quantize` to `[Lower, Upper]`. The old ceiling left roughly the
+> **top 21 % of the axis reachable** while returning zero detections by construction — the collapse this entry
+> measured at 0.9. The bound makes that band unreachable: a **guard against a pathological upward excursion**,
+> expected to be **inert** on any run that never walks up there.
+>
+> **The rename is HALF done, and the half not done is named.** The knob is user-visible **and** persisted
+> (key `"MaxDistortion"`, `StarDetectionOptions.cs:276,764`), reaching 11 C# files, the replay snapshot, the
+> diff, `OptimizedStarDetectionSettings`, `TestApp` and ~12 places in the manual — **renaming the key is a
+> settings migration and was not done**, because doing it under a stop clock risks silently resetting every
+> user's tuned value. What was done is the half a user reads: the label is now
+> *"Max Distortion (min fill ratio)"* and the tooltip leads with *"A MINIMUM fill ratio, despite the name …
+> raising it makes the gate stricter, not looser"*, plus the π/4 ceiling. It also repairs two errors the
+> tooltip carried since it was written: `"circule"`, and *"PI/4, which is approximately 0.7"* — it is 0.785,
+> and the understatement was most of a coarse-grid step. The control already existed, so `CLAUDE.md`'s
+> options-owe-XAML invariant was already satisfied. **The persisted-key rename remains open as a named debt.**
 
 `StarDetector.cs:1804` rejects a candidate as `TooDistorted` when `fillRatio < effectiveMaxDistortion`. The
 parameter is a **lower bound on bounding-box fill ratio**; **raising it tightens the gate.** The file's own
@@ -2182,8 +2303,26 @@ Reproduce: `StepSizeRecommender.cs` (the `BandDemonstrablyUnsampled` guard, the 
 `docs/synthetic-af-bank-followups-wave25-results.md` §3.1, §7, §10.1.
 
 ### F82 — The half-width floor is not sticky across rounds, and the cap recomputed from a shrunken fit pulls it back down
-**Status:** Open (diagnosed to a line, two candidate fixes, priced) · found 2026-08-13, wave 25, on the one
-labelled control that missed its pre-registered bar · **SCOPE AND GENERALITY MEASURED, wave 29 — see below**
+**Status:** **RE-SCOPED, 2026-08-14 — the fix decision below is VOID; the live entry is the F18-vs-F81 ordering
+conflict** · found 2026-08-13, wave 25, on the one labelled control that missed its pre-registered bar ·
+**SCOPE AND GENERALITY MEASURED, wave 29 — see below** · `docs/af-bank-cleanup-results.md`
+
+> #### THE `(3′)` DECISION IS VOID — `V-0` FIRED, exactly as it was written to (2026-08-14)
+>
+> **Do not implement `(3′)`.** [F110](#f110) carries the measurement: in the configuration the product actually
+> runs, F18's detectability bound clamps `D01` r1 to `halfWidth = 7.789`, far below `(3′)`'s requested-span
+> floor of 18.0, and the F18 bound is applied **after** both the cap and the floor and **only ever tightens**.
+> `(3′)` therefore changes **zero recommended steps** on `D01` — and is inert on `D02`/`D03` too. The
+> pre-registered void condition in `docs/f82-fix-choice-decision.md` §6 (`V-0`) and §7 clause 1 is met.
+>
+> **What the decision document nevertheless settled, and which stands:** fix (1), the monotone floor, is
+> **refuted** by arithmetic on F82's own table (see below). So the register no longer records a remedy that does
+> nothing — which §7's "case for doing nothing" identified as the minimum obligation, discharged either way.
+>
+> **The live entry is now the ordering conflict, and it is a different question from the one F82 asks.** On a
+> shallow, star-poor sweep F18's *measured* detectability bound and F81's *band* floor disagree about which way
+> to move, and F18 wins by being applied last. Deciding that needs the blind wide-field population the bank does
+> not have (`c_blind = 0`, [F97](#f97)), i.e. the 1.4–19.4 ″/px render — **it is not decidable on this bank.**
 
 > #### THE FIX CHOICE IS DECIDED, 2026-08-13 — and wave 26's pre-registered fix (1) is **REFUTED**
 >
@@ -2281,7 +2420,17 @@ bound that is supposed to reward widening penalises it on exactly the star-poor 
 **A second instrument measures the same divergence from the other side.** The harness's `A4` assertion computes
 the cap boundary from the **requested** sweep and reports
 `"WasCapped=True but truth predicts False (halfWidth=10.4 vs cap boundary 18, ratio 0.58)"` — **18** against the
-product's **9**. And the corroboration identity every floored round satisfies
+product's **9**.
+
+> **`A4` ITSELF WAS REPAIRED, 2026-08-14 (af-bank-cleanup run), and this quoted FAIL is one of the four it was
+> producing on its own error.** It now builds the boundary from the **fitted** span, so `D01` r1's boundary is
+> 9.0 and truth 10.4 *is* above it — **FAIL → PASS**, three times (`D01` r1, `D01` r3, `D02` r1). And it no
+> longer asserts the cap predicate on **band-floored** rounds at all: the cap clamps *down* and the floor raises
+> *up*, so "truth above the boundary" predicts the cap and says nothing about the floor — `D03` r0's **FAIL**
+> becomes a named `NotApplicable`. **Four of ten A4 verdicts on these three cells were failures and none was a
+> product defect.** Harness-only; no product file touched; see `docs/af-bank-cleanup-results.md`.
+
+And the corroboration identity every floored round satisfies
 (`halfWidth == 1.5 × offsetSteps × bootstrapStep`, 3 of 3 on the floored rounds) is **exactly the identity
 `D01` r1 fails**: `1.5 × 4 × 3 = 18 ≠ 9.0`.
 

--- a/docs/followups.md
+++ b/docs/followups.md
@@ -2422,13 +2422,18 @@ the cap boundary from the **requested** sweep and reports
 `"WasCapped=True but truth predicts False (halfWidth=10.4 vs cap boundary 18, ratio 0.58)"` — **18** against the
 product's **9**.
 
-> **`A4` ITSELF WAS REPAIRED, 2026-08-14 (af-bank-cleanup run), and this quoted FAIL is one of the four it was
-> producing on its own error.** It now builds the boundary from the **fitted** span, so `D01` r1's boundary is
-> 9.0 and truth 10.4 *is* above it — **FAIL → PASS**, three times (`D01` r1, `D01` r3, `D02` r1). And it no
-> longer asserts the cap predicate on **band-floored** rounds at all: the cap clamps *down* and the floor raises
-> *up*, so "truth above the boundary" predicts the cap and says nothing about the floor — `D03` r0's **FAIL**
-> becomes a named `NotApplicable`. **Four of ten A4 verdicts on these three cells were failures and none was a
-> product defect.** Harness-only; no product file touched; see `docs/af-bank-cleanup-results.md`.
+> **`A4` ITSELF WAS REPAIRED, 2026-08-14 (af-bank-cleanup run), and this quoted FAIL is one it was producing on
+> its own error.** It now builds the boundary from the **fitted** span, so `D01` r1's boundary is 9.0 and truth
+> 10.4 *is* above it — **FAIL → PASS**. And it no longer asserts the cap predicate on **band-floored** rounds at
+> all: the cap clamps *down* and the floor raises *up*, so "truth above the boundary" predicts the cap and says
+> nothing about the floor — `D03` r0's **FAIL** becomes a named `NotApplicable`.
+>
+> **Measured by re-running the three cells on the new binary: 3 of 6 A4 verdicts were failures, and 1 remains.**
+> The survivor is `D02` r1, and it is a **real** signal rather than an artifact — its fitted span is 24.0
+> (identical to its requested span, so no rule change touches it), it was capped because the fit wanted to
+> extrapolate past `maxHalfWidth = 18.0`, and the analytic truth half-width is **8.4**. An over-extrapolating
+> fit, previously buried among two failures the assertion was manufacturing itself. Harness-only; no product
+> file touched; see `docs/af-bank-cleanup-results.md`.
 
 And the corroboration identity every floored round satisfies
 (`halfWidth == 1.5 × offsetSteps × bootstrapStep`, 3 of 3 on the floored rounds) is **exactly the identity

--- a/docs/followups.md
+++ b/docs/followups.md
@@ -406,6 +406,15 @@ worse than it needs to be. Worth understanding before anyone "optimises" the don
 ### F6 — Sensitivity and star-clip act only in combination
 **Status:** Open · explains the documented plateau
 
+> **2026-08-14 — this pair is now the named mechanism defeating THREE distinct remedies**, which is worth
+> stating once rather than re-deriving each time. `EffectiveSensitivityGate = max(Sensitivity, PeakResponse ×
+> StarClippingMultiplier)`, so the search reaches any admission threshold it wants through whichever member is
+> cheaper: **(1)** a hard floor on the Sensitivity axis ([F49](#f49)(b), [F84](#f84)); **(2)** `SMarginalSnr`'s
+> accepted-SNR statistic, whose support is left-censored at that same gate ([F83](#f83)); **(3)** F49(b)'s
+> lever question generally. **General form: any signal whose range is bounded by a searchable gate can be
+> lifted out of its own range by the search** — so a successor must key on something no knob controls
+> (the frame's own noise/structure statistics, or cross-frame consistency).
+
 One-at-a-time ablation on `mccomiskey` σ_focus (adaptive on, donut on, NC 4):
 
 | | `clip 2` | `clip 10` |
@@ -1743,7 +1752,42 @@ under-lists by an order of magnitude at defocus.**
 
 ### F83 — `J` carries no precision term on an unlabelled run, so a sensitivity pin is free in the objective by construction
 **Status:** Open · **structural, source-derived, zero compute** · found 2026-08-13, wave 26, pricing the sensitivity
-pin the owner asked to avoid · **[F49](#f49)(b) RESOLVES INTO THIS ENTRY (2026-08-14)**
+pin the owner asked to avoid · **[F49](#f49)(b) RESOLVES INTO THIS ENTRY (2026-08-14)** · **BOTH EXITS RE-SCOPED
+2026-08-14** — `docs/f83-precision-term-design.md`
+
+> #### The two exits this entry names are not what they look like (2026-08-14)
+>
+> **Exit 2, "label the bank to activate `Wl·sLabel`", is REFUTED.** `ComputeLabelScores` (`:1022-1043`) sets
+> **`precision = 1.0` whenever the `ShouldReject` list is empty**, and precision in that schema is not
+> `TP/(TP+FP)` — it is *"what fraction of a curated list of junk locations did you avoid"*, a **recall of
+> rejections**. The bank's `*.golden.json` sidecars are **positive-only**, and the complement of a complete
+> golden set is the rest of the frame, not a box list. So a "labelled" bank run yields
+> `sLabel = 0.5·recall + 0.5·1.0` at `Wl = 0.25` — **a recall term wearing a precision term's name, pointing the
+> wrong way.** Labels also come from `StarReviewVM`, a **human** review flow, which is the wrong instrument for a
+> synthetic bank whose truth is already exact.
+>
+> **Exit 1 already exists and already ships: `SMarginalSnr`**, off at `MarginalSnrStrength = 0.0`. Its source
+> names two preconditions for revival, and **the first is already met:**
+>
+> 1. *"fix the metric (score against truth)"* — **SATISFIED SINCE 2026-08-03.** `TruthProtection` shipped
+>    (`aaf26e8`) and [F85](#f85) records that precision is truth-corrected with 1.000 a **ceiling**. **This entry
+>    was written 2026-08-13 citing [F31](#f31)'s void as current, in the same wave that recorded its repair.**
+>    F106's class again: a shipped, tested term left switched off on a reason that had expired ten days earlier,
+>    because the two facts sit ~1 500 lines apart and neither points at the other.
+> 2. *"the term is structurally escapable … any successor needs a signal the search cannot lift"* — **NOT met,
+>    and it is the real blocker.** The accepted-SNR sample is **left-censored at the effective gate**
+>    `max(Sensitivity, PeakResponse × StarClippingMultiplier)`, so the search can hold `Sensitivity = 0` while
+>    keeping the clip-derived term ≥ `MarginalSnrFloor = 6.0`; the marginal fraction is then identically 0 and
+>    the penalty is exactly 1.0. `D12` (1.0 × 6.25) and `D15` (1.0 × 6.75) already sit there.
+>
+> **The unifying result:** this is the SAME escape that defeats a Sensitivity floor ([F49](#f49)(b), [F6](#f6),
+> [F84](#f84)). **Any signal whose range is bounded by a searchable gate can be lifted out of its own range by
+> the search.** The design doc's §5 tests the candidates against that and finds two survivors — an image-side
+> statistic, and **cross-frame consistency** (a real star repeats across the sweep; noise does not), which is not
+> in this register today and is the strongest of them.
+>
+> **Do NOT simply enable the strength and re-baseline** — the design doc's step 1 is a cheap paired arm whose
+> statistic is the LANDED `PeakResponse × StarClippingMultiplier`, not `BestJ`, with the escape pre-registered.
 
 > **F49(b) asked which knob to expose to a user whose landing floored the gate; the answer is that the knob is
 > not the missing piece — this term is** (`docs/f49b-lever-choice-decision.md`). The user-visible symptom of the
@@ -2738,7 +2782,15 @@ update ORDERING, downstream of [F22](#f22--detection-binning-is-a-hard-threshold
 not the recommender's arithmetic. Untouched, and the guard above is still owed.
 
 ### F23 — ~~The optimizer objective has no precision term, so it trades precision away for marginal recall~~
-**Status:** **Won't fix as written** (2026-08-03, wave 2 — evidence base void; the real effect is ~1/5 the size and the axis is recall, see F32/F33) · found 2026-08-02
+**Status:** **Won't fix as written** (2026-08-03, wave 2 — evidence base void; the real effect is ~1/5 the size and the axis is recall, see F32/F33) · **the successor term's blocker CHANGED 2026-08-14** — `docs/f83-precision-term-design.md`
+
+> **`SMarginalSnr`, this entry's successor, is off on a reason that has EXPIRED.** It ships at
+> `MarginalSnrStrength = 0.0` because the metric this entry was built against was void ([F31](#f31)).
+> `TruthProtection` shipped 2026-08-03 and [F85](#f85) records precision as truth-corrected — so the *"fix the
+> metric"* precondition in `OptimizationObjective.cs:233` is **satisfied**. **The live objection is
+> escapability, not the metric:** the statistic is left-censored at `max(Sensitivity, PeakResponse ×
+> StarClippingMultiplier)`, so the search lifts its support past `MarginalSnrFloor` and the penalty returns 1.0.
+> See [F83](#f83). · found 2026-08-02
 
 The objective `J` rewards star count and fit quality. Nothing in it penalises a false positive — and
 nothing could have, because until this bank existed precision was only ever a *lower bound* on real data

--- a/docs/followups.md
+++ b/docs/followups.md
@@ -644,7 +644,41 @@ partitioned once, printed the difference, and **the five exact balances are them
 ### F106 — A hand-carried debt ledger rots in BOTH directions, and the rot is measured: `P-D08` was published seven hours before the wave that listed it as owed
 
 **Status:** Open — the class is structural · found 2026-08-13, wave 30, `RULE W30-D` = **`D-STALE`** ·
-`/mnt/d/hf_w30/w30d_score.txt`
+`/mnt/d/hf_w30/w30d_score.txt` · **MEASURED IN THE REGISTER ITSELF 2026-08-14, and a cheap detector now exists**
+
+> #### The same rot lives in this file's OWN `**Status:**` lines — 5 of 113, audited and fixed (2026-08-14)
+>
+> `W30-D` measured the rot in a *debt ledger*. It is also in the register's **status field**, and there it is
+> worse, because a status line is what a reader uses to decide what to work on.
+>
+> **Audited all 113 entries.** Twelve had a status saying `Open` while the body said `SHIPPED`/`DONE`. Reading
+> each: **five were genuinely stale** ([F25](#f25), [F53](#f53), [F58](#f58), [F79](#f79), [F80](#f80)),
+> **[F69](#f69) opened with the word "Open" in a sentence that then declared it CLOSED**, **[F49](#f49) and
+> [F51](#f51)** were fixed separately (F51 had shipped **all three** of its parts a week earlier), and **four
+> were false positives** whose statuses already disclosed what shipped (F18, F55, F70) or whose `SHIPPED`
+> referred to a *different* change's default (F63).
+>
+> **[F79](#f79) is the sharpest case: its status said *"deliberately **not** shipped in wave 23"* while its own
+> body said *"SHIPPED IN WAVE 23."*** Both written in the same wave, neither reconciled.
+>
+> **The cost was real and it was paid twice in one session:** F49/F51 were proposed as the next work to do when
+> their implementations were already a week old, and then — *in the message proposing this very audit* — F79 and
+> F80 were described as "already honest" **on the strength of their status lines**. The failure is not
+> inattention to a field; it is that **a status reads as an authority and a body reads as history, and nobody
+> re-reads history.**
+>
+> **The detector, which is the durable part.** Key on the entry's *own* parts shipping — a sub-heading declaring
+> a ship, or a struck-through part marked `DONE` — never on the word "shipped" appearing anywhere in the prose:
+>
+> ```python
+> own = re.findall(r'(?m)^>?\s*#{2,4} .*\bSHIPPED\b.*$', body) \
+>     + re.findall(r'~~[^~]{5,90}~~\s*[—-]+\s*\*\*DONE', body)
+> flag = own and not re.search(r'SHIPPED|DONE|CLOSED', status_block)
+> ```
+>
+> A looser scan (any "shipped" in the body) returns **23** candidates on this register, almost all noise —
+> *"the shipped `Default` profile"*, *"the SHIPPED default is 1"*. This one returned the **5** that were real,
+> and returns **0** now. **Re-run it before trusting a status field to price work.**
 
 `RULE W30-D` parsed wave 29's §11 *"WHAT WAS NOT RUN"* table out of the committed document (sha256 re-asserted
 at scoring time), resolved each of **14** rows to exactly one predicate with a declared **scope**, and searched
@@ -2138,7 +2172,12 @@ stars over the gate on the MEDIAN frame, which on these fields implies ≥ `NHar
 exercise this entry has to be built deliberately — starved on purpose — or borrowed from the real bank.
 
 ### F25 — From a far-too-wide sweep the step recommender widens it further, instead of recovering
-**Status:** Open · found 2026-08-03 running scenario S2 (step ×4) on the synthetic AF bank
+**Status:** Open — **the NARROW half of the owed gate SHIPPED (wave 25, P4); the WIDE half, which is this
+entry's own direction, is UNMEASURED rather than untriggered** · found 2026-08-03 running scenario S2 (step ×4)
+on the synthetic AF bank
+
+> **Status corrected 2026-08-14**: it read a bare *"Open"* and did not mention that half its remedy had shipped,
+> so the entry priced as untouched work. `D05_tec140_1000mm`/S2 remains the published wide-end case.
 
 When the sweep is so wide that the hyperbola fit degenerates, `StepSizeRecommender` responds by asking for a
 **wider** sweep still. There is nothing that recognises "this fit is garbage, retreat".
@@ -7227,7 +7266,8 @@ verified sha-identical. *Three cases recovered from a could-not-look list are wo
 shown to fail on a defect, which is the same bar F66 sets for a gate.*
 
 ### F69 — F39(b)'s flag NAMES and its own COMMENT state the opposite of its default, and that cost a pre-registered rule its verdict
-**Status:** Open · found 2026-08-10 (wave 17) while deciding
+**Status:** **CLOSED 2026-08-11 (wave 21)** — see the inline note below, which this line used to contradict by
+opening with "Open" · found 2026-08-10 (wave 17) while deciding
 [F67](#f67--af-fits-star-count-and-optimizes-are-not-the-same-number-so-the-control-built-on-their-equality-reports-could-not-look-on-exactly-the-datasets-where-the-intervention-bites-hardest)(c)
 · **CLOSED 2026-08-11 (wave 21): (b) and (c) shipped in wave 20, (a) shipped in wave 21 — and (a) turned out to
 be THREE copies across TWO files, not the one this entry named. See the wave-21 block at the end of this
@@ -8576,7 +8616,10 @@ worth stating in any write-up that describes `pinned_settings.json` as a full sn
 **Status:** Open · found 2026-08-08 (wave 11) **at zero compute, out of logs wave 9 left on disk** ·
 **this is the MECHANISM behind [F55](#f55--optimize-is-not-reproducible-when-several-instances-run-at-once-and-the-seed-evaluation-is-what-moves)
 and [F57](#f57--a---settings-pinned-arm-is-not-pinned-the-active-nina-profile-moves-baselinej-by-0014-and-every-cross-wave-comparison-inherits-it),
-which are one defect seen from two directions**
+which are one defect seen from two directions** · **(d) DONE 2026-08-09** — the four other harness runners
+carrying the same defect were fixed
+
+> **Status corrected 2026-08-14**: (d) had shipped and the status did not say so.
 
 Wave 10 established that the active NINA profile moves `BaselineJ` and left *which quantity* (F57(c)) and *the
 nondeterminism's trigger rate* (F55(b)) open. Both close on the same reading, and **no optimization had to be run
@@ -9254,8 +9297,11 @@ answer is worse than no normalization.
 Reproduce: `D:\hf_w9\wing\ctl_nobin.log` vs `D:\hf_w9\wing\opt_0.5_D02_rich_135mm.log`.
 
 ### F53 — Wave 8's arm X does not reproduce from wave 8's own `exe`, because the arm ran on an EARLIER build of it
-**Status:** Open · found 2026-08-07 (wave 9) re-running arm X's exact command to build the wing instrument ·
-**the reproduce line is stale, and nothing in the artifact says so**
+**Status:** **(a) SHIPPED wave 10** — the build is stamped into the run · **open as (b)**, the standing rule
+that a `D:\hf_w*\exe` reproduce line is not a build identity · found 2026-08-07 (wave 9) re-running arm X's
+exact command to build the wing instrument · **the reproduce line is stale, and nothing in the artifact says so**
+
+> **Status corrected 2026-08-14**: it read a bare *"Open"* with no mention that (a) had shipped.
 
 Wave 8's F19 arm X is recorded with `Reproduce: D:\hf_w8\armX\arm_x.sh`, which invokes
 `D:\hf_w8\exe\TestApp.exe`. **Running that script's exact command on that exact binary today does not reproduce
@@ -9482,8 +9528,15 @@ Reproduce: field report, `Default` profile, 2026-08-06; wizard screenshot in the
 ## Harness / tooling
 
 ### F79 — A single non-ASCII byte in a redirected log makes `grep` report ZERO matches for strings elsewhere in the file
-**Status:** Open (fix identified and priced; deliberately **not** shipped in wave 23) · found 2026-08-12, wave 23,
-when the gate driver and its scorer disagreed 0-of-8 against 8-of-8 over the same eight files
+**Status:** **SHIPPED in wave 23** (the ASCII guard + `TestAppOutputAsciiTests`); **open only as a standing
+discipline entry** — a redirected log is not a searchable artifact unless something asserts it is ·
+found 2026-08-12, wave 23, when the gate driver and its scorer disagreed 0-of-8 against 8-of-8 over the same
+eight files
+
+> **Status corrected 2026-08-14.** It previously read *"Open (fix identified and priced; deliberately **not**
+> shipped in wave 23)"* — which its **own body contradicts** two screens further down: *"SHIPPED IN WAVE 23 — and
+> BOTH options above were UNDER-SCOPED by the same defect they describe."* The status was written when the fix
+> was deferred and never updated when it landed in the same wave.
 
 The register already records that *"a Unicode character in a redirected log arrives as the single byte `0x1A` on
 this machine's console code page."* **That is one of two failure modes, and it is the harmless one.** This is the
@@ -9647,8 +9700,12 @@ Reproduce: `python3 -c "d=open('/mnt/d/hf_w23/gate/toml999.log','rb').read(); pr
 `grep -c` vs `grep -ac` on the same file; `docs/synthetic-af-bank-followups-wave23-results.md` §2.
 
 ### F80 — Instruments derived by textual substitution keep their predecessor's prose, and it silently stops describing them
-**Status:** Open (remedy specified and priced) · found 2026-08-12, wave 24, when a scorer refused its own PASS end
-because a `sed` line renamed the paths but not the module
+**Status:** **The `--verify-derivation` pre-flight SHIPPED (wave 25, `RULE V25`) and works**; **open as the
+CLASS**, which the pre-flight narrowed rather than closed — it had the same blind spot twice (`\b` cannot see
+`_`) · found 2026-08-12, wave 24, when a scorer refused its own PASS end because a `sed` line renamed the paths
+but not the module
+
+> **Status corrected 2026-08-14**: it read *"Open (remedy specified and priced)"* after the remedy had shipped.
 
 Every wave in this series carries its measurement instruments forward by `sed`-ing the previous wave's copies —
 deliberately, and for a good reason: *editing an instrument mid-series is how it stops being the same instrument,*

--- a/docs/followups.md
+++ b/docs/followups.md
@@ -1743,7 +1743,15 @@ under-lists by an order of magnitude at defocus.**
 
 ### F83 — `J` carries no precision term on an unlabelled run, so a sensitivity pin is free in the objective by construction
 **Status:** Open · **structural, source-derived, zero compute** · found 2026-08-13, wave 26, pricing the sensitivity
-pin the owner asked to avoid
+pin the owner asked to avoid · **[F49](#f49)(b) RESOLVES INTO THIS ENTRY (2026-08-14)**
+
+> **F49(b) asked which knob to expose to a user whose landing floored the gate; the answer is that the knob is
+> not the missing piece — this term is** (`docs/f49b-lever-choice-decision.md`). The user-visible symptom of the
+> missing precision term is a wizard landing the user **cannot evaluate**: on an unlabelled run precision is
+> unmeasured, so `J` cannot charge for it and the UI cannot report it. A floor is not a substitute for the term —
+> it forbids the answer the objective prefers while leaving the objective unchanged, so the search sits on the
+> floor and the landing is still the best point `J` can see. **This entry's two exits (a precision term on
+> unlabelled runs, owing a fresh baseline; or labelling the bank to activate `Wl·sLabel`) are now also F49's.**
 
 **Every `optimize` result this project has produced on the synthetic AF bank was scored by an objective with no
 false-positive cost in it.** Not because a term is mis-tuned — because the branch that carries precision is not
@@ -4298,7 +4306,11 @@ precision figure rather than being something a reader has to think to ask for.
 ship.** R1(c) fails catastrophically (σ_focus x2000 worse on `vsn07`), R3 fails on the newly-covered population,
 and R2 INVERTS wave 6 — restarts recover 228 % of the floor's gain, so the floor is not a distinct mechanism.
 `MinDetectionKeepFraction` stays default OFF permanently. **The greedy trap itself is confirmed and stands**; the
-floor is simply the wrong instrument for it · found 2026-08-03 re-reading the wave-1 real-bank control arm
+floor is simply the wrong instrument for it — **and it was asked again by [F49](#f49)(b) on 2026-08-14 and
+refused again for a NEW reason: the motivating case is on the ADMISSION end.** F49's landing kept **7× more**
+stars than its seed, while this constraint *"rejects a candidate keeping less than φ of the SEED's accepted
+stars"* — so it could not have bound there at all. Exposing it would put a control on the options page whose
+honest tooltip is *"this does not apply to your situation"* · found 2026-08-03 re-reading the wave-1 real-bank control arm
 
 The objective's landings are not close calls. Across the 17 scorable real-bank runs, `optimize --per-run` gives
 up a **median 0.243 of recall@SNR≥12** to gain a **median ΔJ of +0.0125** — and the worst cases are far starker
@@ -6133,7 +6145,9 @@ Part (b) — state the statistic over the cells that can move — is now a stand
 Reproduce: `D:\hf_w8\f48_rescore.py`.
 
 ### F51 — "Capture a new sweep and optimize" is gated on the EXPOSURE recommendation, so it hides exactly when the run needs re-running — and it would not carry the new step size anyway
-**Status:** Open · found 2026-08-06 (wave 8) from the same field session as
+**Status:** **CLOSED 2026-08-14 — all three parts (a)(b)(c) SHIPPED wave 9.** The residual named at the foot of
+this entry is **not F51's** and is carried by [F21](#f21)/F49(c), not here · found 2026-08-06 (wave 8) from the
+same field session as
 [F49](#f49--the-star-signal-block-fires-on-a-floored-gate-but-every-remedy-it-owns-is-an-exposure-remedy-so-a-rich-well-exposed-field-gets-a-diagnosis-with-no-instruction) ·
 mechanism confirmed in source
 
@@ -9289,8 +9303,17 @@ comes back", which is what wave 8 did by hand. Until then, treat every FN-by-gat
 Reproduce: `D:\hf_w8\p1\knob_sweep.sh` (the `p1_minbox*` arms).
 
 ### F49 — The Star signal block fires on a floored gate but every remedy it owns is an EXPOSURE remedy, so a rich, well-exposed field gets a diagnosis with no instruction
-**Status:** Open · found 2026-08-06 (wave 8) from a **field report on the shipped `Default` profile**, not from the
-bank · mechanism confirmed in source
+**Status:** **CLOSED 2026-08-14 — (a) SHIPPED wave 9, (c) SHIPPED wave 10, (b) DECIDED: won't fix as asked**
+(`docs/f49b-lever-choice-decision.md`) · found 2026-08-06 (wave 8) from a **field report on the shipped
+`Default` profile**, not from the bank · mechanism confirmed in source
+
+> **The status line above was WRONG until 2026-08-14 and this is what it said: _"Open · found 2026-08-06 …"_,
+> with no hint that two of its three parts had shipped a week earlier.** A reader scanning statuses — which is
+> how this register is read — would have priced F49 as untouched work. That is [F106](#f106)'s class exactly
+> ("a hand-carried debt ledger rots in BOTH directions"), and it rotted toward OVERSTATING what was left.
+> **11 other open-status entries carry `SHIPPED`/`DONE` in their bodies**; F49 and F51 are the two audited and
+> corrected here, and the rest are named in `docs/af-bank-cleanup-results.md` rather than bulk-edited on a
+> regex, since deciding what is genuinely left requires reading each one.
 
 The user ran the optimization wizard twice on their own rig. The second landing: **Sensitivity 15.667 → 0.000**,
 **StarClippingMultiplier 6.750 → 0.250**, stars per frame **834 → 5766** (≈ 7×), σ_focus 6.12 → 0.55. The Star
@@ -9389,10 +9412,16 @@ wide side, and the user experienced it as a runaway rather than as convergence.
 > geometric until the sweep contains the band, and their runs 3 and 4 asked +3 % and +5 %. A unit test replays
 > the sequence and asserts the cap releases.
 
-**Next step.** Three separable pieces. **(a)** ~~Give the floored-gate + `ExposureIsNotTheLimit` state a remedy of
-its own~~ — **DONE**; the honest one names the gate, not the exposure. **(b)** Decide
-whether a user-facing floor on the search's Sensitivity (or F32's keep fraction, exposed) is the right lever, since
-today there is none. **(c)** ~~When the step recommendation is capped by the sweep width, say what it is converging TOWARD~~ —
+**Next step — NONE; the entry is closed.** **(a)** ~~Give the floored-gate + `ExposureIsNotTheLimit` state a
+remedy of its own~~ — **DONE**; the honest one names the gate, not the exposure. **(b)** ~~Decide whether a
+user-facing floor on the search's Sensitivity (or F32's keep fraction, exposed) is the right lever~~ —
+**DECIDED 2026-08-14: WON'T FIX AS ASKED** (`docs/f49b-lever-choice-decision.md`). **Neither candidate faces the
+pathology.** This landing kept **7× MORE** stars than its seed, and both levers guard the *shedding* end:
+[F32](#f32)'s keep fraction *"rejects a candidate keeping less than φ of the SEED's accepted stars"* and is
+retired *"permanently"* as *"the wrong instrument"*; a Sensitivity floor is defeatable via the other half of
+[F6](#f6)'s inseparable pair (this very run moved StarClip 6.750 → 0.250 alongside it) and would forbid a
+**real optimum** of an objective that cannot see precision ([F83](#f83), [F84](#f84): 22 of 24 pinned instances
+DRIVEN to the bound). **The missing piece is F83's precision term, not a knob** — F49(b) resolves into F83. **(c)** ~~When the step recommendation is capped by the sweep width, say what it is converging TOWARD~~ —
 **DONE, see above**, and with a measured range and an exact ratio rather than only a sentence.
 Reproduce: field report, `Default` profile, 2026-08-06; wizard screenshot in the wave-8 thread.
 

--- a/docs/followups.md
+++ b/docs/followups.md
@@ -941,8 +941,11 @@ rendered exhibits the transition** (2026-08-14, af-bank-cleanup run) · found 20
 >   `D01` it moved the step 3 → 2. So a fix is arguable on **severity**, never on rate — the position F82's
 >   decision document §7 clause 5 already reached, now with data instead of an argument.
 >
-> The render that made this possible cost **43 seconds**, against the ledger's "≥ 1 h". See the results doc for
-> why that row was unfalsifiable as written.
+> The render that made this possible cost **43 seconds**. Fairly: row 10 priced *"≥ 1 h render"* **and**
+> *"≥ 1 h compute"*, and the **compute** half was about right (this run's blind arm was 27 min for four runs).
+> It is the **render** half that was never measured — wave 12 recorded *"Render + 15 optimizes: 13 m 51 s"* for
+> three datasets. The row was blocked by an inherited number beside an unfalsifiable check, not by an hour of
+> work. See the results doc.
 
 Wave 26 pre-registered a reversal condition on its choice between F82's two fixes — *"if a later wave measures
 that `SearchSpan` … shrinks on more than a single cell while the requested sweep widens, then … (2) becomes
@@ -10215,7 +10218,9 @@ because what was being checked was not the claim. **Both halves of it were wrong
   The real hole is **5.75 → 19.39**, a single 3.38× jump containing exactly one dataset — `D01`, the burned
   one. *That*, and not rarity, is why [F97](#f97) measured `c_blind = 0`.
 - **The price.** Carried as **"≥ 1 h render"** for twelve waves. Rendering two datasets into the hole took
-  **43 seconds**, `--verify` clean.
+  **43 seconds**, `--verify` clean. The row's companion *"≥ 1 h compute"* was about right, so this is one
+  inherited half of a two-part price, not a wholesale error — but nobody re-derived it, and wave 12 had already
+  measured *"Render + 15 optimizes: 13 m 51 s"* for three datasets.
 
 **A render aimed at the row as written would have added cells the bank already had, at a plate scale that
 answers nothing** — and would have looked like progress.

--- a/docs/followups.md
+++ b/docs/followups.md
@@ -917,8 +917,32 @@ which held, and stands.
 
 ### F97 — F82's shrink-while-widening transition occurs on exactly ONE cell in the bank, and on ZERO of the fifteen that were blind
 
-**Status:** Open (measured; F82's fix choice unchanged) · found 2026-08-13, wave 29, `RULE W29-R` =
-**`R-STANDS`** · `/mnt/d/hf_w29/w29r_score.txt`
+**Status:** **`c_blind = 0` IS SUPERSEDED — it was a COVERAGE artifact, and the first blind wide-field cell ever
+rendered exhibits the transition** (2026-08-14, af-bank-cleanup run) · found 2026-08-13, wave 29, `RULE W29-R` =
+**`R-STANDS`** · `/mnt/d/hf_w29/w29r_score.txt`, `docs/af-bank-cleanup-results.md`,
+`/mnt/d/hf_ship1/blind_widefield_prereg.txt`
+
+> #### `c_blind >= 1` (2026-08-14). The zero measured the BANK, not the defect.
+>
+> The bank had exactly **one** cell above 5.75 ″/px — `D01`, which is burned — so "zero blind cells exhibit it"
+> was guaranteed by the dataset list before any measurement ran. Two wide-field cells were rendered into that
+> hole (`D21_widefield_60mm` 12.926 ″/px, `D22_widefield_100mm` 7.756 ″/px; fields 21.3° and 17.2° from the
+> nearest existing dataset, containing none of them) and scored against a **pre-registration written first**.
+>
+> **`D21` r2: requested span 40.0, fitted span 30.0.** The sweep widened and the fit lost its outer points —
+> F82's transition, on a cell nothing has ever been tuned against. `D22` does not show it. **1 of 2.**
+>
+> Two consequences, and they pull in opposite directions, which is why both are stated:
+> - **F82's rarity claim is weaker than `c = 1 of 18` suggested.** That denominator was dominated by cells at
+>   plate scales where the mechanism cannot occur. On the population where it *can* — wide field, oversampled —
+>   the first two cells give 1 of 2.
+> - **Its consequence is still not general.** On `D21` the F18-vs-F81 conflict changes the half-width
+>   (22.5 → 19.384 when the detect bound is supplied) but **not the recommended step** (6 either way), where on
+>   `D01` it moved the step 3 → 2. So a fix is arguable on **severity**, never on rate — the position F82's
+>   decision document §7 clause 5 already reached, now with data instead of an argument.
+>
+> The render that made this possible cost **43 seconds**, against the ledger's "≥ 1 h". See the results doc for
+> why that row was unfalsifiable as written.
 
 Wave 26 pre-registered a reversal condition on its choice between F82's two fixes — *"if a later wave measures
 that `SearchSpan` … shrinks on more than a single cell while the requested sweep widens, then … (2) becomes
@@ -2321,8 +2345,18 @@ conflict** · found 2026-08-13, wave 25, on the one labelled control that missed
 >
 > **The live entry is now the ordering conflict, and it is a different question from the one F82 asks.** On a
 > shallow, star-poor sweep F18's *measured* detectability bound and F81's *band* floor disagree about which way
-> to move, and F18 wins by being applied last. Deciding that needs the blind wide-field population the bank does
-> not have (`c_blind = 0`, [F97](#f97)), i.e. the 1.4–19.4 ″/px render — **it is not decidable on this bank.**
+> to move, and F18 wins by being applied last.
+>
+> **UPDATE, 2026-08-14 — this IS now decidable on this bank, and the conflict REPRODUCES on blind data.** The
+> blocker was `c_blind = 0`, which [F97](#f97) now records as a **coverage artifact**: the bank had one cell
+> above 5.75 ″/px and it was burned. Two wide-field cells were rendered (43 s, not the "≥ 1 h" the ledger
+> carried) and pre-registered. `D21` r2 shows the shrink (requested 40.0, fitted 30.0), and with the product's
+> detectability bound supplied it clamps to **19.384 against a requested-span floor of 30.0** — F18 below F81,
+> off `D01`, on a cell nothing was tuned against.
+>
+> **But the step does not move** (6 either way), where on `D01` it went 3 → 2. So the ordering conflict is
+> **general in mechanism and not in consequence**, and any remedy must be argued on severity — an unbounded
+> stall costing sky — never on rate.
 
 > #### THE FIX CHOICE IS DECIDED, 2026-08-13 — and wave 26's pre-registered fix (1) is **REFUTED**
 >
@@ -10159,6 +10193,37 @@ is not repeatedly investigated.
 ---
 
 ## Process
+
+### F112 — A ledger row carried a checkable-looking search path that could not evaluate its own predicate, and it hid a false claim AND a 100x-wrong price for twelve waves
+
+**Status:** **Closed by doing the thing the row was blocking** (2026-08-14, af-bank-cleanup run) ·
+`docs/af-bank-cleanup-results.md`, `/mnt/d/hf_ship1/coverage_band.py`
+
+Wave 30 §10 was built on a good rule — *"every row below carries a literal search path that returns the
+answer"* — after `RULE W30-D` showed that inherited prose rots. **Row 10 carried a path that returns a
+different answer than the one its claim needs:**
+
+| the claim | the path | what the path actually returns |
+|---|---|---|
+| "new datasets between 1.4 and 19.4 ″/px … **20, none in the band**" | `ls -d /mnt/d/SyntheticAutofocusBank/D*` | a **count of directories** |
+
+`ls` cannot compute a plate scale. The row looked checkable, was checked repeatedly, and passed every time —
+because what was being checked was not the claim. **Both halves of it were wrong:**
+
+- **The band.** `206.265 × pixelSize × binning / focalLength`, with pixel sizes read from `SensorRegistry.cs`:
+  **seven of the twenty are inside [1.4, 19.4]** — `D01` 19.389, `D02` 5.745, `D03` 3.102, and four at 1.410.
+  The real hole is **5.75 → 19.39**, a single 3.38× jump containing exactly one dataset — `D01`, the burned
+  one. *That*, and not rarity, is why [F97](#f97) measured `c_blind = 0`.
+- **The price.** Carried as **"≥ 1 h render"** for twelve waves. Rendering two datasets into the hole took
+  **43 seconds**, `--verify` clean.
+
+**A render aimed at the row as written would have added cells the bank already had, at a plate scale that
+answers nothing** — and would have looked like progress.
+
+**The rule this refines, rather than replaces.** A search path must be able to **return the claim's own
+quantity**, not merely run without error beside it. The tell is cheap: if the claim contains a number with a
+unit, the path must print that number in that unit. `ls | wc -l` answers "how many directories", so it can only
+support a claim about how many directories there are. **A path that cannot fail the claim is not a check.**
 
 ### F75 — The wave held TWO standards for its two interlocks: one driver-written and explicitly protected from hand-writing, the other specified as a controller `printf`
 **Status:** **open** · found 2026-08-11 (wave 21) when the arm aborted on a marker nothing in `*.sh`/`*.py` writes · **one-line repair, named below**


### PR DESCRIPTION
Clears the last of the synthetic-AF-bank backlog. One branch, one PR, five commits.
Full record: `docs/af-bank-cleanup-results.md`.

**Suite by COUNT: 4052 = 4039 baseline + 3 + 10. Zero failures, zero skips, nothing marked expected-to-fail.**
**CI: success, and the count read out of the run log — `Passed! - Failed: 0, Passed: 4052, Skipped: 0`.**
**The 42 m `optimize` gate was OWED, was run, and PASSED 8 of 8 bit-identical to K8.**

## The headline: `V-0` fired, so item 2 is void

The F82 fix `(3′)` **cannot change a single recommended step** in the configuration the product actually runs.
Re-running `D01`/S1 with `--step-detect-bound` shows F18's detectability bound clamps r1 to `halfWidth = 7.789`,
far below `(3′)`'s requested-span floor of **18.0** — and the F18 bound is applied *after* both the cap and the
floor and "only ever tightens". Inert on all three published cells.

Established **before any code was written**, for ~26 minutes of bank time instead of the 2 h 25 m – 3 h 10 m the
decision document priced. A no-flag control on the *same* binary reproduces wave 25's published report
bit-identically, which is what licenses reading the delta as the flag's effect.

Two things the arm was not asked for: in the product's configuration `D01` **does not stall at all** (it
oscillates 3 → 2 → 3 → 3 over four rounds, so F82's published two-round table is itself a harness artifact), and
the detect bound moves the step in the **opposite** direction from `(3′)`.

## What shipped

| item | outcome |
|---|---|
| 1 — `V-0` validity gate | **FIRED.** Item 2 void. |
| 2 — implement `(3′)` | **VOID**, before any code. `StepSizeRecommender.cs` is untouched on this branch. |
| 3 — `ACCEPTED-elsewhere` residual | **RESOLVED**, zero TestApp minutes. Wave 30 §10 row 7 discharged. |
| 4 — bound + rename `MaxDistortion` | **SHIPPED**: axis bounded at π/4, label + tooltip state the direction. |
| 5 — `A4` truth-model gap | **FIXED**, harness-side, no gate owed. |

**Item 3.** `ACCEPTED-elsewhere` is a 1:1-matching consequence of **golden crowding**, not a detector defect: in
93–99 % of competing cases the two golden stars are closer to each other than the 12 px match radius, so a greedy
matcher cannot pair both whatever the detector does. The distortion-linked part is real but bounded — 100 % of it
within 2R, no tail — and costs **recall, not precision** (`FP = 0` at 0.5 / 0.3 / 0.2). Verified by an offline
matcher that reproduces the run's own TP/FN and all seven published totals exactly.

**Item 4.** `MaxDistortion` is a *minimum fill ratio* despite its name; a round star tops out at π/4 ≈ 0.785, so
the top ~21 % of the axis was reachable and returned zero detections. The persisted-key rename is a **settings
migration and was deliberately not attempted** — the label and tooltip carry the direction instead, and the debt
is named.

**Item 5.** `A4` built its cap boundary from the **requested** sweep while the product used the **fitted** span
(2× apart on `D01` r1), and asserted the cap predicate on band-floored rounds where it does not apply. Measured by
re-running the three published cells on the new binary: **3 of 6 A4 verdicts were failures, and 1 remains.** The
survivor (`D02` r1) is a **real** signal — the fit wanted to extrapolate past `maxHalfWidth = 18.0` while truth is
8.4 — previously buried among two failures the assertion was manufacturing itself. It is also the evidence that
the repair did not turn A4 into a rule that cannot fail.

## Two corrections I made to my own work, in the record

1. **The `MaxDistortion` justification was wrong.** I claimed the old ceiling wasted a coarse-grid level. That
   axis is never coarse-gridded — Phase A grids only `Sensitivity × StarClippingMultiplier`. Caught because the
   false premise produced a prediction the gate then **refuted** (I predicted < 8 of 8 bit-identical; it was
   8 of 8). The bound is still right; it is a guard against a pathological upward excursion, and therefore
   expected to be inert — which is what the gate measured.
2. **My first A4 fix was wrong.** `bounded = WasCapped || WasBandFloored` repairs `D03` r0 but breaks the two
   floored rounds whose truth sits *below* the boundary (`D01` r0 PASS → FLAG, `D02` r0 PASS → **FAIL**). The cap
   clamps *down*, the floor raises *up*; exemption is the verdict that is right in both directions.
3. **My A4 before/after table was part prediction, and two entries were wrong.** Re-running the three cells on
   the new binary replaced the guesses with measurements: `D02` r1 does *not* go FAIL → PASS (its fitted span is
   24.0, equal to its requested span), and `D01` r3 should never have been listed (capped *and* detect-bounded,
   so its fitted span is not recoverable from a B15 report).

## Evidence

- Every new test shown **RED against a named mutant** (`M-OLD-CEILING`, `M-A4-REQUESTED-SPAN`,
  `M-A4-NO-FLOOR-EXEMPTION`, `M-A4-FLOOR-COUNTS-AS-CAP`), with byte backup, `finally` restore, `touch` after
  restore and sha256 re-verified identical. The last two are killed by the same pair of tests — stated rather
  than counted as three independent kills.
- The gate's owed-ness was **run, not asserted**, against the BEFORE binary's tree read out of its own provenance
  file. A paired BASE arm was built and deliberately **not** run: nothing moved, so there was no difference to
  attribute.
- Artifacts under `/mnt/d/hf_ship1/`, indexed at the end of the results doc.

## The honest ending

The bank is measured out. Three of five items closed by measurement rather than construction, and two turned out
not to be product questions at all. What is genuinely left needs **new data** — the 1.4–19.4 ″/px render, open
twelve waves and explicitly out of scope here — and that is the owner's decision: render it, or stop.

---

## SCOPE EXPANSION (authorised after the first report)

The prompt's five items were complete at 02:55Z, inside the original 6 h window. Everything below ran after the
owner authorised expanding scope.

### The twelve-wave blocker was false, and its check could never have caught that

Wave 30 §10 row 10 — *"new datasets between 1.4 and 19.4 ″/px … `ls -d D*` → **20, none in the band**"* — carries
a search path that **counts directories**. `ls` cannot compute a plate scale, so the row looked checkable, was
checked repeatedly, and passed every time on a quantity that was not its claim. **Seven of the twenty are in
that band.** The real hole is **5.75 → 19.39**, one 3.38× jump containing exactly one dataset — `D01`, the
burned one. *That*, not rarity, is why F97 measured `c_blind = 0`. Registered as **F112**: a search path must
return the claim's own quantity.

### `c_blind` is no longer 0

Two cells rendered into the real hole — `D21_widefield_60mm` (12.926 ″/px) and `D22_widefield_100mm` (7.756),
in fields 21.3° and 17.2° from anything existing, containing no other cell. **The render took 43 seconds**
(fairly: the row's companion "≥ 1 h *compute*" was about right; it is the *render* half that was inherited and
never measured).

Pre-registered, then measured: **`D21` r2 requested a span of 40.0 and the fit came back spanning 30.0** — F82's
shrink-while-widening, on a cell nothing was ever tuned against. With the product's detectability bound
supplied it clamps to **19.384 against a floor of 30.0** — F18 below F81, off `D01`. **But the step does not
move** (6 either way, where `D01` went 3 → 2), so the conflict is **general in mechanism and not in
consequence**: arguable on severity, never on rate.

### Also paid

- **The paired BASE gate arm**, which I had skipped with an argument: now run. **8 of 8 bit-identical to BASE**,
  so the attribution is measured rather than reasoned.
- **A4 do-no-harm on the 17 non-burned cells**: 31 rounds, **0 verdict changes**. Stated honestly — all 31 are
  `capped` with `fitted == requested`, so the **exemption half was never exercised** and this confirms one half
  of the repair, not both. `D05`/`D19` hit the timeout and are **named**, and they are exactly the two cells
  wave 23 lost.
- **Wave 30 row 3 (the `K` column)**: run, and it **refused** — its population is pinned at 20 and the bank is
  now 22. Refusing was correct and is worth more than the column.
- **Two new wide-field measurements** (F22-fenced): precision **1.000, FP = 0** on both, and `recall@high` is
  **not monotone** in plate scale (0.183 → 0.103 → 0.235 → 0.446), so the table's implied smooth degradation
  does not survive two new points. Landed `MaxDistortion` **0.20** and **0.40** — two fresh datapoints,
  gathered after the bound shipped, confirming π/4 removes nothing the search uses.

**Left alone deliberately:** F92's blur/`StructureLayers` decoupling. Making the blur width settable requires a
**persisted, user-visible option**, and F92's own experiment has never been run — exposing a knob before knowing
it helps is backwards. It needs an owner decision, not a 5 a.m. one.

---

## REGISTER WORK (same branch, after the bank work)

### F49 / F51 — asked for as remaining work, and mostly already shipped

**F51 had shipped all three of its parts in wave 9. F49 had shipped (a) and (c)** (waves 9 and 10). Only
F49(b) remained, and it is a *decision*. Both status lines said a bare `Open`. Corrected; both entries closed.

**F49(b) DECIDED: won't fix as asked** (`docs/f49b-lever-choice-decision.md`). Its two candidate levers both
guard the **shedding** end, while F49's landing kept **7× more** stars than its seed — so neither could bind.
F32's keep fraction is retired *"permanently"* as *"the wrong instrument"*; a Sensitivity floor is defeatable
through F6's inseparable pair (this very run moved StarClip 6.750 → 0.250 alongside the gate) and would forbid
a **real optimum** of an objective that cannot see precision. **F49(b) resolves into F83.**

### F83 — both exits re-scoped (`docs/f83-precision-term-design.md`)

- **"Label the bank" is REFUTED.** `ComputeLabelScores` sets `precision = 1.0` when the `ShouldReject` list is
  empty, and the bank's goldens are **positive-only** — so a "labelled" run yields
  `sLabel = 0.5·recall + 0.5·1.0`, a **recall term wearing a precision term's name**, pointing the wrong way.
- **The precision term already exists and ships off:** `SMarginalSnr`. Its first stated precondition —
  *"fix the metric (score against truth)"* — **has been satisfied since 2026-08-03** (`TruthProtection`/F85) and
  nobody joined the facts. **The real blocker is its second: the statistic is left-censored at the effective
  gate**, so the search lifts its support past the floor.
- **Unifying result, now stated once in F6:** *any signal whose range is bounded by a searchable gate can be
  lifted out of its own range by the search.* It defeats three separate remedies. Two candidates survive —
  an image-side statistic, and **cross-frame consistency**, which is new.

### The register audit — 5 of 113 statuses were stale

All twelve flagged entries were **read, not bulk-edited**. Corrected: **F79** (status said *"deliberately not
shipped"*; its own body says *"SHIPPED IN WAVE 23"*), **F80**, **F25**, **F53**, **F58**, and **F69** (which
opened with "Open" in a sentence declaring it CLOSED). Four were false positives and are named so the next
audit doesn't re-open them.

**I repeated the error while proposing the audit** — I called F79/F80 "already honest" on the strength of their
status lines, and they were the two worst. Recorded in **F106** rather than quietly fixed, because the
recurrence is what shows the cause is structural: *a status reads as an authority and a body reads as history,
and nobody re-reads history.* A detector keyed on an entry's **own** parts shipping is in F106; it found the 5
real cases and now returns **0**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QTNWdSNar6g3Nj5wXnLZc6
