### PR TITLE
Tilt calibration UX: readable alerts, honest step wording, recoverable automation gate

### DIFF
--- a/.claude/docs/tilt-domain.md
+++ b/.claude/docs/tilt-domain.md
@@ -80,3 +80,21 @@ needs a *current* model that is also gone after a restart.
 ## Image mirroring
 
 Camera images may be mirrored horizontally and/or vertically depending on the optical train (e.g., a star diagonal introduces a mirror). **Do not assume that screws numbered clockwise around the physical adapter will appear clockwise around the sensor image.** The screw orientations must be determined from the actual image coordinates after accounting for any mirroring. Plans and features that involve tilt correction must track orientation in image-space, not physical-space.
+
+## Wording: "inward/outward" is adapter-plate motion only
+
+Screw and motor moves are worded CLOCKWISE / COUNTER-CLOCKWISE or as signed steps — never "inward/outward".
+The wizard's all-motors step is titled "All Screws Clockwise" / "All Motors Positive Steps", never "All Screws
+Inward": it applies `+N` to every motor and **measures** which way the plate travels (that is what sets
+`ScrewInwardCurvatureSign`). `WizardStep.AllInward` keeps its historical enum name because it is persisted in
+saved replay runs. `TiltAdapterWizardVMTests.NoUserFacingMoveWording_ClaimsInwardOrOutward` is the guard.
+
+## Trusting a hand-entered calibration for automation
+
+`ApplyManualCalibration` clears `DeviceLinkedCalibrationDeviceName` and `CalibrationIsReliable`, which blocks
+Automatic Adjustment — a hand-entered screw numbering is not guaranteed to match the device's motor wiring.
+The wizard now warns when that revokes something, and the saved-calibration pane offers **Trust This
+Calibration for Automation** (a two-step in-pane confirmation, `TrustCalibrationCommand` →
+`ConfirmTrustCalibrationCommand`) which re-arms both markers deliberately. There is no new persisted option:
+`CalibrationIsManual == true` together with a device link already means "manually trusted". The trust is
+revoked by a fresh manual entry, by `ClearCalibration`, and for free by a device-preset change.

--- a/.claude/docs/wpf-xaml.md
+++ b/.claude/docs/wpf-xaml.md
@@ -104,3 +104,72 @@ public class PositiveOddIntegerRule : ValidationRule {
 ```
 
 Convention: `-1` means "auto/infinite" — validated by `PositiveIntegerOrInfiniteRule`.
+
+## Alert colours — never use the NINA notification brushes as a Foreground
+
+`NotificationErrorBrush` / `NotificationWarningBrush` are **fill** colours. NINA only ever uses them as a
+`Background`, and 13 of its 18 built-in schemas set them to near-black (`#FF700000`, `#FF5E330B`). Used as a
+`Foreground` they render at 1.06–1.9:1 against a dark page background. Their paired
+`NotificationErrorTextBrush` is not a fix either — the "Dark" schema sets it to `#FF02010A`, i.e. near-black
+text on near-black-red fill, 1.67:1.
+
+Use `Resources/AlertBrushes.xaml` instead:
+
+| Need | Brush |
+|---|---|
+| Text inside a filled alert badge | `HF_AlertErrorTextBrush` / `HF_AlertWarningTextBrush` |
+| Alert text drawn on the page background | `HF_AlertErrorAccentBrush` / `HF_AlertWarningAccentBrush` |
+| The filled badge `Border` itself | `HF_AlertErrorBadge` / `HF_AlertWarningBadge` (both `BasedOn`-able) |
+
+Both text colours are computed by `Converters/ContrastMath.cs` and hold ≥ 4.5:1 on all 18 built-in schemas;
+`ContrastMathTests.EveryBuiltInNinaSchema_ClearsWcagAaForBadgeTextAndAccent` is the regression.
+
+Filled vs outlined follows the existing house rule (`AutoFocus/DataTemplates.xaml:120` and `:2967`): **filled**
+for a short alert that carries an action or announces a lost capability, **outlined with accent text** for
+advisory copy and for long banners that wrap paragraphs and buttons. When a `Border` does become filled, every
+`TextBlock` inside it needs the badge text brush — children with no explicit `Foreground` otherwise inherit
+`PrimaryBrush` onto the fill.
+
+**Related trap: `Button`-content `TextBlock`s need their own foreground too, for the same reason.** A
+`TextBlock` used as a `Button`'s content, with no explicit `Foreground` and no explicit `Style`, does not
+inherit the button's foreground — NINA.WPF.Base ships a keyless implicit `TextBlock` style in
+`Application.Resources` (`Foreground = PrimaryBrush`), and an implicit style beats inherited value. The label
+therefore renders in `PrimaryBrush` on `ButtonBackgroundBrush`, and on the **Dark** and **Alternative Custom**
+schemas those two are the identical colour `#FF550C18` — the label renders at 1.00:1, literally invisible.
+Always set `Foreground="{StaticResource ButtonForegroundBrush}"` on a button-content `TextBlock`:
+
+```xml
+<TextBlock Margin="6,2" Foreground="{StaticResource ButtonForegroundBrush}" Text="Stay connected" />
+```
+
+Residual limitation, left as-is deliberately: this only restores the plugin's own pre-existing convention — it
+takes those two schemas from 1.00:1 to 1.44:1, still short of WCAG AA. NINA's button palette itself
+(`ButtonForegroundColor` on `ButtonBackgroundColor`) clears 4.5:1 on only 12 of its 18 built-in schemas.
+Computing a contrast-safe button foreground would make every button in this plugin look different from every
+other button in NINA — a product decision for the maintainer, not a bug fix, and deliberately not taken here.
+Exception: `TiltAdapterDevices/Prompt/TiltDeviceAdjustmentPromptControl.xaml` carries its own self-contained,
+theme-independent palette (`Fg`, `FgDim`, `WarnFg`, `DangerFg`); match that file's local foreground keys there
+instead of `ButtonForegroundBrush`.
+
+**A second form of the same trap: `Button Content="…"` (no `TextBlock` in the markup at all).** WPF's
+`ContentPresenter` generates a `TextBlock` at runtime for string content, and that generated `TextBlock` hits
+the identical keyless-implicit-style rule — so it also paints `PrimaryBrush` on `ButtonBackgroundBrush`. Only
+the explicit-`TextBlock`-child form above is fixed plugin-wide today; the `Content="…"` form is not. The fix
+differs: an explicit `Foreground` on the `Button` itself, or the `ContentPresenter.Resources` empty-`Style`
+pattern already solved and commented in `StarDetection/Optimization/Review/StarReviewControl.xaml`
+(`HF_ReviewToolbarButton`, ~line 171) and reused in `AutoFocus/Review/AutoFocusFrameReviewControl.xaml` and
+`StarDetection/Optimization/Review/FrameReviewControl.xaml` — use that as the worked example. **13 known,
+unfixed `Content="…"` sites remain**, all in `StarDetection/Optimization/DataTemplates.xaml`: two `Browse…`
+(~437, ~612), `Optimize with feedback` (~1135), and the optimizer wizard's whole navigation footer
+(~1257–1331: Cancel, Start, Back, Review frames, Continue optimizing, Use run's settings, Accept, Back to
+summary, Optimize with feedback, Close). These predate this branch and are deliberately out of its scope — not
+fixed here, left for the maintainer to decide. Neither the button-content `TextBlock` scan nor
+`XamlResourceResolutionTests` catches this form — both check that resource keys resolve, not foreground-vs-
+background contrast — so there is no automated net against it; it needs a deliberate audit.
+
+**Related trap: a local value outranks a style *trigger*, not just a style setter.** WPF dependency-property
+precedence puts a local value (rank 3) above both a style setter (rank 8) and a style trigger (rank 6). So an
+element must never carry a local `Visibility` attribute when its `Style` sets `Visibility` from a trigger — the
+local value wins permanently and the trigger becomes dead code, with no error and no warning. This is why every
+badge above keeps `Visibility` inside its `Style` and sets none on the element itself; it is safe to set
+`Visibility` locally only on an element whose `Style` sets no `Visibility` at all.

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/AutoFocus/InspectorVMAutomaticAdjustmentTests.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/AutoFocus/InspectorVMAutomaticAdjustmentTests.cs
@@ -68,6 +68,44 @@ public class InspectorVMAutomaticAdjustmentTests {
         Assert.That(InspectorVM.IsCalibrationDeviceLinked(options), Is.EqualTo(expected));
     }
 
+    [Test]
+    public void RemediationText_ForAHandEnteredCalibration_NamesManualEntryAsTheCause() {
+        var options = Substitute.For<ITiltAdapterOptions>();
+        options.DeviceName.Returns("ASG Electronic EAT - 90mm");
+        options.DeviceLinkedCalibrationDeviceName.Returns(string.Empty);
+        options.CalibrationIsManual.Returns(true);
+
+        var text = InspectorVM.AutomaticAdjustmentRemediationTextFor(options);
+
+        Assert.Multiple(() => {
+            Assert.That(text, Does.Contain("by hand"));
+            Assert.That(text, Does.Contain("Tilt Adapter Wizard"), "the remedy must point at where the Trust button is");
+        });
+    }
+
+    [Test]
+    public void RemediationText_ForANonManualUnlinkedCalibration_KeepsTheExistingWording() {
+        var options = Substitute.For<ITiltAdapterOptions>();
+        options.DeviceName.Returns("ASG Electronic EAT - 90mm");
+        options.DeviceLinkedCalibrationDeviceName.Returns(string.Empty);
+        options.CalibrationIsManual.Returns(false);
+
+        Assert.That(InspectorVM.AutomaticAdjustmentRemediationTextFor(options),
+            Is.EqualTo("This calibration is not linked to the connected device. Re-run calibration with the device connected."));
+    }
+
+    [Test]
+    public void RemediationText_ForALinkedButLowConfidenceCalibration_KeepsTheExistingWording() {
+        var options = Substitute.For<ITiltAdapterOptions>();
+        options.DeviceName.Returns("ASG Electronic EAT - 90mm");
+        options.DeviceLinkedCalibrationDeviceName.Returns("ASG Electronic EAT - 90mm");
+        options.CalibrationIsReliable.Returns(false);
+        options.CalibrationIsManual.Returns(true);   // manual must NOT hijack the low-confidence branch
+
+        Assert.That(InspectorVM.AutomaticAdjustmentRemediationTextFor(options),
+            Is.EqualTo("This calibration is low-confidence (it did not pass quality validation). Re-run calibration to enable Automatic Adjustment."));
+    }
+
     #endregion
 
     #region CanExecuteAutomaticAdjustment

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/AutoFocus/InspectorVMAutomaticAdjustmentTests.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/AutoFocus/InspectorVMAutomaticAdjustmentTests.cs
@@ -106,6 +106,12 @@ public class InspectorVMAutomaticAdjustmentTests {
             Is.EqualTo("This calibration is low-confidence (it did not pass quality validation). Re-run calibration to enable Automatic Adjustment."));
     }
 
+    [Test]
+    public void RemediationText_NullOptions_ReturnsTheNotLinkedWording() {
+        Assert.That(InspectorVM.AutomaticAdjustmentRemediationTextFor(null),
+            Is.EqualTo("This calibration is not linked to the connected device. Re-run calibration with the device connected."));
+    }
+
     #endregion
 
     #region CanExecuteAutomaticAdjustment

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/CameraSimulator/SimulatedTiltAdapterVMTests.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/CameraSimulator/SimulatedTiltAdapterVMTests.cs
@@ -1,4 +1,4 @@
-#region "copyright"
+﻿#region "copyright"
 
 /*
     Copyright © 2021 - 2026 George Hilios <ghilios+NINA@googlemail.com>
@@ -857,6 +857,39 @@ public class SimulatedTiltAdapterVMTests {
             Assert.That(real.DeviceName, Is.EqualTo(TiltAdapterDevicePreset.ManualName),
                 "the hardware fields we just wrote must stay editable, not be locked by a stale preset");
             Assert.That(vm.AdapterMatchesReal, Is.True);
+        });
+    }
+
+    [Test]
+    public void ConfirmCopyToAdapter_ClearsTheAutomationMarkers() {
+        // [CRITICAL GATE] This writes a hand-made calibration over the user's real one, so it must make the
+        // same clears the wizard's manual-entry path makes: the sim geometry's screw numbering has no
+        // established correspondence to any device's motor wiring. Setting DeviceName to Manual breaks
+        // IsCalibrationDeviceLinked implicitly, but a stale device name left in the marker is exactly what
+        // survives a later preset change.
+        //
+        // realAdapter here is a REAL TiltAdapterOptions (this fixture's convention), not a substitute, so this
+        // asserts resulting state rather than Received() calls. Both markers are SEEDED to the "automation
+        // trusted" values first -- their defaults are already empty/false, so without the seed this test would
+        // pass unchanged even if the production clears were deleted.
+        var options = Configured(screwCount: 4, curvatureSign: -1);
+        var real = BuildRealAdapterOptions();
+        real.DeviceName = "ASG Electronic EAT - 90mm";
+        real.DeviceLinkedCalibrationDeviceName = "ASG Electronic EAT - 90mm";
+        real.CalibrationIsReliable = true;
+        Assert.Multiple(() => {
+            Assert.That(real.DeviceLinkedCalibrationDeviceName, Is.Not.Empty, "precondition: automation-trusted");
+            Assert.That(real.CalibrationIsReliable, Is.True, "precondition: automation-trusted");
+        });
+
+        var vm = new SimulatedTiltAdapterVM(options, real);
+        vm.CopyToAdapterCommand.Execute(null);
+        vm.ConfirmCopyToAdapterCommand.Execute(null);
+
+        Assert.Multiple(() => {
+            Assert.That(real.DeviceLinkedCalibrationDeviceName, Is.Empty);
+            Assert.That(real.CalibrationIsReliable, Is.False);
+            Assert.That(real.CalibrationIsManual, Is.True, "precondition for the clears: this IS a manual calibration now");
         });
     }
 

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/CameraSimulator/SimulatedTiltAdapterVMTests.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/CameraSimulator/SimulatedTiltAdapterVMTests.cs
@@ -1,4 +1,4 @@
-﻿#region "copyright"
+#region "copyright"
 
 /*
     Copyright © 2021 - 2026 George Hilios <ghilios+NINA@googlemail.com>
@@ -884,12 +884,32 @@ public class SimulatedTiltAdapterVMTests {
 
         var vm = new SimulatedTiltAdapterVM(options, real);
         vm.CopyToAdapterCommand.Execute(null);
+        // The copy revokes automation, so the confirmation must SAY so before the user agrees to it.
+        Assert.That(vm.CopyToAdapterConfirmText, Does.Contain("Automatic Adjustment will be disabled"));
         vm.ConfirmCopyToAdapterCommand.Execute(null);
 
         Assert.Multiple(() => {
             Assert.That(real.DeviceLinkedCalibrationDeviceName, Is.Empty);
             Assert.That(real.CalibrationIsReliable, Is.False);
             Assert.That(real.CalibrationIsManual, Is.True, "precondition for the clears: this IS a manual calibration now");
+        });
+    }
+
+    [Test]
+    public void CopyToAdapterConfirmText_DoesNotClaimToDisableAutomationThatWasNeverEnabled() {
+        // Mirrors the wizard's manual-entry warning: the clears are unconditional, but the ANNOUNCEMENT is not.
+        // A real adapter with no device link had Automatic Adjustment blocked already.
+        var options = Configured(screwCount: 4, curvatureSign: -1);
+        var real = BuildRealAdapterOptions();
+        real.CalibrationIsReliable = true; // reliable but never device-linked -> automation was still blocked
+
+        var vm = new SimulatedTiltAdapterVM(options, real);
+        vm.CopyToAdapterCommand.Execute(null);
+
+        Assert.Multiple(() => {
+            Assert.That(vm.CopyToAdapterConfirmText, Does.Not.Contain("Automatic Adjustment"));
+            Assert.That(vm.CopyToAdapterConfirmText, Does.Contain("marked as a manual calibration"),
+                "the rest of the confirmation is unchanged");
         });
     }
 

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/Converters/AlertColorConverterTests.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/Converters/AlertColorConverterTests.cs
@@ -1,0 +1,60 @@
+using System.Globalization;
+using NINA.Joko.Plugins.HocusFocus.Converters;
+using NUnit.Framework;
+using Color = System.Windows.Media.Color;
+using Colors = System.Windows.Media.Colors;
+
+namespace NINA.Joko.Plugins.HocusFocus.Tests.Converters;
+
+[TestFixture]
+public class AlertColorConverterTests {
+
+    private static Color Hex(string rgb) => Color.FromRgb(
+        System.Convert.ToByte(rgb.Substring(0, 2), 16),
+        System.Convert.ToByte(rgb.Substring(2, 2), 16),
+        System.Convert.ToByte(rgb.Substring(4, 2), 16));
+
+    [Test]
+    public void BadgeText_OnNinaDefaultErrorFill_IsWhite() {
+        var converter = new BadgeTextColorConverter();
+        var result = converter.Convert(Hex("700000"), typeof(Color), null, CultureInfo.InvariantCulture);
+        Assert.That(result, Is.EqualTo(Colors.White));
+    }
+
+    // WPF pushes DependencyProperty.UnsetValue on the first pass of a resource-level binding. Returning
+    // Binding.DoNothing would leave SolidColorBrush.Color at Transparent, i.e. invisible text; white is the
+    // answer on all 18 built-in schemas anyway.
+    [Test]
+    public void BadgeText_OnNonColourInput_FallsBackToWhite() {
+        var converter = new BadgeTextColorConverter();
+        var result = converter.Convert(System.Windows.DependencyProperty.UnsetValue, typeof(Color), null, CultureInfo.InvariantCulture);
+        Assert.That(result, Is.EqualTo(Colors.White));
+    }
+
+    [Test]
+    public void Accent_LightensTheErrorFillAgainstADarkBackground() {
+        var converter = new AccessibleAccentColorConverter();
+        var result = (Color)converter.Convert(
+            new object[] { Hex("700000"), Hex("02010A") }, typeof(Color), null, CultureInfo.InvariantCulture);
+        Assert.That(ContrastMath.ContrastRatio(result, Hex("02010A")),
+            Is.GreaterThanOrEqualTo(ContrastMath.MinContrastRatio));
+    }
+
+    [Test]
+    public void Accent_WithoutAUsableBackground_DegradesToTheRawAlertColour() {
+        var converter = new AccessibleAccentColorConverter();
+        var result = converter.Convert(
+            new object[] { Hex("700000"), System.Windows.DependencyProperty.UnsetValue },
+            typeof(Color), null, CultureInfo.InvariantCulture);
+        Assert.That(result, Is.EqualTo(Hex("700000")), "no background yet means today's behaviour, not a crash");
+    }
+
+    [Test]
+    public void Accent_WithNoUsableValuesAtAll_FallsBackToWhite() {
+        var converter = new AccessibleAccentColorConverter();
+        Assert.Multiple(() => {
+            Assert.That(converter.Convert(null, typeof(Color), null, CultureInfo.InvariantCulture), Is.EqualTo(Colors.White));
+            Assert.That(converter.Convert(new object[0], typeof(Color), null, CultureInfo.InvariantCulture), Is.EqualTo(Colors.White));
+        });
+    }
+}

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/Converters/AlertColorConverterTests.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/Converters/AlertColorConverterTests.cs
@@ -57,4 +57,15 @@ public class AlertColorConverterTests {
             Assert.That(converter.Convert(new object[0], typeof(Color), null, CultureInfo.InvariantCulture), Is.EqualTo(Colors.White));
         });
     }
+
+    [Test]
+    public void Accent_WhenTheAlertColourIsNotResolvedYet_FallsBackToWhite() {
+        // The shape a MultiBinding actually produces on its first pass: a full-length array whose entries
+        // are still UnsetValue. null and empty arrays never occur in practice.
+        var converter = new AccessibleAccentColorConverter();
+        var result = converter.Convert(
+            new object[] { System.Windows.DependencyProperty.UnsetValue, System.Windows.DependencyProperty.UnsetValue },
+            typeof(Color), null, CultureInfo.InvariantCulture);
+        Assert.That(result, Is.EqualTo(Colors.White));
+    }
 }

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/Converters/ContrastMathTests.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/Converters/ContrastMathTests.cs
@@ -65,6 +65,33 @@ public class ContrastMathTests {
         });
     }
 
+    [Test]
+    public void AccessibleAccent_DarkensAnAchromaticColourAgainstALightBackground() {
+        // Forces the goLighter == false branch: white background means only the dark pole can reach the
+        // target. No built-in NINA schema exercises this path, so without this test an inverted comparison
+        // in the bisection's else-branch would go unnoticed.
+        var accent = ContrastMath.AccessibleAccent(Hex("D0D0D0"), Colors.White);
+        Assert.Multiple(() => {
+            Assert.That(ContrastMath.ContrastRatio(accent, Colors.White),
+                Is.GreaterThanOrEqualTo(ContrastMath.MinContrastRatio));
+            Assert.That(ContrastMath.RelativeLuminance(accent),
+                Is.LessThan(ContrastMath.RelativeLuminance(Hex("D0D0D0"))), "must have moved darker");
+        });
+    }
+
+    [Test]
+    public void AccessibleAccent_DarkeningPreservesHue() {
+        var alert = Hex("FFD54F");   // amber, too light to read on white
+        var accent = ContrastMath.AccessibleAccent(alert, Colors.White);
+        Assert.Multiple(() => {
+            Assert.That(ContrastMath.ContrastRatio(accent, Colors.White),
+                Is.GreaterThanOrEqualTo(ContrastMath.MinContrastRatio));
+            Assert.That(ContrastMath.RelativeLuminance(accent), Is.LessThan(ContrastMath.RelativeLuminance(alert)));
+            Assert.That(accent.R, Is.GreaterThan(accent.G), "still amber");
+            Assert.That(accent.G, Is.GreaterThan(accent.B), "still amber");
+        });
+    }
+
     // The regression that would have caught the original bug: every built-in NINA schema, both roles.
     [Test]
     public void EveryBuiltInNinaSchema_ClearsWcagAaForBadgeTextAndAccent() {

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/Converters/ContrastMathTests.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/Converters/ContrastMathTests.cs
@@ -1,0 +1,93 @@
+using System;
+using NINA.Core.Utility.ColorSchema;
+using NINA.Joko.Plugins.HocusFocus.Converters;
+using NUnit.Framework;
+using Color = System.Windows.Media.Color;
+using Colors = System.Windows.Media.Colors;
+
+namespace NINA.Joko.Plugins.HocusFocus.Tests.Converters;
+
+[TestFixture]
+public class ContrastMathTests {
+
+    private static Color Hex(string rgb) => Color.FromRgb(
+        System.Convert.ToByte(rgb.Substring(0, 2), 16),
+        System.Convert.ToByte(rgb.Substring(2, 2), 16),
+        System.Convert.ToByte(rgb.Substring(4, 2), 16));
+
+    [Test]
+    public void ContrastRatio_BlackOnWhite_Is21() {
+        Assert.That(ContrastMath.ContrastRatio(Colors.Black, Colors.White), Is.EqualTo(21.0).Within(1e-9));
+    }
+
+    [Test]
+    public void ContrastRatio_IsSymmetric() {
+        var a = Hex("700000");
+        var b = Hex("02010A");
+        Assert.That(ContrastMath.ContrastRatio(a, b), Is.EqualTo(ContrastMath.ContrastRatio(b, a)).Within(1e-12));
+    }
+
+    [Test]
+    public void RelativeLuminance_MatchesWcagReferenceValues() {
+        Assert.Multiple(() => {
+            Assert.That(ContrastMath.RelativeLuminance(Colors.White), Is.EqualTo(1.0).Within(1e-9));
+            Assert.That(ContrastMath.RelativeLuminance(Colors.Black), Is.EqualTo(0.0).Within(1e-9));
+            // NINA's default error fill; hand-computed from the WCAG formula.
+            Assert.That(ContrastMath.RelativeLuminance(Hex("700000")), Is.EqualTo(0.034452).Within(1e-5));
+        });
+    }
+
+    [Test]
+    public void BestContrastText_PicksWhiteOnNinaDefaultErrorFill() {
+        Assert.That(ContrastMath.BestContrastText(Hex("700000")), Is.EqualTo(Colors.White));
+    }
+
+    [Test]
+    public void BestContrastText_PicksBlackOnALightFill() {
+        Assert.That(ContrastMath.BestContrastText(Hex("FFD54F")), Is.EqualTo(Colors.Black));
+    }
+
+    [Test]
+    public void AccessibleAccent_LeavesAnAlreadyReadableColorUntouched() {
+        // #700000 on white is 12.4:1 — light themes must stay byte-identical to today.
+        var alert = Hex("700000");
+        Assert.That(ContrastMath.AccessibleAccent(alert, Colors.White), Is.EqualTo(alert));
+    }
+
+    [Test]
+    public void AccessibleAccent_PreservesHueAndAlpha() {
+        var alert = Color.FromArgb(0xCC, 0x70, 0x00, 0x00);
+        var accent = ContrastMath.AccessibleAccent(alert, Hex("02010A"));
+        Assert.Multiple(() => {
+            Assert.That(accent.A, Is.EqualTo(0xCC), "alpha must be carried through");
+            Assert.That(accent.R, Is.GreaterThan(accent.G), "must still read as red");
+            Assert.That(accent.G, Is.EqualTo(accent.B), "pure-red hue has equal green and blue");
+        });
+    }
+
+    // The regression that would have caught the original bug: every built-in NINA schema, both roles.
+    [Test]
+    public void EveryBuiltInNinaSchema_ClearsWcagAaForBadgeTextAndAccent() {
+        var schemas = ColorSchemas.ReadColorSchemas().Items;
+        Assert.That(schemas, Is.Not.Empty, "NINA must expose its built-in schemas");
+        Assert.Multiple(() => {
+            foreach (var s in schemas) {
+                var bg = s.BackgroundColor;
+                foreach (var (role, fill) in new[] {
+                    ("error", s.NotificationErrorColor),
+                    ("warning", s.NotificationWarningColor)
+                }) {
+                    var badgeText = ContrastMath.BestContrastText(fill);
+                    Assert.That(ContrastMath.ContrastRatio(badgeText, fill),
+                        Is.GreaterThanOrEqualTo(ContrastMath.MinContrastRatio),
+                        $"{s.Name}: {role} badge text on fill");
+
+                    var accent = ContrastMath.AccessibleAccent(fill, bg);
+                    Assert.That(ContrastMath.ContrastRatio(accent, bg),
+                        Is.GreaterThanOrEqualTo(ContrastMath.MinContrastRatio),
+                        $"{s.Name}: {role} accent on page background");
+                }
+            }
+        });
+    }
+}

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/TiltAdapterDevices/AsgEat/EatWizardMappingTests.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/TiltAdapterDevices/AsgEat/EatWizardMappingTests.cs
@@ -53,6 +53,17 @@ public class EatWizardMappingTests {
         });
     }
 
+    [Test]
+    public void AllInward_DescriptionDoesNotClaimAPhysicalDirection() {
+        var move = EatWizardMapping.MoveForStep(WizardStep.AllInward, 150);
+        Assert.Multiple(() => {
+            Assert.That(move.Description, Does.Contain("All Motors"));
+            Assert.That(move.Description, Does.Not.Contain("Inward"));
+            Assert.That(move.Steps, Is.EqualTo(150), "wording only — the move itself is unchanged");
+            Assert.That(move.Axis, Is.EqualTo(TiltMoveAxis.Backfocus), "wording only — the axis is unchanged");
+        });
+    }
+
     [TestCase(150)]
     [TestCase(30)]
     public void MoveForStep_ReBaseline1_MatchesWizardInstruction(int n) {

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/TiltAdapterWizard/TiltAdapterWizardVMTests.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/TiltAdapterWizard/TiltAdapterWizardVMTests.cs
@@ -85,6 +85,27 @@ namespace NINA.Joko.Plugins.HocusFocus.Tests.TiltAdapterWizard {
             return (vm, options, camera, focuser);
         }
 
+        // A saved, valid calibration on a motorized preset — the state the Trust banner is about.
+        // "ASG Electronic EAT - 90mm" is a real registered preset name; TiltMotionControllerRegistry.IsMotorized
+        // does an exact-name lookup, so an invented name would silently make every banner test pass vacuously.
+        private const string MotorizedPreset = "ASG Electronic EAT - 90mm";
+
+        // 4 screws, not 3: the ctor's re-lock-on-load ApplyDevice writes the motorized preset's own ScrewCount
+        // (4) onto the substitute -- and an NSubstitute property SET does feed its getter -- so a 3-screw stub
+        // would leave ScrewCount(4) != CalibratedScrewCount(3) and IsCalibrationValid false, silently hiding
+        // the banner for a reason that has nothing to do with automation trust.
+        private static (TiltAdapterWizardVM vm, ITiltAdapterOptions options) BuildCalibrated(
+            string deviceName = MotorizedPreset, string linkedDevice = "", bool reliable = false) {
+            var (vm, options, _, _) = Build(screwCount: 4, configureOptions: o => {
+                o.DeviceName.Returns(deviceName);
+                o.IsCalibrated.Returns(true);
+                o.CalibratedScrewCount.Returns(4);
+                o.DeviceLinkedCalibrationDeviceName.Returns(linkedDevice);
+                o.CalibrationIsReliable.Returns(reliable);
+            });
+            return (vm, options);
+        }
+
         // --- Motorized device connection pane (T10) test rig -------------------------------------------------
 
         // Deterministic ITiltDeviceTimeSource test double (mirrors TiltDeviceConnectionServiceTests): UtcNow is
@@ -3574,6 +3595,161 @@ namespace NINA.Joko.Plugins.HocusFocus.Tests.TiltAdapterWizard {
                 options.DidNotReceive().ScrewInwardCurvatureSign = Arg.Any<int>();
                 options.DidNotReceive().Screw1AngleDegrees = Arg.Any<double>();
                 options.DidNotReceive().IsCalibrated = Arg.Any<bool>();
+            });
+        }
+
+        // --- Opt-in re-link: trusting a hand-entered calibration for automation (Task 9) --------------------
+
+        [Test]
+        public void TrustCalibration_AloneWritesNothing() {
+            var (vm, options) = BuildCalibrated();
+            options.ClearReceivedCalls();
+
+            vm.TrustCalibrationCommand.Execute(null);
+
+            Assert.Multiple(() => {
+                Assert.That(vm.IsTrustCalibrationPending, Is.True, "the button only arms the confirmation");
+                options.DidNotReceive().DeviceLinkedCalibrationDeviceName = Arg.Any<string>();
+                options.DidNotReceive().CalibrationIsReliable = Arg.Any<bool>();
+            });
+        }
+
+        [Test]
+        public void ConfirmTrustCalibration_ArmsBothAutomationMarkersForTheCurrentDevice() {
+            var (vm, options) = BuildCalibrated();
+            options.ClearReceivedCalls();
+
+            vm.TrustCalibrationCommand.Execute(null);
+            vm.ConfirmTrustCalibrationCommand.Execute(null);
+
+            Assert.Multiple(() => {
+                options.Received().DeviceLinkedCalibrationDeviceName = MotorizedPreset;
+                options.Received().CalibrationIsReliable = true;
+                Assert.That(vm.IsTrustCalibrationPending, Is.False);
+            });
+        }
+
+        [Test]
+        public void CancelTrustCalibration_WritesNothing() {
+            var (vm, options) = BuildCalibrated();
+            options.ClearReceivedCalls();
+
+            vm.TrustCalibrationCommand.Execute(null);
+            vm.CancelTrustCalibrationCommand.Execute(null);
+
+            Assert.Multiple(() => {
+                Assert.That(vm.IsTrustCalibrationPending, Is.False);
+                options.DidNotReceive().DeviceLinkedCalibrationDeviceName = Arg.Any<string>();
+                options.DidNotReceive().CalibrationIsReliable = Arg.Any<bool>();
+            });
+        }
+
+        [Test]
+        public void ApplyManualCalibration_DisarmsAPendingTrustConfirmation() {
+            // A stale confirmation must not survive the state change that invalidated it.
+            var (vm, options) = BuildCalibrated(linkedDevice: MotorizedPreset, reliable: true);
+            options.ScrewInwardCurvatureSign.Returns(1);
+            vm.TrustCalibrationCommand.Execute(null);
+            vm.ManualScrew1AngleDegrees = 30;
+
+            vm.ApplyManualCalibration();
+
+            Assert.Multiple(() => {
+                Assert.That(vm.IsTrustCalibrationPending, Is.False);
+                options.Received().DeviceLinkedCalibrationDeviceName = string.Empty;
+                options.Received().CalibrationIsReliable = false;
+            });
+        }
+
+        [Test]
+        public void ClearCalibration_AlsoClearsTheAutomationMarkers() {
+            var (vm, options) = BuildCalibrated(linkedDevice: MotorizedPreset, reliable: true);
+            options.ClearReceivedCalls();
+
+            vm.ClearCalibrationCommand.Execute(null);
+
+            Assert.Multiple(() => {
+                options.Received().DeviceLinkedCalibrationDeviceName = string.Empty;
+                options.Received().CalibrationIsReliable = false;
+            });
+        }
+
+        [Test]
+        public void AutomationTrustBanner_IsHiddenForADeviceLinkedReliableCalibration() {
+            var (vm, _) = BuildCalibrated(linkedDevice: MotorizedPreset, reliable: true);
+            Assert.That(vm.AutomationTrustBannerVisible, Is.False);
+        }
+
+        [Test]
+        public void AutomationTrustBanner_IsShownForAManualCalibrationOnAMotorizedPreset() {
+            var (vm, _) = BuildCalibrated();
+            Assert.That(vm.AutomationTrustBannerVisible, Is.True);
+        }
+
+        [Test]
+        public void AutomationTrustBanner_IsHiddenOnANonMotorizedPreset() {
+            var (vm, _) = BuildCalibrated(deviceName: TiltAdapterDevicePreset.ManualName);
+            Assert.That(vm.AutomationTrustBannerVisible, Is.False,
+                "there is nothing to automate without a motorized device");
+        }
+
+        [Test]
+        public void AutomationTrustBanner_IsHiddenWithNoSavedCalibration() {
+            var (vm, _, _, _) = Build(screwCount: 3, configureOptions: o => {
+                o.DeviceName.Returns(MotorizedPreset);
+                o.IsCalibrated.Returns(false);
+            });
+            Assert.That(vm.AutomationTrustBannerVisible, Is.False);
+        }
+
+        [Test]
+        public void ConfirmedTrust_SatisfiesTheAutomaticAdjustmentGate() {
+            // The point of the whole feature: the Inspector's gate reads exactly these two markers.
+            var (vm, options) = BuildCalibrated();
+            vm.TrustCalibrationCommand.Execute(null);
+            vm.ConfirmTrustCalibrationCommand.Execute(null);
+            // NSubstitute property setters do not feed the getters back, so mirror what was written.
+            options.DeviceLinkedCalibrationDeviceName.Returns(MotorizedPreset);
+            options.CalibrationIsReliable.Returns(true);
+
+            Assert.Multiple(() => {
+                Assert.That(InspectorVM.IsCalibrationDeviceLinked(options), Is.True);
+                Assert.That(InspectorVM.CanExecuteAutomaticAdjustment(
+                    serviceConnected: true, controllerAvailable: true,
+                    deviceLinked: InspectorVM.IsCalibrationDeviceLinked(options),
+                    calibrationIsReliable: options.CalibrationIsReliable,
+                    hasNumericGuidance: true, isOperationActive: false,
+                    currentGeneration: 2, lastExecutedGeneration: 1), Is.True);
+                Assert.That(vm.AutomationTrustBannerVisible, Is.False, "the banner retires once trust is granted");
+            });
+        }
+
+        [Test]
+        public void ChangingTheDevicePreset_DisarmsAPendingTrustConfirmation() {
+            // The confirmation was armed against the PREVIOUS preset's screw wiring — confirming it afterwards
+            // would link a hand-entered calibration to a device it was never entered for.
+            var (vm, options) = BuildCalibrated();
+            vm.TrustCalibrationCommand.Execute(null);
+            Assert.That(vm.IsTrustCalibrationPending, Is.True, "precondition: armed");
+
+            options.DeviceName.Returns("ASG Electronic EAT - ZWO 461");
+            options.PropertyChanged += Raise.Event<System.ComponentModel.PropertyChangedEventHandler>(
+                options, new System.ComponentModel.PropertyChangedEventArgs(nameof(ITiltAdapterOptions.DeviceName)));
+
+            Assert.That(vm.IsTrustCalibrationPending, Is.False);
+        }
+
+        [Test]
+        public void SelectingADifferentDevicePreset_RevokesTheTrust() {
+            // No explicit revoke needed: IsCalibrationDeviceLinked compares against the CURRENT DeviceName.
+            var (vm, options) = BuildCalibrated(linkedDevice: MotorizedPreset, reliable: true);
+            Assert.That(vm.AutomationTrustBannerVisible, Is.False, "precondition: trusted");
+
+            options.DeviceName.Returns("ASG Electronic EAT - ZWO 461");
+
+            Assert.Multiple(() => {
+                Assert.That(InspectorVM.IsCalibrationDeviceLinked(options), Is.False);
+                Assert.That(vm.AutomationTrustBannerVisible, Is.True);
             });
         }
 

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/TiltAdapterWizard/TiltAdapterWizardVMTests.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/TiltAdapterWizard/TiltAdapterWizardVMTests.cs
@@ -3787,9 +3787,9 @@ namespace NINA.Joko.Plugins.HocusFocus.Tests.TiltAdapterWizard {
             var (vm, options) = BuildCalibrated();
             vm.TrustCalibrationCommand.Execute(null);
             vm.ConfirmTrustCalibrationCommand.Execute(null);
-            // NSubstitute property setters do not feed the getters back, so mirror what was written.
-            options.DeviceLinkedCalibrationDeviceName.Returns(MotorizedPreset);
-            options.CalibrationIsReliable.Returns(true);
+            // No re-stubbing needed: an NSubstitute property setter feeds its own getter, so the getters below
+            // return exactly what ConfirmTrustCalibration just wrote. That is the point -- the assertion reads
+            // production state, not test state.
 
             Assert.Multiple(() => {
                 Assert.That(InspectorVM.IsCalibrationDeviceLinked(options), Is.True);
@@ -3800,6 +3800,31 @@ namespace NINA.Joko.Plugins.HocusFocus.Tests.TiltAdapterWizard {
                     hasNumericGuidance: true, isOperationActive: false,
                     currentGeneration: 2, lastExecutedGeneration: 1), Is.True);
                 Assert.That(vm.AutomationTrustBannerVisible, Is.False, "the banner retires once trust is granted");
+            });
+        }
+
+        [Test]
+        public void RunCalibrationForTest_DisarmsAPendingTrustConfirmation() {
+            // Same invariant as the manual-entry / clear / preset-change disarms: a fresh run rewrites both
+            // automation markers, so a confirmation armed against the PREVIOUS calibration is stale. Seed data
+            // is the device-driven-but-low-confidence case (the one that leaves the banner showing), copied
+            // from RunCalibrationForTest_DeviceDriven_UnreliableCalibration_SetsCalibrationIsReliableFalse_EvenThoughDeviceLinked.
+            var (vm, options, _, _, _, _) = BuildMotorized();
+            options.IsCalibrated.Returns(true);
+            options.CalibratedScrewCount.Returns(4);
+            vm.TrustCalibrationCommand.Execute(null);
+            Assert.That(vm.IsTrustCalibrationPending, Is.True, "precondition: armed");
+
+            vm.SeedStepReading(WizardStep.Baseline, 0.0, 0.0, 1000.0);
+            vm.SeedStepReading(WizardStep.Screw1, 0.5, 0.0, 1000.0);
+            vm.SeedStepReading(WizardStep.ReBaseline2, 0.4, 0.0, 1000.0);
+            vm.SeedStepReading(WizardStep.Screw2, 0.9, 0.0, 1000.0);
+            vm.RunCalibrationForTest(deviceDriven: true, pixelSizeMicrons: 3.76, focuserStepMicrons: 3.6);
+
+            Assert.Multiple(() => {
+                Assert.That(vm.IsTrustCalibrationPending, Is.False);
+                // The banner is back to its arm state: device-linked but not reliable still blocks automation.
+                Assert.That(vm.AutomationTrustBannerVisible, Is.True);
             });
         }
 

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/TiltAdapterWizard/TiltAdapterWizardVMTests.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/TiltAdapterWizard/TiltAdapterWizardVMTests.cs
@@ -94,13 +94,18 @@ namespace NINA.Joko.Plugins.HocusFocus.Tests.TiltAdapterWizard {
         // (4) onto the substitute -- and an NSubstitute property SET does feed its getter -- so a 3-screw stub
         // would leave ScrewCount(4) != CalibratedScrewCount(3) and IsCalibrationValid false, silently hiding
         // the banner for a reason that has nothing to do with automation trust.
+        //
+        // manual defaults TRUE because the Trust banner is about a HAND-ENTERED calibration specifically; pass
+        // false for the device-driven/replay states that also lack the automation markers but must NOT be
+        // offered a Trust button.
         private static (TiltAdapterWizardVM vm, ITiltAdapterOptions options) BuildCalibrated(
             string deviceName = MotorizedPreset, string linkedDevice = "", bool reliable = false,
-            IProfileService profileService = null) {
+            bool manual = true, IProfileService profileService = null) {
             var (vm, options, _, _) = Build(screwCount: 4, profileService: profileService, configureOptions: o => {
                 o.DeviceName.Returns(deviceName);
                 o.IsCalibrated.Returns(true);
                 o.CalibratedScrewCount.Returns(4);
+                o.CalibrationIsManual.Returns(manual);
                 o.DeviceLinkedCalibrationDeviceName.Returns(linkedDevice);
                 o.CalibrationIsReliable.Returns(reliable);
             });
@@ -3824,8 +3829,9 @@ namespace NINA.Joko.Plugins.HocusFocus.Tests.TiltAdapterWizard {
 
             Assert.Multiple(() => {
                 Assert.That(vm.IsTrustCalibrationPending, Is.False);
-                // The banner is back to its arm state: device-linked but not reliable still blocks automation.
-                Assert.That(vm.AutomationTrustBannerVisible, Is.True);
+                // And NO Trust button afterwards: the run cleared CalibrationIsManual, and a low-confidence
+                // calibration is not something the banner's screw-numbering check could validate anyway.
+                Assert.That(vm.AutomationTrustBannerVisible, Is.False);
             });
         }
 
@@ -3890,6 +3896,26 @@ namespace NINA.Joko.Plugins.HocusFocus.Tests.TiltAdapterWizard {
                 calibrationIsReliable: options.CalibrationIsReliable,
                 hasNumericGuidance: true, isOperationActive: false,
                 currentGeneration: 2, lastExecutedGeneration: 1), Is.EqualTo(expected));
+        }
+
+        [Test]
+        public void AutomationTrustBanner_IsHiddenForADeviceDrivenLowConfidenceCalibration() {
+            // [CRITICAL GATE] Device-linked but not reliable, and NOT hand-entered (RunCalibrationMath writes
+            // CalibrationIsManual = false). Trust writes CalibrationIsReliable = true, which overrides the
+            // noise-vs-signal quality check -- and the banner's verification ("move one screw, watch which
+            // corner moves") cannot detect a noise-dominated calibration, which has correct screw numbering and
+            // wrong angles. The remedy for this state is re-running the calibration, not trusting it.
+            var (vm, _) = BuildCalibrated(linkedDevice: MotorizedPreset, reliable: false, manual: false);
+            Assert.That(vm.AutomationTrustBannerVisible, Is.False);
+        }
+
+        [Test]
+        public void AutomationTrustBanner_IsHiddenForAReplayedCalibration() {
+            // A replay clears the device link (not a connected run) and CalibrationIsManual -- so it lands in
+            // the same not-automatable state as a hand entry, but "entered or edited by hand" would be false.
+            var (vm, _) = BuildCalibrated(linkedDevice: "", reliable: true, manual: false);
+            Assert.That(vm.AutomationTrustBannerVisible, Is.False,
+                "the banner asserts hand-entry; a replay is not hand-entry");
         }
 
         [Test]

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/TiltAdapterWizard/TiltAdapterWizardVMTests.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/TiltAdapterWizard/TiltAdapterWizardVMTests.cs
@@ -685,16 +685,46 @@ namespace NINA.Joko.Plugins.HocusFocus.Tests.TiltAdapterWizard {
             });
         }
 
-        [TestCase(WizardStep.Baseline, "Baseline Measurement")]
-        [TestCase(WizardStep.AllInward, "All Screws Inward")]
-        [TestCase(WizardStep.ReBaseline1, "Return to Baseline")]
-        [TestCase(WizardStep.Screw1, "Move Screw 1")]
-        [TestCase(WizardStep.ReBaseline2, "Return to Baseline")]
-        [TestCase(WizardStep.Screw2, "Move Screw 2")]
-        [TestCase(WizardStep.Complete, "Calibration Complete")]
-        [TestCase(WizardStep.ReBaseline3, "Return to Baseline")]
-        public void StepTitleText_IsShortPerStepHeader(WizardStep step, string expected) {
-            Assert.That(TiltAdapterWizardVM.StepTitleText(step), Is.EqualTo(expected));
+        [TestCase(WizardStep.Baseline, false, "Baseline Measurement")]
+        [TestCase(WizardStep.AllInward, false, "All Screws Clockwise")]
+        [TestCase(WizardStep.AllInward, true, "All Motors + Steps")]
+        [TestCase(WizardStep.ReBaseline1, false, "Return to Baseline")]
+        [TestCase(WizardStep.Screw1, false, "Move Screw 1")]
+        [TestCase(WizardStep.ReBaseline2, false, "Return to Baseline")]
+        [TestCase(WizardStep.Screw2, false, "Move Screw 2")]
+        [TestCase(WizardStep.Complete, false, "Calibration Complete")]
+        [TestCase(WizardStep.ReBaseline3, false, "Return to Baseline")]
+        public void StepTitleText_IsShortPerStepHeader(WizardStep step, bool isStepper, string expected) {
+            Assert.That(TiltAdapterWizardVM.StepTitleText(step, isStepper: isStepper), Is.EqualTo(expected));
+        }
+
+        // The wizard reserves "inward"/"outward" for ADAPTER-PLATE motion; screw and motor moves are worded
+        // clockwise/counter-clockwise or as signed steps. A step titled "All Screws Inward" while the device
+        // applies +N to every motor is what made a correct move look like a bug — and "+N is inward" is not
+        // something the wizard knows, it is what this very step measures.
+        [Test]
+        public void NoUserFacingMoveWording_ClaimsInwardOrOutward() {
+            var offenders = new List<string>();
+            foreach (var step in Enum.GetValues<WizardStep>()) {
+                foreach (var isStepper in new[] { false, true }) {
+                    foreach (var screwCount in new[] { 3, 4 }) {
+                        offenders.AddRange(new[] {
+                            TiltAdapterWizardVM.StepTitleText(step, null, isStepper),
+                            TiltAdapterWizardVM.StepInstructionsText(step, screwCount, isStepper, 1.0),
+                            TiltAdapterWizardVM.BaselineRecoveryText(step, screwCount, isStepper, 1.0),
+                        }.Where(t => t != null &&
+                            (t.IndexOf("inward", StringComparison.OrdinalIgnoreCase) >= 0 ||
+                             t.IndexOf("outward", StringComparison.OrdinalIgnoreCase) >= 0)));
+                    }
+                }
+                var move = EatWizardMapping.MoveForStep(step, 150);
+                if (move?.Description != null &&
+                    (move.Description.IndexOf("inward", StringComparison.OrdinalIgnoreCase) >= 0 ||
+                     move.Description.IndexOf("outward", StringComparison.OrdinalIgnoreCase) >= 0)) {
+                    offenders.Add(move.Description);
+                }
+            }
+            Assert.That(offenders, Is.Empty, "user-facing move wording must not claim a direction the wizard has not measured");
         }
 
         [Test]

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/TiltAdapterWizard/TiltAdapterWizardVMTests.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/TiltAdapterWizard/TiltAdapterWizardVMTests.cs
@@ -701,14 +701,14 @@ namespace NINA.Joko.Plugins.HocusFocus.Tests.TiltAdapterWizard {
         public void StepTitleText_UsesTheScrewName() {
             var eat = TiltScrewLabels.ForScheme(ScrewLabelScheme.AsgEat);
             Assert.Multiple(() => {
-                Assert.That(TiltAdapterWizardVM.StepTitleText(WizardStep.Screw1, eat), Is.EqualTo("Move M1"));
-                Assert.That(TiltAdapterWizardVM.StepTitleText(WizardStep.Screw2, eat), Is.EqualTo("Move M2"));
+                Assert.That(TiltAdapterWizardVM.StepTitleText(WizardStep.Screw1, eat, false), Is.EqualTo("Move M1"));
+                Assert.That(TiltAdapterWizardVM.StepTitleText(WizardStep.Screw2, eat, false), Is.EqualTo("Move M2"));
             });
         }
 
         [TestCase(WizardStep.Baseline, false, "Baseline Measurement")]
         [TestCase(WizardStep.AllInward, false, "All Screws Clockwise")]
-        [TestCase(WizardStep.AllInward, true, "All Motors + Steps")]
+        [TestCase(WizardStep.AllInward, true, "All Motors Positive Steps")]
         [TestCase(WizardStep.ReBaseline1, false, "Return to Baseline")]
         [TestCase(WizardStep.Screw1, false, "Move Screw 1")]
         [TestCase(WizardStep.ReBaseline2, false, "Return to Baseline")]
@@ -716,7 +716,7 @@ namespace NINA.Joko.Plugins.HocusFocus.Tests.TiltAdapterWizard {
         [TestCase(WizardStep.Complete, false, "Calibration Complete")]
         [TestCase(WizardStep.ReBaseline3, false, "Return to Baseline")]
         public void StepTitleText_IsShortPerStepHeader(WizardStep step, bool isStepper, string expected) {
-            Assert.That(TiltAdapterWizardVM.StepTitleText(step, isStepper: isStepper), Is.EqualTo(expected));
+            Assert.That(TiltAdapterWizardVM.StepTitleText(step, null, isStepper), Is.EqualTo(expected));
         }
 
         // The wizard reserves "inward"/"outward" for ADAPTER-PLATE motion; screw and motor moves are worded
@@ -733,6 +733,17 @@ namespace NINA.Joko.Plugins.HocusFocus.Tests.TiltAdapterWizard {
                             TiltAdapterWizardVM.StepTitleText(step, null, isStepper),
                             TiltAdapterWizardVM.StepInstructionsText(step, screwCount, isStepper, 1.0),
                             TiltAdapterWizardVM.BaselineRecoveryText(step, screwCount, isStepper, 1.0),
+                        }.Where(t => t != null &&
+                            (t.IndexOf("inward", StringComparison.OrdinalIgnoreCase) >= 0 ||
+                             t.IndexOf("outward", StringComparison.OrdinalIgnoreCase) >= 0)));
+                    }
+                }
+                // DeviceStepInstructionsText is the wording actually shown for a connected motorized run — it
+                // must be in the sweep, not merely safe transitively via StepInstructionsText.
+                foreach (var autoRunning in new[] { false, true }) {
+                    foreach (var measuredFinalRebaseline in new[] { false, true }) {
+                        offenders.AddRange(new[] {
+                            TiltAdapterWizardVM.DeviceStepInstructionsText(step, 150, autoRunning, measuredFinalRebaseline),
                         }.Where(t => t != null &&
                             (t.IndexOf("inward", StringComparison.OrdinalIgnoreCase) >= 0 ||
                              t.IndexOf("outward", StringComparison.OrdinalIgnoreCase) >= 0)));
@@ -2758,18 +2769,86 @@ namespace NINA.Joko.Plugins.HocusFocus.Tests.TiltAdapterWizard {
                         "Step 1 of 6", "Step 2 of 6", "Step 3 of 6", "Step 4 of 6", "Step 5 of 6", "Step 6 of 6" }));
                     // The title must track the step too -- same root cause, separately visible to the user.
                     Assert.That(observed.Select(o => o.title),
-                        Is.EqualTo(steps.Select(s => TiltAdapterWizardVM.StepTitleText(s))));
+                        Is.EqualTo(steps.Select(s => TiltAdapterWizardVM.StepTitleText(s, null, false))));
                     // Status text uses the human step title, not the raw enum name.
                     Assert.That(observed.Select(o => o.status),
-                        Is.EqualTo(steps.Select(s => $"Replaying {TiltAdapterWizardVM.StepTitleText(s)}...")));
+                        Is.EqualTo(steps.Select(s => $"Replaying {TiltAdapterWizardVM.StepTitleText(s, null, false)}...")));
                     // A replay re-analyzes saved frames: the instruction paragraph must not tell the user to turn
                     // screws or click a button that is collapsed for the whole replay.
                     Assert.That(observed.Select(o => o.instructions),
-                        Is.EqualTo(steps.Select(s => TiltAdapterWizardVM.ReplayStepInstructionsText(s))));
+                        Is.EqualTo(steps.Select(s => TiltAdapterWizardVM.ReplayStepInstructionsText(s, null, false))));
                     Assert.That(observed.Select(o => o.instructions),
                         Has.None.Contains("Run Measurement").And.None.Contains("CLOCKWISE"));
                     // The replay flag is transient: it must be cleared once the replay finishes.
                     Assert.That(vm.IsReplaying, Is.False);
+                });
+            } finally {
+                System.IO.Directory.Delete(runRoot, recursive: true);
+            }
+        }
+
+        // CRITICAL regression (code review of Task 8): the bold StepTitle header and the StatusText line
+        // directly below it are both derived from StepTitleText, but ReplayAsync's StatusText assignment
+        // used to omit isStepper -- silently defaulting to false. On a stepper rig replaying a saved run,
+        // StepTitle correctly read "All Motors Positive Steps" while StatusText, on screen at the same
+        // time, read "Replaying All Screws Clockwise...": title and status visibly disagreeing about the
+        // rig's own adjustment type. The previous test (screw rig, isStepper defaults to false on both
+        // sides) could never have caught this -- it passed by coincidence. This test forces a stepper rig
+        // and asserts title and status agree.
+        [Test]
+        public void ReplayAsync_OnStepperRig_TitleAndStatusAgreeOnAdjustmentType() {
+            var (vm, _, _, _) = Build(screwCount: 3, configureOptions: o => {
+                o.MeasureCurvatureDuringCalibration.Returns(true);
+                o.AdjustmentType.Returns(TiltAdjustmentType.StepperMotors);
+            });
+
+            string runRoot = System.IO.Path.Combine(System.IO.Path.GetTempPath(), "hf-tilt-replay-stepper-test-" + Guid.NewGuid().ToString("N"));
+            var stepFolders = new[] { "01_Baseline", "02_AllInward", "03_ReBaseline1", "04_Screw1", "05_ReBaseline2", "06_Screw2" };
+            var steps = new[] { WizardStep.Baseline, WizardStep.AllInward, WizardStep.ReBaseline1, WizardStep.Screw1, WizardStep.ReBaseline2, WizardStep.Screw2 };
+            System.IO.Directory.CreateDirectory(runRoot);
+            try {
+                foreach (var stepFolder in stepFolders) {
+                    System.IO.Directory.CreateDirectory(System.IO.Path.Combine(runRoot, stepFolder));
+                }
+                var metadata = new TiltCalibrationMetadata {
+                    NumberOfScrews = 3,
+                    PixelSizeMicrons = 3.76,
+                    FocuserStepSizeMicrons = 3.6,
+                    ScrewRadiusMillimeters = 44,
+                    CalibrationAppliedAmount = 1.0,
+                    RunStepMapping = steps.Select((s, i) => new TiltRunStepMapping { Step = s.ToString(), Folder = stepFolders[i] }).ToList()
+                };
+                System.IO.File.WriteAllText(System.IO.Path.Combine(runRoot, "metadata.json"), metadata.Serialize());
+
+                var tiltPlane = new TiltPlaneModel(new System.Drawing.Size(6248, 4176), fRatio: 7,
+                    a: 0.1, b: 0.05, c: 0, mean: 7000, focuserStepSizeMicrons: 3.6,
+                    centerPosition: 7000, topLeftPosition: 7000, topRightPosition: 7000,
+                    bottomLeftPosition: 7000, bottomRightPosition: 7000);
+                vm.CalibrationTiltPlaneOverrideForTest = tiltPlane;
+                vm.SelectReplayFolderForTest = _ => runRoot;
+                vm.SelectReplaySettingsForTest = _ => Task.FromResult(ReplaySettingsChoice.UseCurrentSettings);
+
+                var observed = new List<(WizardStep step, string title, string status)>();
+                vm.ReplayStepOverrideForTest = (step, ct) => {
+                    observed.Add((step, vm.StepTitle, vm.StatusText));
+                    return Task.FromResult(true);
+                };
+
+                ((AsyncRelayCommand)vm.ReplayCommand).ExecuteAsync(null).GetAwaiter().GetResult();
+
+                Assert.Multiple(() => {
+                    Assert.That(vm.IsComplete, Is.True, "precondition: the replay actually ran to completion");
+                    // The AllInward step is where the two used to disagree: the title said stepper wording,
+                    // the status line said screw wording, for the same rig at the same instant.
+                    var allInward = observed.Single(o => o.step == WizardStep.AllInward);
+                    Assert.That(allInward.title, Is.EqualTo("All Motors Positive Steps"));
+                    Assert.That(allInward.status, Is.EqualTo("Replaying All Motors Positive Steps..."));
+                    Assert.That(allInward.status, Does.Not.Contain("Clockwise"), "status must not show screw wording on a stepper rig");
+                    // Every step, not just AllInward: the status line's embedded title must always equal the
+                    // bold title shown above it, whatever the rig.
+                    foreach (var o in observed) {
+                        Assert.That(o.status, Is.EqualTo($"Replaying {o.title}..."), $"title/status must agree for {o.step}");
+                    }
                 });
             } finally {
                 System.IO.Directory.Delete(runRoot, recursive: true);

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/TiltAdapterWizard/TiltAdapterWizardVMTests.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/TiltAdapterWizard/TiltAdapterWizardVMTests.cs
@@ -95,8 +95,9 @@ namespace NINA.Joko.Plugins.HocusFocus.Tests.TiltAdapterWizard {
         // would leave ScrewCount(4) != CalibratedScrewCount(3) and IsCalibrationValid false, silently hiding
         // the banner for a reason that has nothing to do with automation trust.
         private static (TiltAdapterWizardVM vm, ITiltAdapterOptions options) BuildCalibrated(
-            string deviceName = MotorizedPreset, string linkedDevice = "", bool reliable = false) {
-            var (vm, options, _, _) = Build(screwCount: 4, configureOptions: o => {
+            string deviceName = MotorizedPreset, string linkedDevice = "", bool reliable = false,
+            IProfileService profileService = null) {
+            var (vm, options, _, _) = Build(screwCount: 4, profileService: profileService, configureOptions: o => {
                 o.DeviceName.Returns(deviceName);
                 o.IsCalibrated.Returns(true);
                 o.CalibratedScrewCount.Returns(4);
@@ -3826,6 +3827,69 @@ namespace NINA.Joko.Plugins.HocusFocus.Tests.TiltAdapterWizard {
                 // The banner is back to its arm state: device-linked but not reliable still blocks automation.
                 Assert.That(vm.AutomationTrustBannerVisible, Is.True);
             });
+        }
+
+        [Test]
+        public void SwitchingProfiles_DisarmsAPendingTrustConfirmation() {
+            // [CRITICAL GATE] TiltAdapterOptions' own ProfileChanged reload raises one broadcast (null-name)
+            // PropertyChanged that the VM's named-property handler never matches, so the VM re-raises its
+            // derived properties in its ProfileChanged handler instead. An armed confirmation left standing
+            // there would end up describing a DIFFERENT profile's calibration.
+            var profileService = Substitute.For<IProfileService>();
+            var (vm, _) = BuildCalibrated(profileService: profileService);
+            vm.TrustCalibrationCommand.Execute(null);
+            Assert.That(vm.IsTrustCalibrationPending, Is.True, "precondition: armed");
+
+            var raised = new List<string>();
+            vm.PropertyChanged += (_, e) => raised.Add(e.PropertyName);
+            profileService.ProfileChanged += Raise.Event<EventHandler>(profileService, EventArgs.Empty);
+
+            Assert.Multiple(() => {
+                Assert.That(vm.IsTrustCalibrationPending, Is.False);
+                Assert.That(raised, Does.Contain(nameof(TiltAdapterWizardVM.AutomationTrustBannerVisible)),
+                    "the banner must re-read the new profile's calibration, not keep showing the old one's");
+            });
+        }
+
+        [Test]
+        public void ConfirmTrustCalibration_WithTheBannerHidden_WritesNothing() {
+            // The button lives inside the collapsed banner Border, but this write unlocks unattended hardware
+            // motion -- it must not rest on a XAML binding alone.
+            var (vm, options) = BuildCalibrated(deviceName: TiltAdapterDevicePreset.ManualName);
+            Assert.That(vm.AutomationTrustBannerVisible, Is.False, "precondition: nothing to trust");
+            options.ClearReceivedCalls();
+
+            vm.TrustCalibrationCommand.Execute(null);
+            vm.ConfirmTrustCalibrationCommand.Execute(null);
+
+            Assert.Multiple(() => {
+                Assert.That(vm.IsTrustCalibrationPending, Is.False);
+                options.DidNotReceive().DeviceLinkedCalibrationDeviceName = Arg.Any<string>();
+                options.DidNotReceive().CalibrationIsReliable = Arg.Any<bool>();
+            });
+        }
+
+        // [CRITICAL GATE] The warning fires only when automation was genuinely available, which is the SAME
+        // conjunction InspectorVM.CanExecuteAutomaticAdjustment requires -- not either half on its own.
+        [TestCase(true, true, true, TestName = "ManualEntryRevokesAutomation_LinkedAndReliable_Revokes")]
+        [TestCase(false, true, false, TestName = "ManualEntryRevokesAutomation_ReliableButNeverLinked_RevokesNothing")]
+        [TestCase(true, false, false, TestName = "ManualEntryRevokesAutomation_LinkedButUnreliable_RevokesNothing")]
+        [TestCase(false, false, false, TestName = "ManualEntryRevokesAutomation_NeitherMarker_RevokesNothing")]
+        public void ManualEntryRevokesAutomation_MirrorsTheAutomationGateExactly(
+                bool linked, bool reliable, bool expected) {
+            var options = Substitute.For<ITiltAdapterOptions>();
+            options.DeviceName.Returns(MotorizedPreset);
+            options.DeviceLinkedCalibrationDeviceName.Returns(linked ? MotorizedPreset : string.Empty);
+            options.CalibrationIsReliable.Returns(reliable);
+
+            Assert.That(TiltAdapterWizardVM.ManualEntryRevokesAutomation(options), Is.EqualTo(expected));
+            // Whatever the warning claims must match what the gate actually permits.
+            Assert.That(InspectorVM.CanExecuteAutomaticAdjustment(
+                serviceConnected: true, controllerAvailable: true,
+                deviceLinked: InspectorVM.IsCalibrationDeviceLinked(options),
+                calibrationIsReliable: options.CalibrationIsReliable,
+                hasNumericGuidance: true, isOperationActive: false,
+                currentGeneration: 2, lastExecutedGeneration: 1), Is.EqualTo(expected));
         }
 
         [Test]

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/AutoFocus/DataTemplates.xaml
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/AutoFocus/DataTemplates.xaml
@@ -150,7 +150,7 @@
                         Style="{StaticResource StandardButton}"
                         ToolTip="Resets the idle timer and keeps the device connected."
                         AutomationProperties.Name="Keep the tilt adapter connected">
-                        <TextBlock Margin="6,2" Text="Stay connected" />
+                        <TextBlock Margin="6,2" Foreground="{StaticResource ButtonForegroundBrush}" Text="Stay connected" />
                     </Button>
                 </WrapPanel>
             </StackPanel>
@@ -721,7 +721,7 @@
                     VerticalAlignment="Center"
                     Command="{Binding ReviewFramesCommand}"
                     ToolTip="Open the Review Frames window to inspect each frame of the last auto-focus run started from this pane (a live run or a Replay Saved AF) — its detected stars with the Hocus Focus Star Annotator's bounds, per-star text, rejection-reason and ROI boxes, plus per-frame HFR statistics. Enabled after such a run completes with &quot;Keep frames for review&quot; turned on.">
-                    <TextBlock Margin="5,0,5,0" Text="Review Frames" />
+                    <TextBlock Margin="5,0,5,0" Foreground="{StaticResource ButtonForegroundBrush}" Text="Review Frames" />
                 </Button>
                 <StackPanel
                     VerticalAlignment="Center"
@@ -3364,7 +3364,7 @@
                                     HorizontalAlignment="Left"
                                     Command="{Binding AutomaticAdjustmentCommand}"
                                     ToolTip="Computes a move plan from this measurement's fitted sensor model, shows an approval dialog listing the exact device commands, and executes it on the connected tilt-adapter device. Disabled until a fresh measurement is available to adjust from, or if the current calibration is not linked to the connected device.">
-                                    <TextBlock Margin="5,0,5,0" Text="Automatic Adjustment" />
+                                    <TextBlock Margin="5,0,5,0" Foreground="{StaticResource ButtonForegroundBrush}" Text="Automatic Adjustment" />
                                 </Button>
                                 <TextBlock
                                     Margin="0,4,0,0"

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/AutoFocus/DataTemplates.xaml
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/AutoFocus/DataTemplates.xaml
@@ -132,7 +132,7 @@
                     MaxWidth="420"
                     HorizontalAlignment="Left"
                     FontWeight="Bold"
-                    Foreground="{StaticResource NotificationWarningTextBrush}"
+                    Foreground="{StaticResource HF_AlertWarningTextBrush}"
                     Text="{Binding HeadlineText}"
                     TextWrapping="Wrap" />
                 <TextBlock
@@ -140,7 +140,7 @@
                     Margin="0,2,0,0"
                     HorizontalAlignment="Left"
                     FontSize="10"
-                    Foreground="{StaticResource NotificationWarningTextBrush}"
+                    Foreground="{StaticResource HF_AlertWarningTextBrush}"
                     Text="{Binding DetailText}"
                     TextWrapping="Wrap" />
                 <WrapPanel Margin="0,4,0,0">
@@ -1842,7 +1842,7 @@
                                 HorizontalAlignment="Left"
                                 VerticalAlignment="Center"
                                 FontStyle="Italic"
-                                Foreground="{StaticResource NotificationWarningBrush}"
+                                Foreground="{StaticResource HF_AlertWarningAccentBrush}"
                                 Text="⚠ differs from the focuser driver"
                                 ToolTip="{StaticResource FocuserStepSizeMismatch_Tooltip}"
                                 Visibility="{Binding InspectorOptions.HasFocuserStepSizeMismatch, Converter={StaticResource BooleanToVisibilityCollapsedConverter}}" />
@@ -2978,7 +2978,7 @@
                                     MaxWidth="520"
                                     HorizontalAlignment="Left"
                                     FontWeight="Bold"
-                                    Foreground="{StaticResource NotificationErrorBrush}"
+                                    Foreground="{StaticResource HF_AlertErrorAccentBrush}"
                                     Text="Tilt got worse after the last adjustment"
                                     TextWrapping="Wrap" />
                                 <TextBlock
@@ -3034,7 +3034,7 @@
                                 Margin="5,4,5,2"
                                 HorizontalAlignment="Left"
                                 FontStyle="Italic"
-                                Foreground="{StaticResource NotificationWarningBrush}"
+                                Foreground="{StaticResource HF_AlertWarningAccentBrush}"
                                 Text="{Binding ViewingPastRunNotice}"
                                 TextWrapping="Wrap"
                                 Visibility="{Binding HasViewingPastRunNotice, Converter={StaticResource BooleanToVisibilityCollapsedConverter}}" />
@@ -3370,7 +3370,7 @@
                                     Margin="0,4,0,0"
                                     FontStyle="Italic"
                                     TextWrapping="Wrap"
-                                    Foreground="{StaticResource NotificationWarningBrush}"
+                                    Foreground="{StaticResource HF_AlertWarningAccentBrush}"
                                     Text="{Binding AutomaticAdjustmentRemediationText}"
                                     Visibility="{Binding AutomaticAdjustmentRemediationVisible, Converter={StaticResource BooleanToVisibilityCollapsedConverter}}" />
                             </StackPanel>

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/AutoFocus/DataTemplates.xaml
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/AutoFocus/DataTemplates.xaml
@@ -123,9 +123,7 @@
     <DataTemplate DataType="{x:Type tiltdevices:TiltDeviceIdleCountdownVM}">
         <Border
             Margin="0,4,0,4"
-            Padding="6,4"
-            Background="{StaticResource NotificationWarningBrush}"
-            CornerRadius="3"
+            Style="{StaticResource HF_AlertWarningBadge}"
             Visibility="{Binding IsVisible, Converter={StaticResource BooleanToVisibilityCollapsedConverter}}">
             <StackPanel>
                 <TextBlock

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/AutoFocus/InspectorVM.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/AutoFocus/InspectorVM.cs
@@ -2499,10 +2499,24 @@ namespace NINA.Joko.Plugins.HocusFocus.AutoFocus {
             IsTiltDeviceConnected &&
             (!IsCalibrationDeviceLinked(tiltAdapterOptions) || !(tiltAdapterOptions?.CalibrationIsReliable ?? false));
 
-        public string AutomaticAdjustmentRemediationText =>
-            !IsCalibrationDeviceLinked(tiltAdapterOptions)
-                ? "This calibration is not linked to the connected device. Re-run calibration with the device connected."
-                : "This calibration is low-confidence (it did not pass quality validation). Re-run calibration to enable Automatic Adjustment.";
+        public string AutomaticAdjustmentRemediationText => AutomaticAdjustmentRemediationTextFor(tiltAdapterOptions);
+
+        /// <summary>
+        /// Pure form of <see cref="AutomaticAdjustmentRemediationText"/>, so the wording is unit-testable
+        /// without a live VM. Names MANUAL ENTRY explicitly when that is the cause: the previous copy said only
+        /// "not linked to the connected device", which is true but gave a user who had just corrected an angle
+        /// by hand no way to connect the message to what they did, and no remedy but a full re-run.
+        /// </summary>
+        internal static string AutomaticAdjustmentRemediationTextFor(ITiltAdapterOptions options) {
+            if (!IsCalibrationDeviceLinked(options)) {
+                return (options?.CalibrationIsManual ?? false)
+                    ? "This calibration was entered by hand, so Automatic Adjustment is disabled — HocusFocus can't " +
+                      "confirm your screw numbering matches the device's motor wiring. Re-run calibration with the " +
+                      "device connected, or trust it explicitly in the Tilt Adapter Wizard."
+                    : "This calibration is not linked to the connected device. Re-run calibration with the device connected.";
+            }
+            return "This calibration is low-confidence (it did not pass quality validation). Re-run calibration to enable Automatic Adjustment.";
+        }
 
         /// <summary>
         /// [CRITICAL GATE] True only when the stored calibration was produced by a completed, connected

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/AutoFocus/InspectorVM.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/AutoFocus/InspectorVM.cs
@@ -2510,7 +2510,7 @@ namespace NINA.Joko.Plugins.HocusFocus.AutoFocus {
         internal static string AutomaticAdjustmentRemediationTextFor(ITiltAdapterOptions options) {
             if (!IsCalibrationDeviceLinked(options)) {
                 return (options?.CalibrationIsManual ?? false)
-                    ? "This calibration was entered by hand, so Automatic Adjustment is disabled — HocusFocus can't " +
+                    ? "This calibration was entered or edited by hand, so Automatic Adjustment is disabled — HocusFocus can't " +
                       "confirm your screw numbering matches the device's motor wiring. Re-run calibration with the " +
                       "device connected, or trust it explicitly in the Tilt Adapter Wizard."
                     : "This calibration is not linked to the connected device. Re-run calibration with the device connected.";

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/AutoFocus/Replay/ReplaySettingsPromptControl.xaml
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/AutoFocus/Replay/ReplaySettingsPromptControl.xaml
@@ -132,7 +132,7 @@
             HorizontalAlignment="Right"
             Orientation="Horizontal">
             <Button MinWidth="90" Command="{Binding CloseCommand}">
-                <TextBlock Margin="12,6" Text="Cancel" />
+                <TextBlock Margin="12,6" Foreground="{StaticResource ButtonForegroundBrush}" Text="Cancel" />
             </Button>
         </StackPanel>
     </Grid>

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/CameraSimulator/TiltAdapter/SimulatedTiltAdapterVM.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/CameraSimulator/TiltAdapter/SimulatedTiltAdapterVM.cs
@@ -935,6 +935,11 @@ namespace NINA.Joko.Plugins.HocusFocus.CameraSimulator.TiltAdapter {
             realAdapter.IsCalibrated = true;
             realAdapter.ScrewInwardCurvatureSignIsMeasured = false;
             realAdapter.CalibrationIsManual = true;
+            // [CRITICAL GATE] Same clears the wizard's manual-entry path makes. Setting DeviceName to Manual
+            // above already breaks IsCalibrationDeviceLinked implicitly, but leaving a stale device name in the
+            // marker is exactly the kind of thing that survives a later preset change.
+            realAdapter.DeviceLinkedCalibrationDeviceName = string.Empty;
+            realAdapter.CalibrationIsReliable = false;
             // Retire the previous adapter's wizard measurements, so the inspector's pitch-mismatch warning cannot
             // compare the values we just wrote against a stale measurement (the manual-entry path does the same).
             realAdapter.LastMeasuredThreadPitchMicrons = -1;

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/CameraSimulator/TiltAdapter/SimulatedTiltAdapterVM.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/CameraSimulator/TiltAdapter/SimulatedTiltAdapterVM.cs
@@ -11,6 +11,7 @@
 #endregion "copyright"
 
 using NINA.Core.Utility;
+using NINA.Core.Utility.Notification;
 using NINA.Joko.Plugins.HocusFocus.CameraSimulator.Sensors;
 using NINA.Joko.Plugins.HocusFocus.Interfaces;
 using NINA.Joko.Plugins.HocusFocus.TiltAdapterDevices.Manual;
@@ -166,7 +167,13 @@ namespace NINA.Joko.Plugins.HocusFocus.CameraSimulator.TiltAdapter {
             ZeroAberrationsCommand = new RelayCommand(ZeroAberrations);
             EnableAberrationsCommand = new RelayCommand(() => options.EnableAberrations = true);
             CopyFromAdapterCommand = new RelayCommand(CopyFromAdapter, () => CanCopyAdapterSettings);
-            CopyToAdapterCommand = new RelayCommand(() => IsCopyToAdapterPending = true, () => CanCopyAdapterSettings);
+            CopyToAdapterCommand = new RelayCommand(() => {
+                // The text is conditional on the real adapter's automation markers, which change underneath this
+                // VM -- re-read it every time the confirmation is armed rather than trusting a one-time binding
+                // evaluation.
+                RaisePropertyChanged(nameof(CopyToAdapterConfirmText));
+                IsCopyToAdapterPending = true;
+            }, () => CanCopyAdapterSettings);
             ConfirmCopyToAdapterCommand = new RelayCommand(ConfirmCopyToAdapter);
             CancelCopyToAdapterCommand = new RelayCommand(() => IsCopyToAdapterPending = false);
 
@@ -641,11 +648,20 @@ namespace NINA.Joko.Plugins.HocusFocus.CameraSimulator.TiltAdapter {
             }
         }
 
-        /// <summary>Names exactly what the copy overwrites — this is real, hand-measured calibration.</summary>
+        /// <summary>
+        /// Names exactly what the copy overwrites — this is real, hand-measured calibration. The automation
+        /// sentence appears only when automation was genuinely available: the marker clears below are
+        /// unconditional, but announcing the loss of something already unavailable is the same false claim the
+        /// wizard's manual-entry warning avoids.
+        /// </summary>
         public string CopyToAdapterConfirmText =>
             "Overwrite the real tilt adapter settings — screw count, screw angles, adapter direction, adjustment type, " +
             $"{(IsStepper ? "stepper step size" : "thread pitch")} and screw radius — with this simulated adapter's values? " +
-            "The result is marked as a manual calibration.";
+            "The result is marked as a manual calibration." +
+            (TiltAdapterWizardVM.ManualEntryRevokesAutomation(realAdapter)
+                ? " Automatic Adjustment will be disabled: a hand-made calibration can't be checked against the " +
+                  "device's motor wiring. Re-run calibration with the device connected to re-enable it."
+                : string.Empty);
 
         // ---- Turning ---------------------------------------------------------------------------------
 
@@ -917,6 +933,11 @@ namespace NINA.Joko.Plugins.HocusFocus.CameraSimulator.TiltAdapter {
             IsCopyToAdapterPending = false;
             if (realAdapter == null) return;
 
+            // Captured BEFORE ANY write below -- in particular before DeviceName becomes "Manual", which by
+            // itself makes IsCalibrationDeviceLinked false and would make this always report "nothing revoked".
+            // Same test, and the same message, as TiltAdapterWizardVM's manual-entry path.
+            bool revokedAutomation = TiltAdapterWizardVM.ManualEntryRevokesAutomation(realAdapter);
+
             realAdapter.ScrewCount = ScrewCount;
             realAdapter.Screw1AngleDegrees = options.SimScrew1AngleDegrees;
             realAdapter.Screw2AngleDegrees = options.SimScrew2AngleDegrees;
@@ -945,6 +966,11 @@ namespace NINA.Joko.Plugins.HocusFocus.CameraSimulator.TiltAdapter {
             realAdapter.LastMeasuredThreadPitchMicrons = -1;
             realAdapter.LastMeasuredStepperStepSizeMicrons = -1;
 
+            if (revokedAutomation) {
+                Notification.ShowWarning(
+                    "Automatic Adjustment is now disabled: a hand-made calibration can't be checked against the " +
+                    "device's motor wiring. Re-run calibration with the device connected to re-enable it.");
+            }
             RaiseCoherenceChanged();
         }
 

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/CameraSimulator/TiltAdapter/TiltAdapterDataTemplates.xaml
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/CameraSimulator/TiltAdapter/TiltAdapterDataTemplates.xaml
@@ -208,14 +208,14 @@
                     Command="{Binding CopyFromAdapterCommand}"
                     Style="{StaticResource StandardButton}"
                     ToolTip="Replaces this simulated adapter's geometry with the real tilt-adapter settings. Does not touch the real settings.">
-                    <TextBlock Margin="6,2" Text="Copy from adapter settings" />
+                    <TextBlock Margin="6,2" Foreground="{StaticResource ButtonForegroundBrush}" Text="Copy from adapter settings" />
                 </Button>
                 <Button
                     Margin="6,0,0,0"
                     Command="{Binding CopyToAdapterCommand}"
                     Style="{StaticResource StandardButton}"
                     ToolTip="Overwrites the real tilt-adapter calibration with this simulated adapter's geometry. Asks for confirmation first.">
-                    <TextBlock Margin="6,2" Text="Copy to adapter settings…" />
+                    <TextBlock Margin="6,2" Foreground="{StaticResource ButtonForegroundBrush}" Text="Copy to adapter settings…" />
                 </Button>
             </WrapPanel>
 
@@ -236,13 +236,13 @@
                         TextWrapping="Wrap" />
                     <WrapPanel Margin="0,4,0,0">
                         <Button Command="{Binding ConfirmCopyToAdapterCommand}" Style="{StaticResource StandardButton}">
-                            <TextBlock Margin="6,2" Text="Overwrite" />
+                            <TextBlock Margin="6,2" Foreground="{StaticResource ButtonForegroundBrush}" Text="Overwrite" />
                         </Button>
                         <Button
                             Margin="6,0,0,0"
                             Command="{Binding CancelCopyToAdapterCommand}"
                             Style="{StaticResource StandardButton}">
-                            <TextBlock Margin="6,2" Text="Cancel" />
+                            <TextBlock Margin="6,2" Foreground="{StaticResource ButtonForegroundBrush}" Text="Cancel" />
                         </Button>
                     </WrapPanel>
                 </StackPanel>
@@ -303,7 +303,7 @@
                         VerticalAlignment="Center"
                         Command="{Binding EnableAberrationsCommand}"
                         Style="{StaticResource StandardButton}">
-                        <TextBlock Margin="6,1" Text="Enable" />
+                        <TextBlock Margin="6,1" Foreground="{StaticResource ButtonForegroundBrush}" Text="Enable" />
                     </Button>
                 </WrapPanel>
             </Border>
@@ -353,7 +353,7 @@
                     Command="{Binding UndoCommand}"
                     Style="{StaticResource StandardButton}"
                     ToolTip="Reverts the last click — the injected plane, the best-focus position and the net counters.">
-                    <TextBlock Margin="6,1" Text="Undo" />
+                    <TextBlock Margin="6,1" Foreground="{StaticResource ButtonForegroundBrush}" Text="Undo" />
                 </Button>
             </WrapPanel>
 
@@ -488,7 +488,7 @@
                     Command="{Binding RezeroCommand}"
                     Style="{StaticResource StandardButton}"
                     ToolTip="{Binding RezeroTooltip}">
-                    <TextBlock Margin="6,1" Text="Re-zero" />
+                    <TextBlock Margin="6,1" Foreground="{StaticResource ButtonForegroundBrush}" Text="Re-zero" />
                 </Button>
             </WrapPanel>
 
@@ -565,7 +565,7 @@
                         Command="{Binding ZeroAberrationsCommand}"
                         Style="{StaticResource StandardButton}"
                         ToolTip="Flattens the injected plane instantly, for starting a fresh scenario.">
-                        <TextBlock Margin="6,2" Text="Zero all aberrations" />
+                        <TextBlock Margin="6,2" Foreground="{StaticResource ButtonForegroundBrush}" Text="Zero all aberrations" />
                     </Button>
                 </StackPanel>
             </Expander>

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/CameraSimulator/TiltAdapter/TiltAdapterDataTemplates.xaml
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/CameraSimulator/TiltAdapter/TiltAdapterDataTemplates.xaml
@@ -7,6 +7,13 @@
     xmlns:ninactrl="clr-namespace:NINA.CustomControlLibrary;assembly=NINA.CustomControlLibrary"
     xmlns:rules="clr-namespace:NINA.Core.Utility.ValidationRules;assembly=NINA.Core">
 
+    <!--  MERGED, not reached for: a merged dictionary's keys resolve inside this dictionary's own parse-time
+          scope, so it is not the cross-dictionary load-order race the note below is about. Only AlertBrushes is
+          merged, not the large OptionsDataTemplates.  -->
+    <ResourceDictionary.MergedDictionaries>
+        <ResourceDictionary Source="../../Resources/AlertBrushes.xaml" />
+    </ResourceDictionary.MergedDictionaries>
+
     <!--  Declared locally rather than reached for across dictionaries: StaticResource resolves at parse time and
           the merge order of separately-exported plugin ResourceDictionaries into Application.Current.Resources is
           not guaranteed, so a cross-dictionary lookup would be a load-order race (see

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/CameraSimulator/TiltAdapter/TiltAdapterDataTemplates.xaml
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/CameraSimulator/TiltAdapter/TiltAdapterDataTemplates.xaml
@@ -231,7 +231,7 @@
                     <TextBlock
                         MaxWidth="380"
                         HorizontalAlignment="Left"
-                        Foreground="{StaticResource NotificationWarningTextBrush}"
+                        Foreground="{StaticResource HF_AlertWarningTextBrush}"
                         Text="{Binding CopyToAdapterConfirmText}"
                         TextWrapping="Wrap" />
                     <WrapPanel Margin="0,4,0,0">
@@ -279,7 +279,7 @@
                 <WrapPanel>
                     <TextBlock
                         VerticalAlignment="Center"
-                        Foreground="{StaticResource NotificationWarningTextBrush}"
+                        Foreground="{StaticResource HF_AlertWarningTextBrush}"
                         Text="{Binding ConfigurationBannerText}"
                         TextWrapping="Wrap" />
                 </WrapPanel>
@@ -294,7 +294,7 @@
                 <WrapPanel>
                     <TextBlock
                         VerticalAlignment="Center"
-                        Foreground="{StaticResource NotificationWarningTextBrush}"
+                        Foreground="{StaticResource HF_AlertWarningTextBrush}"
                         Text="Aberrations are disabled — the plane below has no effect on rendered frames"
                         TextWrapping="Wrap" />
                     <!--  Operate deliberately stays enabled: editing an inert state is legal, just inert.  -->
@@ -331,7 +331,7 @@
                     Margin="8,0,0,0"
                     VerticalAlignment="Center"
                     FontStyle="Italic"
-                    Foreground="{StaticResource NotificationWarningBrush}"
+                    Foreground="{StaticResource HF_AlertWarningAccentBrush}"
                     Text="{Binding ExtremeTiltText}"
                     Visibility="{Binding HasExtremeTilt, Converter={StaticResource HFSim_BooleanToVisibilityConverter}}" />
             </WrapPanel>

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/CameraSimulator/TiltAdapter/TiltAdapterDataTemplates.xaml
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/CameraSimulator/TiltAdapter/TiltAdapterDataTemplates.xaml
@@ -223,9 +223,7 @@
                   It names the fields it will overwrite, per the UX design.  -->
             <Border
                 Margin="0,6,0,0"
-                Padding="6,4"
-                Background="{StaticResource NotificationWarningBrush}"
-                CornerRadius="3"
+                Style="{StaticResource HF_AlertWarningBadge}"
                 Visibility="{Binding IsCopyToAdapterPending, Converter={StaticResource HFSim_BooleanToVisibilityConverter}}">
                 <StackPanel>
                     <TextBlock
@@ -272,9 +270,7 @@
                   rapid-click loop must never be interrupted by a dialog.  -->
             <Border
                 Margin="0,0,0,6"
-                Padding="6,4"
-                Background="{StaticResource NotificationWarningBrush}"
-                CornerRadius="3"
+                Style="{StaticResource HF_AlertWarningBadge}"
                 Visibility="{Binding HasConfigurationBanner, Converter={StaticResource HFSim_BooleanToVisibilityConverter}}">
                 <WrapPanel>
                     <TextBlock
@@ -287,9 +283,7 @@
 
             <Border
                 Margin="0,0,0,6"
-                Padding="6,4"
-                Background="{StaticResource NotificationWarningBrush}"
-                CornerRadius="3"
+                Style="{StaticResource HF_AlertWarningBadge}"
                 Visibility="{Binding ShowAberrationsDisabledBanner, Converter={StaticResource HFSim_BooleanToVisibilityConverter}}">
                 <WrapPanel>
                     <TextBlock

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/Converters/AccessibleAccentColorConverter.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/Converters/AccessibleAccentColorConverter.cs
@@ -1,0 +1,43 @@
+#region "copyright"
+
+/*
+    Copyright © 2021 - 2026 George Hilios <ghilios+NINA@googlemail.com>
+
+    This Source Code Form is subject to the terms of the Mozilla Public
+    License, v. 2.0. If a copy of the MPL was not distributed with this
+    file, You can obtain one at http://mozilla.org/MPL/2.0/.
+*/
+
+#endregion "copyright"
+
+using System;
+using System.Globalization;
+using System.Windows.Data;
+using System.Windows.Media;
+
+namespace NINA.Joko.Plugins.HocusFocus.Converters {
+
+    /// <summary>
+    /// Foreground for INLINE alert text drawn straight on the page: the schema's alert color, hue preserved,
+    /// lightened or darkened only as far as WCAG AA needs against the page background.
+    /// values[0] = alert color, values[1] = page background color.
+    /// </summary>
+    public class AccessibleAccentColorConverter : IMultiValueConverter {
+
+        public object Convert(object[] values, Type targetType, object parameter, CultureInfo culture) {
+            if (values == null || values.Length < 1 || !(values[0] is Color alert)) {
+                return Colors.White;
+            }
+            // Background not resolved yet: degrade to the raw alert color (exactly today's behaviour) rather
+            // than guessing. The real value arrives on the next pass.
+            if (values.Length < 2 || !(values[1] is Color background)) {
+                return alert;
+            }
+            return ContrastMath.AccessibleAccent(alert, background);
+        }
+
+        public object[] ConvertBack(object value, Type[] targetTypes, object parameter, CultureInfo culture) {
+            throw new NotSupportedException();
+        }
+    }
+}

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/Converters/AccessibleAccentColorConverter.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/Converters/AccessibleAccentColorConverter.cs
@@ -21,10 +21,16 @@ namespace NINA.Joko.Plugins.HocusFocus.Converters {
     /// Foreground for INLINE alert text drawn straight on the page: the schema's alert color, hue preserved,
     /// lightened or darkened only as far as WCAG AA needs against the page background.
     /// values[0] = alert color, values[1] = page background color.
+    ///
+    /// Assumes the binding target is a Color dependency property, e.g. SolidColorBrush.Color — targetType is
+    /// otherwise ignored. Do not bind this converter directly to a Brush property.
     /// </summary>
     public class AccessibleAccentColorConverter : IMultiValueConverter {
 
         public object Convert(object[] values, Type targetType, object parameter, CultureInfo culture) {
+            // The first pass of a resource-level binding arrives as an UnsetValue entry (or, for a null/empty
+            // array, no entries at all). White rather than Binding.DoNothing: DoNothing would leave
+            // SolidColorBrush.Color at Transparent (invisible text).
             if (values == null || values.Length < 1 || !(values[0] is Color alert)) {
                 return Colors.White;
             }
@@ -37,7 +43,7 @@ namespace NINA.Joko.Plugins.HocusFocus.Converters {
         }
 
         public object[] ConvertBack(object value, Type[] targetTypes, object parameter, CultureInfo culture) {
-            throw new NotSupportedException();
+            throw new NotSupportedException("One-way only: bind with Mode=OneWay.");
         }
     }
 }

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/Converters/BadgeTextColorConverter.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/Converters/BadgeTextColorConverter.cs
@@ -1,0 +1,37 @@
+#region "copyright"
+
+/*
+    Copyright © 2021 - 2026 George Hilios <ghilios+NINA@googlemail.com>
+
+    This Source Code Form is subject to the terms of the Mozilla Public
+    License, v. 2.0. If a copy of the MPL was not distributed with this
+    file, You can obtain one at http://mozilla.org/MPL/2.0/.
+*/
+
+#endregion "copyright"
+
+using System;
+using System.Globalization;
+using System.Windows.Data;
+using System.Windows.Media;
+
+namespace NINA.Joko.Plugins.HocusFocus.Converters {
+
+    /// <summary>
+    /// Text color for a FILLED alert badge: black or white, whichever is readable on the badge's own fill.
+    /// Deliberately not NINA's NotificationErrorTextColor — see the note on <see cref="ContrastMath"/>.
+    /// </summary>
+    public class BadgeTextColorConverter : IValueConverter {
+
+        public object Convert(object value, Type targetType, object parameter, CultureInfo culture) {
+            // The first pass of a resource-level binding arrives as DependencyProperty.UnsetValue. White rather
+            // than Binding.DoNothing: DoNothing would leave SolidColorBrush.Color at Transparent (invisible
+            // text), and white is the computed answer on all 18 built-in schemas.
+            return value is Color fill ? ContrastMath.BestContrastText(fill) : Colors.White;
+        }
+
+        public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture) {
+            throw new NotSupportedException();
+        }
+    }
+}

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/Converters/BadgeTextColorConverter.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/Converters/BadgeTextColorConverter.cs
@@ -20,6 +20,9 @@ namespace NINA.Joko.Plugins.HocusFocus.Converters {
     /// <summary>
     /// Text color for a FILLED alert badge: black or white, whichever is readable on the badge's own fill.
     /// Deliberately not NINA's NotificationErrorTextColor — see the note on <see cref="ContrastMath"/>.
+    ///
+    /// Assumes the binding target is a Color dependency property, e.g. SolidColorBrush.Color — targetType is
+    /// otherwise ignored. Do not bind this converter directly to a Brush property.
     /// </summary>
     public class BadgeTextColorConverter : IValueConverter {
 
@@ -31,7 +34,7 @@ namespace NINA.Joko.Plugins.HocusFocus.Converters {
         }
 
         public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture) {
-            throw new NotSupportedException();
+            throw new NotSupportedException("One-way only: bind with Mode=OneWay.");
         }
     }
 }

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/Converters/ContrastMath.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/Converters/ContrastMath.cs
@@ -19,7 +19,7 @@ namespace NINA.Joko.Plugins.HocusFocus.Converters {
     /// WCAG 2.x contrast math, and the two color decisions the alert brushes are built from.
     ///
     /// WHY THIS EXISTS: NINA's ColorSchema exposes NotificationErrorColor / NotificationWarningColor as FILL
-    /// colors (it only ever uses them as a Background), and 15 of its 18 built-in schemas set them to near-black
+    /// colors (it only ever uses them as a Background), and 13 of its 18 built-in schemas set them to near-black
     /// #FF700000 / #FF5E330B. Used as a Foreground — which this plugin did in 27 places — they land at 1.06:1
     /// against a dark page background. Its paired NotificationErrorTextColor is not a way out either: the "Dark"
     /// schema sets it to #FF02010A, i.e. near-black text on near-black-red fill, 1.67:1. So both alert text

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/Converters/ContrastMath.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/Converters/ContrastMath.cs
@@ -19,7 +19,7 @@ namespace NINA.Joko.Plugins.HocusFocus.Converters {
     /// WCAG 2.x contrast math, and the two color decisions the alert brushes are built from.
     ///
     /// WHY THIS EXISTS: NINA's ColorSchema exposes NotificationErrorColor / NotificationWarningColor as FILL
-    /// colors (it only ever uses them as a Background), and 14 of its 16 built-in schemas set them to near-black
+    /// colors (it only ever uses them as a Background), and 15 of its 18 built-in schemas set them to near-black
     /// #FF700000 / #FF5E330B. Used as a Foreground — which this plugin did in 27 places — they land at 1.06:1
     /// against a dark page background. Its paired NotificationErrorTextColor is not a way out either: the "Dark"
     /// schema sets it to #FF02010A, i.e. near-black text on near-black-red fill, 1.67:1. So both alert text
@@ -81,7 +81,10 @@ namespace NINA.Joko.Plugins.HocusFocus.Converters {
 
             bool goLighter;
             if (lighterReaches && darkerReaches) {
-                // Both poles work, so head for the one the background is furthest from.
+                // Unreachable at TargetContrastRatio = 4.6, and deliberately kept anyway: reaching white
+                // needs background luminance <= 1.05/T - 0.05, reaching black needs >= (T-1)/20, and those
+                // ranges are disjoint for any T above sqrt(21) ~= 4.583. Lower the threshold and this
+                // becomes live, so the tie-break stays. Do not try to unit-test it at the current T.
                 goLighter = ContrastRatio(Colors.White, pageBackground) >= ContrastRatio(Colors.Black, pageBackground);
             } else if (lighterReaches) {
                 goLighter = true;
@@ -115,7 +118,9 @@ namespace NINA.Joko.Plugins.HocusFocus.Converters {
             double min = Math.Min(r, Math.Min(g, b));
             l = (max + min) / 2.0;
             double delta = max - min;
-            if (delta <= double.Epsilon) {
+            // Exact-zero test, deliberately: r/g/b are byte/255.0, so channel maths is exact and an
+            // achromatic color lands on delta == 0.0 precisely rather than merely near it.
+            if (delta == 0.0) {
                 h = 0.0;
                 s = 0.0;
                 return;
@@ -132,7 +137,9 @@ namespace NINA.Joko.Plugins.HocusFocus.Converters {
 
         private static Color FromHsl(double h, double s, double l, byte alpha) {
             l = Math.Max(0.0, Math.Min(1.0, l));
-            if (s <= double.Epsilon) {
+            // Exact-zero test, deliberately: s is only ever 0.0 here because RgbToHsl set it that way for an
+            // exact-zero delta (see above), never as a result of accumulated floating-point error.
+            if (s == 0.0) {
                 byte v = (byte)Math.Round(l * 255.0);
                 return Color.FromArgb(alpha, v, v, v);
             }

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/Converters/ContrastMath.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/Converters/ContrastMath.cs
@@ -1,0 +1,157 @@
+#region "copyright"
+
+/*
+    Copyright © 2021 - 2026 George Hilios <ghilios+NINA@googlemail.com>
+
+    This Source Code Form is subject to the terms of the Mozilla Public
+    License, v. 2.0. If a copy of the MPL was not distributed with this
+    file, You can obtain one at http://mozilla.org/MPL/2.0/.
+*/
+
+#endregion "copyright"
+
+using System;
+using System.Windows.Media;
+
+namespace NINA.Joko.Plugins.HocusFocus.Converters {
+
+    /// <summary>
+    /// WCAG 2.x contrast math, and the two color decisions the alert brushes are built from.
+    ///
+    /// WHY THIS EXISTS: NINA's ColorSchema exposes NotificationErrorColor / NotificationWarningColor as FILL
+    /// colors (it only ever uses them as a Background), and 14 of its 16 built-in schemas set them to near-black
+    /// #FF700000 / #FF5E330B. Used as a Foreground — which this plugin did in 27 places — they land at 1.06:1
+    /// against a dark page background. Its paired NotificationErrorTextColor is not a way out either: the "Dark"
+    /// schema sets it to #FF02010A, i.e. near-black text on near-black-red fill, 1.67:1. So both alert text
+    /// colors are COMPUTED here rather than read from the schema.
+    ///
+    /// Pure and WPF-binding-free on purpose: the all-schemas regression sweep in ContrastMathTests runs directly
+    /// against this, with no converter or dispatcher in the way.
+    /// </summary>
+    internal static class ContrastMath {
+
+        /// <summary>WCAG AA for body text. What the tests assert.</summary>
+        internal const double MinContrastRatio = 4.5;
+
+        /// <summary>
+        /// What <see cref="AccessibleAccent"/> actually searches for. Deliberately above
+        /// <see cref="MinContrastRatio"/>: the search evaluates byte-rounded colors, and landing exactly on 4.5
+        /// leaves no headroom for that rounding.
+        /// </summary>
+        private const double TargetContrastRatio = 4.6;
+
+        private static double Linearize(byte channel) {
+            double c = channel / 255.0;
+            return c <= 0.04045 ? c / 12.92 : Math.Pow((c + 0.055) / 1.055, 2.4);
+        }
+
+        internal static double RelativeLuminance(Color c) =>
+            0.2126 * Linearize(c.R) + 0.7152 * Linearize(c.G) + 0.0722 * Linearize(c.B);
+
+        internal static double ContrastRatio(Color a, Color b) {
+            double la = RelativeLuminance(a);
+            double lb = RelativeLuminance(b);
+            double hi = Math.Max(la, lb);
+            double lo = Math.Min(la, lb);
+            return (hi + 0.05) / (lo + 0.05);
+        }
+
+        /// <summary>Black or white — whichever is more readable ON <paramref name="fill"/>.</summary>
+        internal static Color BestContrastText(Color fill) =>
+            ContrastRatio(Colors.Black, fill) >= ContrastRatio(Colors.White, fill) ? Colors.Black : Colors.White;
+
+        /// <summary>
+        /// <paramref name="alert"/> made readable against <paramref name="pageBackground"/>, keeping its HUE and
+        /// SATURATION and moving only HSL lightness.
+        ///
+        /// Moving in HSL rather than lerping toward white is the point: #700000 lerped toward white only reaches
+        /// 4.5:1 at roughly #A96666, a washed-out rose that no longer reads as an error, while raising its HSL
+        /// lightness reaches the same ratio at #EF0000 — still unmistakably red. Returned unchanged when it
+        /// already passes, so light-background schemas stay byte-identical to their previous appearance.
+        /// </summary>
+        internal static Color AccessibleAccent(Color alert, Color pageBackground) {
+            if (ContrastRatio(alert, pageBackground) >= TargetContrastRatio) {
+                return alert;
+            }
+
+            RgbToHsl(alert, out double h, out double s, out double l);
+
+            bool lighterReaches = ContrastRatio(FromHsl(h, s, 1.0, alert.A), pageBackground) >= TargetContrastRatio;
+            bool darkerReaches = ContrastRatio(FromHsl(h, s, 0.0, alert.A), pageBackground) >= TargetContrastRatio;
+
+            bool goLighter;
+            if (lighterReaches && darkerReaches) {
+                // Both poles work, so head for the one the background is furthest from.
+                goLighter = ContrastRatio(Colors.White, pageBackground) >= ContrastRatio(Colors.Black, pageBackground);
+            } else if (lighterReaches) {
+                goLighter = true;
+            } else if (darkerReaches) {
+                goLighter = false;
+            } else {
+                // A fully saturated hue cannot reach the target against this background (only possible for an
+                // exotic custom schema). Legibility beats hue: fall back to plain black or white.
+                var fallback = BestContrastText(pageBackground);
+                return Color.FromArgb(alert.A, fallback.R, fallback.G, fallback.B);
+            }
+
+            // Contrast is monotonic in lightness once we are moving away from the background, so bisect.
+            double lo = goLighter ? l : 0.0;
+            double hi = goLighter ? 1.0 : l;
+            for (int i = 0; i < 24; i++) {
+                double mid = (lo + hi) / 2.0;
+                bool reaches = ContrastRatio(FromHsl(h, s, mid, alert.A), pageBackground) >= TargetContrastRatio;
+                if (goLighter) {
+                    if (reaches) { hi = mid; } else { lo = mid; }
+                } else {
+                    if (reaches) { lo = mid; } else { hi = mid; }
+                }
+            }
+            return FromHsl(h, s, goLighter ? hi : lo, alert.A);
+        }
+
+        private static void RgbToHsl(Color c, out double h, out double s, out double l) {
+            double r = c.R / 255.0, g = c.G / 255.0, b = c.B / 255.0;
+            double max = Math.Max(r, Math.Max(g, b));
+            double min = Math.Min(r, Math.Min(g, b));
+            l = (max + min) / 2.0;
+            double delta = max - min;
+            if (delta <= double.Epsilon) {
+                h = 0.0;
+                s = 0.0;
+                return;
+            }
+            s = l > 0.5 ? delta / (2.0 - max - min) : delta / (max + min);
+            if (max == r) {
+                h = ((g - b) / delta + (g < b ? 6.0 : 0.0)) / 6.0;
+            } else if (max == g) {
+                h = ((b - r) / delta + 2.0) / 6.0;
+            } else {
+                h = ((r - g) / delta + 4.0) / 6.0;
+            }
+        }
+
+        private static Color FromHsl(double h, double s, double l, byte alpha) {
+            l = Math.Max(0.0, Math.Min(1.0, l));
+            if (s <= double.Epsilon) {
+                byte v = (byte)Math.Round(l * 255.0);
+                return Color.FromArgb(alpha, v, v, v);
+            }
+            double q = l < 0.5 ? l * (1.0 + s) : l + s - l * s;
+            double p = 2.0 * l - q;
+            return Color.FromArgb(
+                alpha,
+                (byte)Math.Round(HueToChannel(p, q, h + 1.0 / 3.0) * 255.0),
+                (byte)Math.Round(HueToChannel(p, q, h) * 255.0),
+                (byte)Math.Round(HueToChannel(p, q, h - 1.0 / 3.0) * 255.0));
+        }
+
+        private static double HueToChannel(double p, double q, double t) {
+            if (t < 0.0) { t += 1.0; }
+            if (t > 1.0) { t -= 1.0; }
+            if (t < 1.0 / 6.0) { return p + (q - p) * 6.0 * t; }
+            if (t < 1.0 / 2.0) { return q; }
+            if (t < 2.0 / 3.0) { return p + (q - p) * (2.0 / 3.0 - t) * 6.0; }
+            return p;
+        }
+    }
+}

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/Resources/AlertBrushes.xaml
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/Resources/AlertBrushes.xaml
@@ -1,0 +1,84 @@
+<ResourceDictionary
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:hfconverters="clr-namespace:NINA.Joko.Plugins.HocusFocus.Converters">
+
+    <!--
+        Accessible alert chrome. NINA's NotificationError/WarningBrush are FILL colours (it only ever uses them
+        as a Background) and are near-black in 13 of its 18 built-in schemas, so using them as a Foreground
+        renders at 1.06-1.9:1 on every dark theme. Its paired NotificationErrorTextBrush is no better — the
+        "Dark" schema sets it to #FF02010A, near-black on near-black-red, 1.67:1. Both text colours are
+        therefore COMPUTED (see Converters/ContrastMath.cs), which holds >= 4.5:1 on all 18 built-in schemas and
+        on custom ones.
+
+        The Color properties are BOUND rather than fixed so a live colour-schema change flows through, the same
+        shape NINA uses in NINA.WPF.Base/Resources/StaticResources/Brushes.xaml.
+
+        USAGE:
+          HF_Alert*TextBrush   -> text INSIDE a filled badge
+          HF_Alert*AccentBrush -> alert text drawn straight on the page background
+          HF_Alert*Badge       -> the filled Border itself (BasedOn-able, so a local Style can add triggers)
+
+        When a Border becomes a filled badge, EVERY TextBlock inside it needs the badge text brush — children
+        with no explicit Foreground otherwise inherit PrimaryBrush onto the fill.
+
+        Mode=OneWay is stated EXPLICITLY on every binding below, and is not decoration. Both converters throw
+        NotSupportedException from ConvertBack, and WPF does NOT catch exceptions thrown out of a converter's
+        ConvertBack — unlike a failed Convert, which it logs and leaves the target unset, a throwing ConvertBack
+        propagates and can take the application down. These bindings resolve to OneWay implicitly today only
+        because SolidColorBrush.ColorProperty is registered through Animatable.RegisterProperty, which carries no
+        BindsTwoWayByDefault. Saying OneWay outright makes the guarantee structural instead of incidental, so it
+        survives someone re-pointing a converter at a target property whose metadata does default to two-way.
+    -->
+
+    <hfconverters:BadgeTextColorConverter x:Key="HF_BadgeTextColorConverter" />
+    <hfconverters:AccessibleAccentColorConverter x:Key="HF_AccessibleAccentColorConverter" />
+
+    <SolidColorBrush
+        x:Key="HF_AlertErrorTextBrush"
+        Color="{Binding Source={StaticResource NotificationErrorBrush},
+                        Path=Color,
+                        Mode=OneWay,
+                        Converter={StaticResource HF_BadgeTextColorConverter}}" />
+
+    <SolidColorBrush
+        x:Key="HF_AlertWarningTextBrush"
+        Color="{Binding Source={StaticResource NotificationWarningBrush},
+                        Path=Color,
+                        Mode=OneWay,
+                        Converter={StaticResource HF_BadgeTextColorConverter}}" />
+
+    <SolidColorBrush x:Key="HF_AlertErrorAccentBrush">
+        <SolidColorBrush.Color>
+            <MultiBinding Converter="{StaticResource HF_AccessibleAccentColorConverter}" Mode="OneWay">
+                <Binding Path="Color" Source="{StaticResource NotificationErrorBrush}" Mode="OneWay" />
+                <Binding Path="Color" Source="{StaticResource BackgroundBrush}" Mode="OneWay" />
+            </MultiBinding>
+        </SolidColorBrush.Color>
+    </SolidColorBrush>
+
+    <SolidColorBrush x:Key="HF_AlertWarningAccentBrush">
+        <SolidColorBrush.Color>
+            <MultiBinding Converter="{StaticResource HF_AccessibleAccentColorConverter}" Mode="OneWay">
+                <Binding Path="Color" Source="{StaticResource NotificationWarningBrush}" Mode="OneWay" />
+                <Binding Path="Color" Source="{StaticResource BackgroundBrush}" Mode="OneWay" />
+            </MultiBinding>
+        </SolidColorBrush.Color>
+    </SolidColorBrush>
+
+    <Style x:Key="HF_AlertErrorBadge" TargetType="Border">
+        <Setter Property="Background" Value="{StaticResource NotificationErrorBrush}" />
+        <Setter Property="BorderBrush" Value="{StaticResource NotificationErrorBrush}" />
+        <Setter Property="BorderThickness" Value="1" />
+        <Setter Property="CornerRadius" Value="3" />
+        <Setter Property="Padding" Value="6,4" />
+    </Style>
+
+    <Style x:Key="HF_AlertWarningBadge" TargetType="Border">
+        <Setter Property="Background" Value="{StaticResource NotificationWarningBrush}" />
+        <Setter Property="BorderBrush" Value="{StaticResource NotificationWarningBrush}" />
+        <Setter Property="BorderThickness" Value="1" />
+        <Setter Property="CornerRadius" Value="3" />
+        <Setter Property="Padding" Value="6,4" />
+    </Style>
+</ResourceDictionary>

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/Resources/OptionsDataTemplates.xaml
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/Resources/OptionsDataTemplates.xaml
@@ -2619,7 +2619,7 @@
                 MaxWidth="420"
                 HorizontalAlignment="Left"
                 FontStyle="Italic"
-                Foreground="{StaticResource NotificationWarningBrush}"
+                Foreground="{StaticResource HF_AlertWarningAccentBrush}"
                 Text="{Binding PerFilterEditBinder.ActiveFilterWarning}"
                 TextWrapping="Wrap">
                 <TextBlock.Style>
@@ -3362,7 +3362,7 @@
                         HorizontalAlignment="Left"
                         VerticalAlignment="Center"
                         FontStyle="Italic"
-                        Foreground="{StaticResource NotificationWarningBrush}"
+                        Foreground="{StaticResource HF_AlertWarningAccentBrush}"
                         Text="⚠ differs from the focuser driver"
                         ToolTip="{StaticResource FocuserStepSizeMismatch_Tooltip}"
                         Visibility="{Binding InspectorOptions.HasFocuserStepSizeMismatch, Converter={StaticResource BooleanToVisibilityCollapsedConverter}}" />

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/Resources/OptionsDataTemplates.xaml
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/Resources/OptionsDataTemplates.xaml
@@ -17,6 +17,12 @@
     xmlns:util="clr-namespace:NINA.Core.Utility;assembly=NINA.Core"
     xmlns:xceed="http://schemas.xceed.com/wpf/xaml/toolkit"
     mc:Ignorable="d">
+    <!--  Alert chrome. Merged (not cross-dictionary StaticResource) so the keys resolve at parse time in every
+          dictionary that merges this one: AutoFocus, TiltAdapterWizard and StarDetection/Optimization all merge
+          OptionsDataTemplates already, so they inherit it for free.  -->
+    <ResourceDictionary.MergedDictionaries>
+        <ResourceDictionary Source="AlertBrushes.xaml" />
+    </ResourceDictionary.MergedDictionaries>
     <hfconverters:ShowStructureMapToVisibilityConverter x:Key="HF_ShowStructureMapToVisibilityConverter" />
     <hfconverters:DoubleZeroToVisibilityConverter x:Key="HF_DoubleZeroToVisibilityConverter" />
     <hfconverters:IntNegativeToVisibilityConverter x:Key="HF_IntNegativeToVisibilityConverter" />

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/DataTemplates.xaml
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/DataTemplates.xaml
@@ -779,7 +779,7 @@
                         <TextBlock
                             Margin="0,0,0,8"
                             FontStyle="Italic"
-                            Foreground="{StaticResource NotificationWarningBrush}"
+                            Foreground="{StaticResource HF_AlertWarningAccentBrush}"
                             Text="{Binding LowSignalChartNote, Mode=OneWay}"
                             TextWrapping="Wrap"
                             Visibility="{Binding HasExposureBlock, Converter={StaticResource BooleanToVisibilityCollapsedConverter}}" />
@@ -792,7 +792,7 @@
                         <TextBlock
                             Margin="0,0,0,8"
                             FontStyle="Italic"
-                            Foreground="{StaticResource NotificationWarningBrush}"
+                            Foreground="{StaticResource HF_AlertWarningAccentBrush}"
                             Text="{Binding UndersampledStarsChartNote, Mode=OneWay}"
                             TextWrapping="Wrap"
                             Visibility="{Binding HasUndersampledStarsNote, Converter={StaticResource BooleanToVisibilityCollapsedConverter}}" />
@@ -1213,18 +1213,23 @@
                   practice (an error returns to SelectSource, the notice only ever accompanies a run that
                   proceeded), so stacking costs no layout and leaves the grid's row definitions alone.  -->
             <StackPanel Grid.Row="2" Orientation="Vertical">
-                <TextBlock
+                <!--  The BORDER carries the visibility, not the TextBlock: a filled badge whose text is blank
+                      would otherwise render as an empty red pill.  -->
+                <Border
                     Margin="0,8,0,0"
-                    Foreground="{StaticResource NotificationErrorBrush}"
-                    Text="{Binding ErrorMessage}"
-                    TextWrapping="Wrap"
-                    Visibility="{Binding HasError, Converter={StaticResource BooleanToVisibilityCollapsedConverter}}" />
+                    Style="{StaticResource HF_AlertErrorBadge}"
+                    Visibility="{Binding HasError, Converter={StaticResource BooleanToVisibilityCollapsedConverter}}">
+                    <TextBlock
+                        Foreground="{StaticResource HF_AlertErrorTextBrush}"
+                        Text="{Binding ErrorMessage}"
+                        TextWrapping="Wrap" />
+                </Border>
 
                 <!--  Not an error: the run continued, but on FEWER positions than the user asked for, so the
                       exclusion has to be visible rather than silently applied.  -->
                 <TextBlock
                     Margin="0,8,0,0"
-                    Foreground="{StaticResource NotificationWarningBrush}"
+                    Foreground="{StaticResource HF_AlertWarningAccentBrush}"
                     Text="{Binding RecoveryWidenedNotice}"
                     TextWrapping="Wrap"
                     Visibility="{Binding HasRecoveryWidenedNotice, Converter={StaticResource BooleanToVisibilityCollapsedConverter}}" />
@@ -1235,7 +1240,7 @@
                       gate is the single setting they most need to know about.  -->
                 <TextBlock
                     Margin="0,8,0,0"
-                    Foreground="{StaticResource NotificationWarningBrush}"
+                    Foreground="{StaticResource HF_AlertWarningAccentBrush}"
                     Text="{Binding MinHfrRescueNotice}"
                     TextWrapping="Wrap"
                     Visibility="{Binding HasMinHfrRescueNotice, Converter={StaticResource BooleanToVisibilityCollapsedConverter}}" />

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/DataTemplates.xaml
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/DataTemplates.xaml
@@ -999,7 +999,7 @@
                                     VerticalAlignment="Center"
                                     Command="{Binding CaptureNewSweepCommand}"
                                     ToolTip="{StaticResource SDOpt_CaptureNewSweep_Tooltip}">
-                                    <TextBlock Margin="12,6" Text="Capture a new sweep and optimize" />
+                                    <TextBlock Margin="12,6" Foreground="{StaticResource ButtonForegroundBrush}" Text="Capture a new sweep and optimize" />
                                 </Button>
                             </StackPanel>
                         </StackPanel>
@@ -1034,7 +1034,7 @@
                                 HorizontalAlignment="Left"
                                 Command="{Binding OptimizeAgainAtRecommendedBinningCommand}"
                                 Visibility="{Binding ShowOptimizeAgainAtRecommendedBinning, Converter={StaticResource BooleanToVisibilityCollapsedConverter}}">
-                                <TextBlock Margin="12,6" Text="{Binding OptimizeAgainAtRecommendedBinningText}" />
+                                <TextBlock Margin="12,6" Foreground="{StaticResource ButtonForegroundBrush}" Text="{Binding OptimizeAgainAtRecommendedBinningText}" />
                             </Button>
                         </StackPanel>
 

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/TiltAdapterDevices/AsgEat/EatWizardMapping.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/TiltAdapterDevices/AsgEat/EatWizardMapping.cs
@@ -59,7 +59,7 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterDevices.AsgEat {
         /// Each case is annotated with the exact <c>StepInstructionsText</c> wording (four-screw,
         /// isStepper) it realizes. Two variants of the executed sequence both sum to (0,0,0,0) per corner --
         /// the device returns to baseline by the end either way; see EatWizardMappingTests for both
-        /// full-sequence regressions that pin this: the standard six-move sequence (AllInward, ReBaseline1,
+        /// full-sequence regressions that pin this: the standard six-move sequence (AllInward (all motors), ReBaseline1,
         /// Screw1, ReBaseline2, Screw2, Complete, <paramref name="measuredFinalRebaseline"/> false) and the
         /// optional seven-move sequence that substitutes a measured ReBaseline3 restore for Complete's move
         /// (<paramref name="measuredFinalRebaseline"/> true, Complete becomes a no-move).
@@ -73,10 +73,11 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterDevices.AsgEat {
 
                 case WizardStep.AllInward:
                     // "Apply +N steps to EVERY motor, then click Run Measurement." -> all four wizard
-                    // screws +N -> (+N,+N,+N,+N) = Backfocus(+N).
+                    // screws +N -> (+N,+N,+N,+N) = Backfocus(+N). Described as "All Motors", never "Inward":
+                    // whether +N is physically inward is exactly what this step measures.
                     return new TiltAdapterMove(
                         TiltMoveAxis.Backfocus, appliedSteps, TiltMoveGroup.Backfocus,
-                        $"Wizard All Inward: {FormatSigned(appliedSteps)} backfocus");
+                        $"Wizard All Motors: {FormatSigned(appliedSteps)} backfocus");
 
                 case WizardStep.ReBaseline1:
                     // "Apply -N steps to every motor, returning to the baseline position, then click Run

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/TiltAdapterDevices/Prompt/TiltDeviceAdjustmentPromptControl.xaml
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/TiltAdapterDevices/Prompt/TiltDeviceAdjustmentPromptControl.xaml
@@ -370,7 +370,7 @@
             </StackPanel>
             <StackPanel Grid.Column="1" VerticalAlignment="Center" Orientation="Horizontal">
                 <Button MinWidth="90" Command="{Binding CancelCommand}">
-                    <TextBlock Margin="12,6" Text="Cancel" />
+                    <TextBlock Margin="12,6" Foreground="{StaticResource ButtonForegroundBrush}" Text="Cancel" />
                 </Button>
                 <Button
                     Margin="8,0,0,0"

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/TiltAdapterWizard/DataTemplates.xaml
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/TiltAdapterWizard/DataTemplates.xaml
@@ -1675,7 +1675,7 @@
                                     Margin="0,3,0,0"
                                     HorizontalAlignment="Left"
                                     Foreground="{StaticResource HF_AlertWarningTextBrush}"
-                                    Text="This calibration was entered or edited by hand, so HocusFocus cannot verify that your screw numbering matches the device's motor wiring. Re-run the wizard with the device connected, or trust this calibration explicitly."
+                                    Text="This calibration was entered or edited by hand, so HocusFocus cannot verify that your screw numbering matches the device's motor wiring. Re-run the wizard with the device connected, or trust this calibration explicitly using the button below."
                                     TextWrapping="Wrap" />
 
                                 <!--  Step 1: arm.  -->
@@ -1701,13 +1701,18 @@
                                         Text="If your screw numbering does not match the device's motor wiring, Automatic Adjustment will drive the adapter unattended in the wrong direction and make tilt worse. Verify with a single manual adjustment before leaving it unattended."
                                         TextWrapping="Wrap" />
                                     <WrapPanel Margin="0,6,0,0">
-                                        <Button Command="{Binding ConfirmTrustCalibrationCommand}">
+                                        <Button
+                                            AutomationProperties.Name="Confirm trusting this calibration for automation"
+                                            Command="{Binding ConfirmTrustCalibrationCommand}">
                                             <TextBlock
                                                 Margin="10,5,10,5"
                                                 Foreground="{StaticResource ButtonForegroundBrush}"
                                                 Text="Yes, trust it" />
                                         </Button>
-                                        <Button Margin="6,0,0,0" Command="{Binding CancelTrustCalibrationCommand}">
+                                        <Button
+                                            Margin="6,0,0,0"
+                                            AutomationProperties.Name="Cancel trusting this calibration"
+                                            Command="{Binding CancelTrustCalibrationCommand}">
                                             <TextBlock
                                                 Margin="10,5,10,5"
                                                 Foreground="{StaticResource ButtonForegroundBrush}"

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/TiltAdapterWizard/DataTemplates.xaml
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/TiltAdapterWizard/DataTemplates.xaml
@@ -6,7 +6,8 @@
     xmlns:ninactrl="clr-namespace:NINA.CustomControlLibrary;assembly=NINA.CustomControlLibrary"
     xmlns:rules="clr-namespace:NINA.Core.Utility.ValidationRules;assembly=NINA.Core"
     xmlns:s="clr-namespace:System;assembly=mscorlib"
-    xmlns:interfaces="clr-namespace:NINA.Joko.Plugins.HocusFocus.Interfaces">
+    xmlns:interfaces="clr-namespace:NINA.Joko.Plugins.HocusFocus.Interfaces"
+    xmlns:local="clr-namespace:NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard">
     <ResourceDictionary.MergedDictionaries>
         <ResourceDictionary Source="../Resources/OptionsDataTemplates.xaml" />
         <ResourceDictionary Source="../Resources/SharedTooltips.xaml" />
@@ -1754,8 +1755,21 @@
                     <TextBlock
                         Margin="0,1,0,6"
                         FontWeight="Bold"
-                        Text="{Binding StepTitle}"
-                        ToolTip="Moving every screw or motor together changes backfocus, and this step measures which way the adapter plate actually travels. A '+' step is not assumed to be inward — determining that direction is the point of the step." />
+                        Text="{Binding StepTitle}">
+                        <!--  The tooltip is about the all-motors step SPECIFICALLY, and this one TextBlock renders
+                              every step's title, so it must be scoped. Unscoped it would tell a user hovering
+                              "Move Screw 1" about a different step's mechanics — a smaller version of the
+                              text-does-not-match-the-hardware confusion this task exists to remove.  -->
+                        <TextBlock.Style>
+                            <Style BasedOn="{StaticResource StandardTextBlock}" TargetType="TextBlock">
+                                <Style.Triggers>
+                                    <DataTrigger Binding="{Binding CurrentStep}" Value="{x:Static local:WizardStep.AllInward}">
+                                        <Setter Property="ToolTip" Value="Moving every screw or motor together changes backfocus, and this step measures which way the adapter plate actually travels. A '+' step is not assumed to be inward — determining that direction is the point of the step." />
+                                    </DataTrigger>
+                                </Style.Triggers>
+                            </Style>
+                        </TextBlock.Style>
+                    </TextBlock>
 
                     <TextBlock
                         Margin="0,0,0,10"

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/TiltAdapterWizard/DataTemplates.xaml
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/TiltAdapterWizard/DataTemplates.xaml
@@ -369,13 +369,13 @@
                                                         <TextBlock.Style>
                                                             <Style TargetType="TextBlock" BasedOn="{StaticResource StandardTextBlock}">
                                                                 <Setter Property="Visibility" Value="Collapsed" />
-                                                                <Setter Property="Foreground" Value="{StaticResource NotificationWarningBrush}" />
+                                                                <Setter Property="Foreground" Value="{StaticResource HF_AlertWarningAccentBrush}" />
                                                                 <Style.Triggers>
                                                                     <DataTrigger Binding="{Binding HasLimitTag}" Value="True">
                                                                         <Setter Property="Visibility" Value="Visible" />
                                                                     </DataTrigger>
                                                                     <DataTrigger Binding="{Binding IsBlocking}" Value="True">
-                                                                        <Setter Property="Foreground" Value="{StaticResource NotificationErrorBrush}" />
+                                                                        <Setter Property="Foreground" Value="{StaticResource HF_AlertErrorAccentBrush}" />
                                                                         <Setter Property="FontWeight" Value="Bold" />
                                                                     </DataTrigger>
                                                                 </Style.Triggers>
@@ -400,7 +400,7 @@
                                       enforces the travel window, just against a possibly-stale estimate.  -->
                                 <TextBlock
                                     Margin="0,6,0,0"
-                                    Foreground="{StaticResource NotificationWarningBrush}"
+                                    Foreground="{StaticResource HF_AlertWarningAccentBrush}"
                                     Text="{Binding PositionsUnknownAdvisory}"
                                     TextWrapping="Wrap">
                                     <TextBlock.Style>
@@ -417,7 +417,7 @@
 
                                 <TextBlock
                                     Margin="0,6,0,0"
-                                    Foreground="{StaticResource NotificationWarningBrush}"
+                                    Foreground="{StaticResource HF_AlertWarningAccentBrush}"
                                     Text="{Binding SendDisabledReason}"
                                     TextWrapping="Wrap">
                                     <TextBlock.Style>
@@ -507,7 +507,7 @@
                                             </TextBlock>
                                             <!--  Only present when the request contains twist: the position this
                                                   motor will actually reach, which is not the one typed above.  -->
-                                            <TextBlock FontSize="10" Foreground="{StaticResource NotificationWarningBrush}" Text="{Binding WillReachText}">
+                                            <TextBlock FontSize="10" Foreground="{StaticResource HF_AlertWarningAccentBrush}" Text="{Binding WillReachText}">
                                                 <TextBlock.Style>
                                                     <Style TargetType="TextBlock" BasedOn="{StaticResource StandardTextBlock}">
                                                         <Setter Property="Visibility" Value="Collapsed" />
@@ -534,7 +534,7 @@
                                             <Setter Property="Visibility" Value="Visible" />
                                         </DataTrigger>
                                         <DataTrigger Binding="{Binding TargetHintIsError}" Value="True">
-                                            <Setter Property="Foreground" Value="{StaticResource NotificationErrorBrush}" />
+                                            <Setter Property="Foreground" Value="{StaticResource HF_AlertErrorAccentBrush}" />
                                         </DataTrigger>
                                     </Style.Triggers>
                                 </Style>
@@ -566,7 +566,7 @@
 
                         <TextBlock
                             Margin="0,6,0,0"
-                            Foreground="{StaticResource NotificationWarningBrush}"
+                            Foreground="{StaticResource HF_AlertWarningAccentBrush}"
                             Text="{Binding ReviewDisabledReason}"
                             TextWrapping="Wrap">
                             <TextBlock.Style>
@@ -1998,7 +1998,7 @@
                         <StackPanel>
                             <TextBlock
                                 Margin="0,0,0,6"
-                                Foreground="{StaticResource NotificationErrorBrush}"
+                                Foreground="{StaticResource HF_AlertErrorAccentBrush}"
                                 Text="{Binding MeasurementFailureText}"
                                 TextWrapping="Wrap" />
                             <Button

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/TiltAdapterWizard/DataTemplates.xaml
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/TiltAdapterWizard/DataTemplates.xaml
@@ -1869,14 +1869,12 @@
                         Content="{Binding}"
                         ContentTemplate="{StaticResource HF_TiltDevicePositionsGrid}" />
 
-                    <!--  Device connection warning: shown when Run Measurement is visible but devices are not connected  -->
-                    <TextBlock
-                        Margin="0,0,0,4"
-                        Foreground="{StaticResource NotificationErrorBrush}"
-                        Text="{Binding ConnectionWarningText}"
-                        TextWrapping="Wrap">
-                        <TextBlock.Style>
-                            <Style BasedOn="{StaticResource StandardTextBlock}" TargetType="TextBlock">
+                    <!--  Device connection warning: shown when Run Measurement is visible but devices are not
+                          connected. The BORDER owns the visibility trigger, not the TextBlock — otherwise the
+                          filled badge would render as an empty red pill whenever the text is blank.  -->
+                    <Border Margin="0,0,0,4">
+                        <Border.Style>
+                            <Style TargetType="Border" BasedOn="{StaticResource HF_AlertErrorBadge}">
                                 <Setter Property="Visibility" Value="Collapsed" />
                                 <Style.Triggers>
                                     <MultiDataTrigger>
@@ -1889,8 +1887,12 @@
                                     </MultiDataTrigger>
                                 </Style.Triggers>
                             </Style>
-                        </TextBlock.Style>
-                    </TextBlock>
+                        </Border.Style>
+                        <TextBlock
+                            Foreground="{StaticResource HF_AlertErrorTextBrush}"
+                            Text="{Binding ConnectionWarningText}"
+                            TextWrapping="Wrap" />
+                    </Border>
 
                     <!--  Measurement progress area: visible while measuring  -->
                     <StackPanel>
@@ -2041,11 +2043,9 @@
                           rendered there too.  -->
                     <Border
                         Margin="0,6,0,0"
-                        Padding="5"
-                        BorderBrush="{StaticResource NotificationErrorBrush}"
-                        BorderThickness="1">
+                        Padding="5">
                         <Border.Style>
-                            <Style TargetType="Border">
+                            <Style TargetType="Border" BasedOn="{StaticResource HF_AlertErrorBadge}">
                                 <Setter Property="Visibility" Value="Collapsed" />
                                 <Style.Triggers>
                                     <DataTrigger Binding="{Binding HasDeviceLinkDroppedWarning}" Value="True">
@@ -2055,7 +2055,7 @@
                             </Style>
                         </Border.Style>
                         <TextBlock
-                            Foreground="{StaticResource NotificationErrorBrush}"
+                            Foreground="{StaticResource HF_AlertErrorTextBrush}"
                             Text="{Binding DeviceLinkDroppedWarningText}"
                             TextWrapping="Wrap" />
                     </Border>
@@ -2063,11 +2063,9 @@
                     <!--  Consistency warning (shown when tilt measurements across runs diverge)  -->
                     <Border
                         Margin="0,6,0,0"
-                        Padding="5"
-                        BorderBrush="{StaticResource NotificationErrorBrush}"
-                        BorderThickness="1">
+                        Padding="5">
                         <Border.Style>
-                            <Style TargetType="Border">
+                            <Style TargetType="Border" BasedOn="{StaticResource HF_AlertErrorBadge}">
                                 <Setter Property="Visibility" Value="Collapsed" />
                                 <Style.Triggers>
                                     <DataTrigger Binding="{Binding HasMeasurementConsistencyWarning}" Value="True">
@@ -2077,7 +2075,7 @@
                             </Style>
                         </Border.Style>
                         <TextBlock
-                            Foreground="{StaticResource NotificationErrorBrush}"
+                            Foreground="{StaticResource HF_AlertErrorTextBrush}"
                             Text="{Binding MeasurementConsistencyWarningText}"
                             TextWrapping="Wrap" />
                     </Border>
@@ -2217,11 +2215,9 @@
                           raised it is already hidden), so it must render here too  -->
                     <Border
                         Margin="0,5"
-                        Padding="5"
-                        BorderBrush="{StaticResource NotificationErrorBrush}"
-                        BorderThickness="1">
+                        Padding="5">
                         <Border.Style>
-                            <Style TargetType="Border">
+                            <Style TargetType="Border" BasedOn="{StaticResource HF_AlertErrorBadge}">
                                 <Setter Property="Visibility" Value="Collapsed" />
                                 <Style.Triggers>
                                     <DataTrigger Binding="{Binding HasDeviceLinkDroppedWarning}" Value="True">
@@ -2231,7 +2227,7 @@
                             </Style>
                         </Border.Style>
                         <TextBlock
-                            Foreground="{StaticResource NotificationErrorBrush}"
+                            Foreground="{StaticResource HF_AlertErrorTextBrush}"
                             Text="{Binding DeviceLinkDroppedWarningText}"
                             TextWrapping="Wrap" />
                     </Border>
@@ -2240,11 +2236,9 @@
                           Complete (the step panel that raised it is already hidden), so it must render here too  -->
                     <Border
                         Margin="0,5"
-                        Padding="5"
-                        BorderBrush="{StaticResource NotificationErrorBrush}"
-                        BorderThickness="1">
+                        Padding="5">
                         <Border.Style>
-                            <Style TargetType="Border">
+                            <Style TargetType="Border" BasedOn="{StaticResource HF_AlertErrorBadge}">
                                 <Setter Property="Visibility" Value="Collapsed" />
                                 <Style.Triggers>
                                     <DataTrigger Binding="{Binding HasMeasurementConsistencyWarning}" Value="True">
@@ -2254,7 +2248,7 @@
                             </Style>
                         </Border.Style>
                         <TextBlock
-                            Foreground="{StaticResource NotificationErrorBrush}"
+                            Foreground="{StaticResource HF_AlertErrorTextBrush}"
                             Text="{Binding MeasurementConsistencyWarningText}"
                             TextWrapping="Wrap" />
                     </Border>
@@ -2262,11 +2256,9 @@
                     <!--  Re-baseline drift warning (an undo between moves left residual tilt)  -->
                     <Border
                         Margin="0,5"
-                        Padding="5"
-                        BorderBrush="{StaticResource NotificationErrorBrush}"
-                        BorderThickness="1">
+                        Padding="5">
                         <Border.Style>
-                            <Style TargetType="Border">
+                            <Style TargetType="Border" BasedOn="{StaticResource HF_AlertErrorBadge}">
                                 <Setter Property="Visibility" Value="Collapsed" />
                                 <Style.Triggers>
                                     <DataTrigger Binding="{Binding HasRebaselineDriftWarning}" Value="True">
@@ -2276,7 +2268,7 @@
                             </Style>
                         </Border.Style>
                         <TextBlock
-                            Foreground="{StaticResource NotificationErrorBrush}"
+                            Foreground="{StaticResource HF_AlertErrorTextBrush}"
                             Text="{Binding RebaselineDriftWarningText}"
                             TextWrapping="Wrap" />
                     </Border>
@@ -2284,11 +2276,9 @@
                     <!--  Low calibration confidence: measurement noise rivals the screw-move signal (do not apply)  -->
                     <Border
                         Margin="0,5"
-                        Padding="5"
-                        BorderBrush="{StaticResource NotificationErrorBrush}"
-                        BorderThickness="1">
+                        Padding="5">
                         <Border.Style>
-                            <Style TargetType="Border">
+                            <Style TargetType="Border" BasedOn="{StaticResource HF_AlertErrorBadge}">
                                 <Setter Property="Visibility" Value="Collapsed" />
                                 <Style.Triggers>
                                     <DataTrigger Binding="{Binding HasConfidenceWarning}" Value="True">
@@ -2298,7 +2288,7 @@
                             </Style>
                         </Border.Style>
                         <TextBlock
-                            Foreground="{StaticResource NotificationErrorBrush}"
+                            Foreground="{StaticResource HF_AlertErrorTextBrush}"
                             Text="{Binding ConfidenceWarningText}"
                             TextWrapping="Wrap" />
                     </Border>

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/TiltAdapterWizard/DataTemplates.xaml
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/TiltAdapterWizard/DataTemplates.xaml
@@ -1727,7 +1727,7 @@
                             HorizontalAlignment="Left"
                             Command="{Binding ClearCalibrationCommand}"
                             ToolTip="Clears the saved calibration (screw angles and the calibrated/manual flags), returning this pane to &quot;No calibration saved.&quot; The device selection and its configured hardware/direction are kept — re-run the wizard or use Manual Calibration Entry to set a new one.">
-                            <TextBlock Margin="6,2" Text="Clear Calibration" />
+                            <TextBlock Margin="6,2" Foreground="{StaticResource ButtonForegroundBrush}" Text="Clear Calibration" />
                         </Button>
                     </StackPanel>
 

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/TiltAdapterWizard/DataTemplates.xaml
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/TiltAdapterWizard/DataTemplates.xaml
@@ -1698,7 +1698,7 @@
                                         HorizontalAlignment="Left"
                                         FontWeight="Bold"
                                         Foreground="{StaticResource HF_AlertWarningTextBrush}"
-                                        Text="If your screw numbering does not match the device's motor wiring, Automatic Adjustment will drive the adapter unattended in the wrong direction and make tilt worse. Verify with a single manual adjustment before leaving it unattended."
+                                        Text="If your screw numbering does not match the device's motor wiring, Automatic Adjustment will drive the adapter unattended in the wrong direction and make tilt worse. Before trusting it, use Manual adjustment to move one screw a small amount and confirm the corner that actually moves is the one you expect for that screw label — then it is safe."
                                         TextWrapping="Wrap" />
                                     <WrapPanel Margin="0,6,0,0">
                                         <Button

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/TiltAdapterWizard/DataTemplates.xaml
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/TiltAdapterWizard/DataTemplates.xaml
@@ -2126,8 +2126,7 @@
                           started as a device-driven run) — survives the advance to Complete (below), so it is
                           rendered there too.  -->
                     <Border
-                        Margin="0,6,0,0"
-                        Padding="5">
+                        Margin="0,6,0,0">
                         <Border.Style>
                             <Style TargetType="Border" BasedOn="{StaticResource HF_AlertErrorBadge}">
                                 <Setter Property="Visibility" Value="Collapsed" />
@@ -2146,8 +2145,7 @@
 
                     <!--  Consistency warning (shown when tilt measurements across runs diverge)  -->
                     <Border
-                        Margin="0,6,0,0"
-                        Padding="5">
+                        Margin="0,6,0,0">
                         <Border.Style>
                             <Style TargetType="Border" BasedOn="{StaticResource HF_AlertErrorBadge}">
                                 <Setter Property="Visibility" Value="Collapsed" />
@@ -2298,8 +2296,7 @@
                     <!--  Device-link dropped mid-run: it survives the advance to Complete (the step panel that
                           raised it is already hidden), so it must render here too  -->
                     <Border
-                        Margin="0,5"
-                        Padding="5">
+                        Margin="0,5">
                         <Border.Style>
                             <Style TargetType="Border" BasedOn="{StaticResource HF_AlertErrorBadge}">
                                 <Setter Property="Visibility" Value="Collapsed" />
@@ -2319,8 +2316,7 @@
                     <!--  Consistency warning raised by the final step's repeats: it survives the advance to
                           Complete (the step panel that raised it is already hidden), so it must render here too  -->
                     <Border
-                        Margin="0,5"
-                        Padding="5">
+                        Margin="0,5">
                         <Border.Style>
                             <Style TargetType="Border" BasedOn="{StaticResource HF_AlertErrorBadge}">
                                 <Setter Property="Visibility" Value="Collapsed" />
@@ -2339,8 +2335,7 @@
 
                     <!--  Re-baseline drift warning (an undo between moves left residual tilt)  -->
                     <Border
-                        Margin="0,5"
-                        Padding="5">
+                        Margin="0,5">
                         <Border.Style>
                             <Style TargetType="Border" BasedOn="{StaticResource HF_AlertErrorBadge}">
                                 <Setter Property="Visibility" Value="Collapsed" />
@@ -2360,9 +2355,11 @@
                     <!--  Low calibration confidence: measurement noise rivals the screw-move signal (do not apply)  -->
                     <Border
                         Margin="0,5"
-                        Padding="5">
+                        Padding="5"
+                        BorderBrush="{StaticResource NotificationErrorBrush}"
+                        BorderThickness="1">
                         <Border.Style>
-                            <Style TargetType="Border" BasedOn="{StaticResource HF_AlertErrorBadge}">
+                            <Style TargetType="Border">
                                 <Setter Property="Visibility" Value="Collapsed" />
                                 <Style.Triggers>
                                     <DataTrigger Binding="{Binding HasConfidenceWarning}" Value="True">
@@ -2372,7 +2369,7 @@
                             </Style>
                         </Border.Style>
                         <TextBlock
-                            Foreground="{StaticResource HF_AlertErrorTextBrush}"
+                            Foreground="{StaticResource HF_AlertErrorAccentBrush}"
                             Text="{Binding ConfidenceWarningText}"
                             TextWrapping="Wrap" />
                     </Border>

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/TiltAdapterWizard/DataTemplates.xaml
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/TiltAdapterWizard/DataTemplates.xaml
@@ -1653,6 +1653,70 @@
                                 Content="{Binding}" />
                         </Grid>
 
+                        <!--  [CRITICAL GATE] Automation is blocked for a calibration that is not device-linked or
+                              not confidence-checked. Clearing those markers used to be entirely silent — a user
+                              who corrected one angle by hand after a device-driven run lost Automatic Adjustment
+                              with no message and no way back short of repeating the calibration. Filled badge
+                              rather than the quiet outlined style because this CARRIES AN ACTION and explains a
+                              capability that has disappeared (same reasoning as the idle-countdown banner in
+                              AutoFocus/DataTemplates.xaml).  -->
+                        <Border Margin="0,10,0,0" Visibility="{Binding AutomationTrustBannerVisible, Converter={StaticResource BooleanToVisibilityCollapsedConverter}}"
+                            Style="{StaticResource HF_AlertWarningBadge}">
+                            <StackPanel>
+                                <TextBlock
+                                    MaxWidth="520"
+                                    HorizontalAlignment="Left"
+                                    FontWeight="Bold"
+                                    Foreground="{StaticResource HF_AlertWarningTextBrush}"
+                                    Text="Automatic Adjustment is disabled"
+                                    TextWrapping="Wrap" />
+                                <TextBlock
+                                    MaxWidth="520"
+                                    Margin="0,3,0,0"
+                                    HorizontalAlignment="Left"
+                                    Foreground="{StaticResource HF_AlertWarningTextBrush}"
+                                    Text="This calibration was entered or edited by hand, so HocusFocus cannot verify that your screw numbering matches the device's motor wiring. Re-run the wizard with the device connected, or trust this calibration explicitly."
+                                    TextWrapping="Wrap" />
+
+                                <!--  Step 1: arm.  -->
+                                <Button
+                                    Margin="0,6,0,0"
+                                    HorizontalAlignment="Left"
+                                    Command="{Binding TrustCalibrationCommand}"
+                                    Visibility="{Binding IsTrustCalibrationPending, Converter={StaticResource InverseBooleanToVisibilityCollapsedConverter}}">
+                                    <TextBlock
+                                        Margin="10,5,10,5"
+                                        Foreground="{StaticResource ButtonForegroundBrush}"
+                                        Text="Trust This Calibration for Automation" />
+                                </Button>
+
+                                <!--  Step 2: the risk, then confirm or back out.  -->
+                                <StackPanel Visibility="{Binding IsTrustCalibrationPending, Converter={StaticResource BooleanToVisibilityCollapsedConverter}}">
+                                    <TextBlock
+                                        MaxWidth="520"
+                                        Margin="0,6,0,0"
+                                        HorizontalAlignment="Left"
+                                        FontWeight="Bold"
+                                        Foreground="{StaticResource HF_AlertWarningTextBrush}"
+                                        Text="If your screw numbering does not match the device's motor wiring, Automatic Adjustment will drive the adapter unattended in the wrong direction and make tilt worse. Verify with a single manual adjustment before leaving it unattended."
+                                        TextWrapping="Wrap" />
+                                    <WrapPanel Margin="0,6,0,0">
+                                        <Button Command="{Binding ConfirmTrustCalibrationCommand}">
+                                            <TextBlock
+                                                Margin="10,5,10,5"
+                                                Foreground="{StaticResource ButtonForegroundBrush}"
+                                                Text="Yes, trust it" />
+                                        </Button>
+                                        <Button Margin="6,0,0,0" Command="{Binding CancelTrustCalibrationCommand}">
+                                            <TextBlock
+                                                Margin="10,5,10,5"
+                                                Foreground="{StaticResource ButtonForegroundBrush}"
+                                                Text="Cancel" />
+                                        </Button>
+                                    </WrapPanel>
+                                </StackPanel>
+                            </StackPanel>
+                        </Border>
                         <Button
                             Margin="0,10,0,0"
                             HorizontalAlignment="Left"

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/TiltAdapterWizard/DataTemplates.xaml
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/TiltAdapterWizard/DataTemplates.xaml
@@ -1754,7 +1754,8 @@
                     <TextBlock
                         Margin="0,1,0,6"
                         FontWeight="Bold"
-                        Text="{Binding StepTitle}" />
+                        Text="{Binding StepTitle}"
+                        ToolTip="Moving every screw or motor together changes backfocus, and this step measures which way the adapter plate actually travels. A '+' step is not assumed to be inward — determining that direction is the point of the step." />
 
                     <TextBlock
                         Margin="0,0,0,10"

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/TiltAdapterWizard/TiltAdapterWizardVM.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/TiltAdapterWizard/TiltAdapterWizardVM.cs
@@ -3308,7 +3308,16 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
             // the same lastConfidence.IsReliable the wizard already surfaces as the (previously non-blocking)
             // HasConfidenceWarning banner above.
             tiltAdapterOptions.CalibrationIsReliable = lastConfidence?.IsReliable ?? false;
+            // A stale confirmation must not survive the state change that invalidated it -- the same invariant
+            // ApplyManualCalibration, ClearCalibration and the DeviceName handler apply. A fresh run rewrites
+            // both automation markers above, so a Trust confirmation armed against the PREVIOUS calibration is
+            // no longer about the calibration on screen; re-arm from the banner's button if it is still needed.
+            IsTrustCalibrationPending = false;
             RaiseHardwareSummaryChanged();
+            // Neither marker written above routes back through the options PropertyChanged handler that raises
+            // the banner, and IsCalibrated/CalibratedScrewCount raise nothing when a re-calibration leaves them
+            // unchanged -- so the banner would otherwise keep showing the previous run's verdict.
+            RaisePropertyChanged(nameof(AutomationTrustBannerVisible));
         }
 
         private void RaiseHardwareSummaryChanged() {

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/TiltAdapterWizard/TiltAdapterWizardVM.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/TiltAdapterWizard/TiltAdapterWizardVM.cs
@@ -64,7 +64,10 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
     /// </summary>
     public enum WizardStep {
         Baseline = 0,     // a
-        AllInward = 1,    // b: all screws inward once (curvature/backfocus sign via a→b)
+        AllInward = 1,    // b: all screws clockwise / all motors +N once (curvature/backfocus sign via a→b;
+                          // the NAME is historical and stays — it is persisted in saved replay runs — but no
+                          // user-facing string may claim "+N" is physically inward: measuring that is the
+                          // whole purpose of this step.
         ReBaseline1 = 2,  // c: all screws back out once (≈ baseline)
         Screw1 = 3,       // d: screw 1 inward once (4-screw: + screw 3 outward)
         ReBaseline2 = 4,  // e: undo the screw-1 move (≈ c)
@@ -480,6 +483,7 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
                     // Adjustment type changes the prompt vocabulary (screw turns vs signed steps).
                     RaisePropertyChanged(nameof(CwDirectionLabel));
                     RaisePropertyChanged(nameof(StepInstructions));
+                    RaisePropertyChanged(nameof(StepTitle));
                     RaisePropertyChanged(nameof(BaselineRecoveryInstructions));
                     RaiseHardwareSummaryChanged();
                 }
@@ -748,12 +752,14 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
 
         // Short, scannable title shown above the longer StepInstructions paragraph so the user can tell where
         // they are without re-reading the instructions.
-        public string StepTitle => StepTitleText(currentStep, ScrewLabels);
+        public string StepTitle => StepTitleText(currentStep, ScrewLabels, IsStepperAdjustment);
 
-        internal static string StepTitleText(WizardStep step, IScrewLabelProvider labels = null) {
+        internal static string StepTitleText(WizardStep step, IScrewLabelProvider labels = null, bool isStepper = false) {
             switch (step) {
                 case WizardStep.Baseline: return "Baseline Measurement";
-                case WizardStep.AllInward: return "All Screws Inward";
+                // NOT "All Screws Inward": the wizard applies +N to every motor and MEASURES which way the
+                // adapter plate goes. Naming the direction here contradicts the step and misreads as a bug.
+                case WizardStep.AllInward: return isStepper ? "All Motors + Steps" : "All Screws Clockwise";
                 case WizardStep.ReBaseline1: return "Return to Baseline";
                 case WizardStep.Screw1: return $"Move {TiltScrewLabels.Resolve(labels, 1)}";
                 case WizardStep.ReBaseline2: return "Return to Baseline";
@@ -1039,7 +1045,7 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
         // IsTiltDeviceConnected is false whenever the service is null or not connected).
         public string StepInstructions =>
             IsReplaying
-                ? ReplayStepInstructionsText(currentStep, ScrewLabels)
+                ? ReplayStepInstructionsText(currentStep, ScrewLabels, IsStepperAdjustment)
                 : (IsTiltDeviceConnected && IsMotorizedDevice)
                     ? DeviceStepInstructionsText(currentStep, (int)Math.Round(CalibrationAppliedAmount), IsAutoRunningAll,
                         ActiveRunHasFinalRebaseline)
@@ -1048,8 +1054,8 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
         // Replay wording: a replay re-analyzes already-captured frames, so every imperative in the live copy
         // ("turn ALL screws CLOCKWISE", "click Run Measurement") is wrong — nothing is captured, no hardware
         // moves, and the measurement buttons are collapsed by the IsMeasuring trigger for the whole replay.
-        internal static string ReplayStepInstructionsText(WizardStep step, IScrewLabelProvider labels = null) =>
-            $"Replaying — re-analyzing the saved frames for {StepTitleText(step, labels)}. No action needed: nothing is " +
+        internal static string ReplayStepInstructionsText(WizardStep step, IScrewLabelProvider labels = null, bool isStepper = false) =>
+            $"Replaying — re-analyzing the saved frames for {StepTitleText(step, labels, isStepper)}. No action needed: nothing is " +
             "captured and the tilt adapter is not moved during a replay.";
 
         // Automated-status wording for a connected, device-driven run: describes what the wizard will send

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/TiltAdapterWizard/TiltAdapterWizardVM.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/TiltAdapterWizard/TiltAdapterWizardVM.cs
@@ -362,6 +362,12 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
             RetryMeasurementCommand = new AsyncRelayCommand(RunMeasurementAsync, () => HasMeasurementFailureChoice && IsOnMeasurementStep && !IsMeasuring && AreDevicesConnected && !deviceRunAbandoned);
             ApplyManualCalibrationCommand = new RelayCommand(ApplyManualCalibration);
             ClearCalibrationCommand = new RelayCommand(ClearCalibration);
+            // No canExecute predicate on purpose: the whole banner that hosts these buttons is collapsed
+            // unless AutomationTrustBannerVisible, so gating them again would only add a second source of
+            // truth that NotifyCommandsCanExecuteChangedCore does not know to refresh.
+            TrustCalibrationCommand = new RelayCommand(() => IsTrustCalibrationPending = true);
+            ConfirmTrustCalibrationCommand = new RelayCommand(ConfirmTrustCalibration);
+            CancelTrustCalibrationCommand = new RelayCommand(() => IsTrustCalibrationPending = false);
             RefreshPortsCommand = new RelayCommand(RefreshPorts);
             ConnectDeviceCommand = new AsyncRelayCommand(ConnectTiltDeviceAsync, () =>
                 IsMotorizedDevice && this.tiltDeviceConnectionService != null && !IsTiltDeviceConnected && !string.IsNullOrEmpty(SelectedPortName));
@@ -440,11 +446,13 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
                 }
                 if (e.PropertyName == nameof(ITiltAdapterOptions.CalibrationIsManual)) {
                     RaisePropertyChanged(nameof(IsCalibrationValid));
+                    RaisePropertyChanged(nameof(AutomationTrustBannerVisible));
                 }
                 if (e.PropertyName == nameof(ITiltAdapterOptions.ScrewCount) ||
                     e.PropertyName == nameof(ITiltAdapterOptions.IsCalibrated) ||
                     e.PropertyName == nameof(ITiltAdapterOptions.CalibratedScrewCount)) {
                     RaisePropertyChanged(nameof(IsCalibrationValid));
+                    RaisePropertyChanged(nameof(AutomationTrustBannerVisible));
                     RebuildDiagram();
                 }
                 if (e.PropertyName == nameof(ITiltAdapterOptions.MeasurementAverageCount)) {
@@ -454,6 +462,12 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
                     RaisePropertyChanged(nameof(SelectedDevice));
                     RaisePropertyChanged(nameof(IsManualDevice));
                     RaisePropertyChanged(nameof(IsMotorizedDevice));
+                    RaisePropertyChanged(nameof(AutomationTrustBannerVisible));
+                    // [CRITICAL GATE] A pending Trust confirmation was armed against the PREVIOUS preset's screw
+                    // wiring; confirming it after a preset change would link the calibration to a device it was
+                    // never entered for. Same reasoning as ApplyManualCalibration's disarm: a stale confirmation
+                    // must not survive the state change that invalidated it.
+                    IsTrustCalibrationPending = false;
                     // A preset change swaps which stored label set is in effect, and which default names
                     // apply when the user has stored none -- every label-derived surface has to re-read.
                     RaiseScrewLabelsChanged();
@@ -801,6 +815,50 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
         public bool IsCalibrationValid =>
             tiltAdapterOptions.IsCalibrated &&
             tiltAdapterOptions.ScrewCount == tiltAdapterOptions.CalibratedScrewCount;
+
+        private bool isTrustCalibrationPending;
+
+        /// <summary>
+        /// True once the user has asked to trust a hand-entered calibration and the in-pane confirmation is
+        /// showing. Two-step rather than a modal, mirroring SimulatedTiltAdapterVM's CopyToAdapter trio, which
+        /// guards the structurally identical decision — and unlike a MyMessageBox it stays unit-testable.
+        /// </summary>
+        public bool IsTrustCalibrationPending {
+            get => isTrustCalibrationPending;
+            private set {
+                if (isTrustCalibrationPending != value) {
+                    isTrustCalibrationPending = value;
+                    RaisePropertyChanged();
+                }
+            }
+        }
+
+        /// <summary>
+        /// [CRITICAL GATE] Shown when a saved calibration cannot drive Automatic Adjustment because it is not
+        /// linked to the selected device preset, or did not pass its own confidence check — the exact pair
+        /// InspectorVM.CanExecuteAutomaticAdjustment requires. Gated on a motorized preset because there is
+        /// nothing to automate otherwise.
+        ///
+        /// This exists because clearing those markers used to be completely silent: a user who corrected one
+        /// angle by hand after a device-driven run lost Automatic Adjustment with no message, no cause named,
+        /// and no remedy short of repeating the whole calibration.
+        /// </summary>
+        public bool AutomationTrustBannerVisible =>
+            IsCalibrationValid
+            && IsMotorizedDevice
+            && !(InspectorVM.IsCalibrationDeviceLinked(tiltAdapterOptions) && tiltAdapterOptions.CalibrationIsReliable);
+
+        private void ConfirmTrustCalibration() {
+            IsTrustCalibrationPending = false;
+            // Deliberately re-arming the two markers ApplyManualCalibration cleared. The user has been told,
+            // in the confirmation copy, exactly what goes wrong if the screw numbering does not match the
+            // device's wiring. Both markers are re-cleared by every path that invalidates the correspondence:
+            // a fresh manual entry, ClearCalibration, or selecting a different device preset (which
+            // IsCalibrationDeviceLinked invalidates for free by comparing against the CURRENT DeviceName).
+            tiltAdapterOptions.DeviceLinkedCalibrationDeviceName = tiltAdapterOptions.DeviceName;
+            tiltAdapterOptions.CalibrationIsReliable = true;
+            RaisePropertyChanged(nameof(AutomationTrustBannerVisible));
+        }
 
         public bool HasCurvatureCalibration => tiltAdapterOptions.ScrewInwardCurvatureSign != 0;
 
@@ -1237,6 +1295,9 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
         public ICommand RetryMeasurementCommand { get; }
         public ICommand ApplyManualCalibrationCommand { get; }
         public ICommand ClearCalibrationCommand { get; }
+        public ICommand TrustCalibrationCommand { get; }
+        public ICommand ConfirmTrustCalibrationCommand { get; }
+        public ICommand CancelTrustCalibrationCommand { get; }
         public ICommand RefreshPortsCommand { get; }
         public ICommand ConnectDeviceCommand { get; }
         public ICommand DisconnectDeviceCommand { get; }
@@ -1374,6 +1435,10 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
             tiltAdapterOptions.IsCalibrated = true;
             tiltAdapterOptions.ScrewInwardCurvatureSignIsMeasured = false;
             tiltAdapterOptions.CalibrationIsManual = true;
+            // Whether this entry actually TAKES automation away, so a first-ever manual entry (which never had
+            // it) does not warn about losing something the user never had.
+            bool revokedAutomation =
+                InspectorVM.IsCalibrationDeviceLinked(tiltAdapterOptions) || tiltAdapterOptions.CalibrationIsReliable;
             // [CRITICAL GATE] A manual entry's screw numbering/orientation is not guaranteed to match how the
             // device's motors are wired — clear any device-linked marker so automation (the wizard's
             // hands-off calibration and the inspector's Automatic Adjustment, T14) stays blocked until a
@@ -1383,6 +1448,14 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
             // tilt vectors — the user typed a single angle) — conservative default: not automation-trusted
             // until a fresh calibration run demonstrably passes its own confidence check.
             tiltAdapterOptions.CalibrationIsReliable = false;
+            // A stale confirmation must not survive the state change that invalidated it.
+            IsTrustCalibrationPending = false;
+            if (revokedAutomation) {
+                Notification.ShowWarning(
+                    "Automatic Adjustment is now disabled: a hand-entered calibration can't be checked against the " +
+                    "device's motor wiring. Use \"Trust This Calibration for Automation\" in the wizard to re-enable it, " +
+                    "or re-run calibration with the device connected.");
+            }
             // A manual entry supersedes whatever wizard run last measured the hardware — reset to the
             // unset sentinel (-1, what the options initialize to; PitchMismatchExceeds ignores <= 0) so
             // the inspector's pitch-mismatch warning can't compare the new adapter's configured pitch
@@ -1405,6 +1478,7 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
             ClearSummaryRows();
             RaiseHardwareSummaryChanged();
             RebuildDiagram();
+            RaisePropertyChanged(nameof(AutomationTrustBannerVisible));
         }
 
         /// <summary>
@@ -1422,6 +1496,11 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
             tiltAdapterOptions.CalibratedScrewCount = 0;
             tiltAdapterOptions.IsCalibrated = false;
             tiltAdapterOptions.CalibrationIsManual = false;
+            // [CRITICAL GATE] Clearing the calibration must also clear what made it automation-trusted; leaving
+            // these set would let a later Trust-free calibration inherit a stale link.
+            tiltAdapterOptions.DeviceLinkedCalibrationDeviceName = string.Empty;
+            tiltAdapterOptions.CalibrationIsReliable = false;
+            IsTrustCalibrationPending = false;
             tiltAdapterOptions.ScrewInwardCurvatureSignIsMeasured = false;
             tiltAdapterOptions.LastMeasuredThreadPitchMicrons = -1;
             tiltAdapterOptions.LastMeasuredStepperStepSizeMicrons = -1;
@@ -1439,6 +1518,7 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
             ClearSummaryRows();
             RaiseHardwareSummaryChanged();
             RebuildDiagram();
+            RaisePropertyChanged(nameof(AutomationTrustBannerVisible));
         }
 
         // Shared by ApplyManualCalibration, ClearCalibration, and Restart: every path that invalidates the

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/TiltAdapterWizard/TiltAdapterWizardVM.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/TiltAdapterWizard/TiltAdapterWizardVM.cs
@@ -554,6 +554,13 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
                 RaisePropertyChanged(nameof(CwDirectionLabel));
                 RaisePropertyChanged(nameof(HasCurvatureCalibration));
                 RaisePropertyChanged(nameof(IsCalibrationValid));
+                // [CRITICAL GATE] The banner is derived from IsCalibrationValid + the two automation markers,
+                // and the options reload above raises only the broadcast (null-name) PropertyChanged the named
+                // filters never match -- so without these two lines an armed confirmation stays on screen
+                // across a profile switch, now describing a DIFFERENT profile's calibration, and "Yes, trust
+                // it" would write both markers for a calibration the user never saw the arm-step warning for.
+                IsTrustCalibrationPending = false;
+                RaisePropertyChanged(nameof(AutomationTrustBannerVisible));
                 RaisePropertyChanged(nameof(StepInstructions));
                 RaisePropertyChanged(nameof(StepTitle));
                 RaisePropertyChanged(nameof(BaselineRecoveryInstructions));
@@ -851,8 +858,26 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
             && IsMotorizedDevice
             && !(InspectorVM.IsCalibrationDeviceLinked(tiltAdapterOptions) && tiltAdapterOptions.CalibrationIsReliable);
 
+        /// <summary>
+        /// [CRITICAL GATE] Whether automation was actually AVAILABLE before a manual entry wipes the markers --
+        /// i.e. whether the warning has anything true to report. Deliberately AND, exactly mirroring
+        /// InspectorVM.CanExecuteAutomaticAdjustment (which requires deviceLinked AND calibrationIsReliable) and
+        /// AutomationTrustBannerVisible's !(linked &amp;&amp; reliable). With OR, a calibration that was reliable but
+        /// never device-linked (a wizard run on the Manual preset, or a disconnected live run) would warn that
+        /// Automatic Adjustment "is now disabled" when it had been blocked all along -- and point at a Trust
+        /// button the non-motorized banner never shows.
+        /// </summary>
+        internal static bool ManualEntryRevokesAutomation(ITiltAdapterOptions options) =>
+            InspectorVM.IsCalibrationDeviceLinked(options) && (options?.CalibrationIsReliable ?? false);
+
         private void ConfirmTrustCalibration() {
             IsTrustCalibrationPending = false;
+            // The precondition that justified showing the button at all. Its Border being collapsed is a
+            // UI-only guarantee, and this write unlocks unattended hardware motion -- too much to rest on a
+            // XAML binding. This is NOT the second source of truth the ctor comment warns about: that concern
+            // is specific to a canExecute predicate, which NotifyCommandsCanExecuteChangedCore would have to
+            // remember to refresh. An early return in the body is evaluated fresh on every click.
+            if (!AutomationTrustBannerVisible) return;
             // Deliberately re-arming the two markers ApplyManualCalibration cleared. The user has been told,
             // in the confirmation copy, exactly what goes wrong if the screw numbering does not match the
             // device's wiring. Both markers are re-cleared by every path that invalidates the correspondence:
@@ -1440,8 +1465,7 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
             tiltAdapterOptions.CalibrationIsManual = true;
             // Whether this entry actually TAKES automation away, so a first-ever manual entry (which never had
             // it) does not warn about losing something the user never had.
-            bool revokedAutomation =
-                InspectorVM.IsCalibrationDeviceLinked(tiltAdapterOptions) || tiltAdapterOptions.CalibrationIsReliable;
+            bool revokedAutomation = ManualEntryRevokesAutomation(tiltAdapterOptions);
             // [CRITICAL GATE] A manual entry's screw numbering/orientation is not guaranteed to match how the
             // device's motors are wired — clear any device-linked marker so automation (the wizard's
             // hands-off calibration and the inspector's Automatic Adjustment, T14) stays blocked until a

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/TiltAdapterWizard/TiltAdapterWizardVM.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/TiltAdapterWizard/TiltAdapterWizardVM.cs
@@ -555,6 +555,7 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
                 RaisePropertyChanged(nameof(HasCurvatureCalibration));
                 RaisePropertyChanged(nameof(IsCalibrationValid));
                 RaisePropertyChanged(nameof(StepInstructions));
+                RaisePropertyChanged(nameof(StepTitle));
                 RaisePropertyChanged(nameof(BaselineRecoveryInstructions));
                 RaisePropertyChanged(nameof(AdjustmentType));
                 RaisePropertyChanged(nameof(IsStepperAdjustment));
@@ -768,12 +769,14 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
         // they are without re-reading the instructions.
         public string StepTitle => StepTitleText(currentStep, ScrewLabels, IsStepperAdjustment);
 
-        internal static string StepTitleText(WizardStep step, IScrewLabelProvider labels = null, bool isStepper = false) {
+        internal static string StepTitleText(WizardStep step, IScrewLabelProvider labels, bool isStepper) {
             switch (step) {
                 case WizardStep.Baseline: return "Baseline Measurement";
                 // NOT "All Screws Inward": the wizard applies +N to every motor and MEASURES which way the
                 // adapter plate goes. Naming the direction here contradicts the step and misreads as a bug.
-                case WizardStep.AllInward: return isStepper ? "All Motors + Steps" : "All Screws Clockwise";
+                // "Positive Steps", not "+ Steps": the latter parses as two nouns ("motors AND steps") rather
+                // than naming the sign the instruction body actually uses ("Apply +N steps to EVERY motor").
+                case WizardStep.AllInward: return isStepper ? "All Motors Positive Steps" : "All Screws Clockwise";
                 case WizardStep.ReBaseline1: return "Return to Baseline";
                 case WizardStep.Screw1: return $"Move {TiltScrewLabels.Resolve(labels, 1)}";
                 case WizardStep.ReBaseline2: return "Return to Baseline";
@@ -1112,7 +1115,7 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
         // Replay wording: a replay re-analyzes already-captured frames, so every imperative in the live copy
         // ("turn ALL screws CLOCKWISE", "click Run Measurement") is wrong — nothing is captured, no hardware
         // moves, and the measurement buttons are collapsed by the IsMeasuring trigger for the whole replay.
-        internal static string ReplayStepInstructionsText(WizardStep step, IScrewLabelProvider labels = null, bool isStepper = false) =>
+        internal static string ReplayStepInstructionsText(WizardStep step, IScrewLabelProvider labels, bool isStepper) =>
             $"Replaying — re-analyzing the saved frames for {StepTitleText(step, labels, isStepper)}. No action needed: nothing is " +
             "captured and the tilt adapter is not moved during a replay.";
 
@@ -3753,7 +3756,7 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
                     // Safe mid-replay despite the setter's NotifyCommandsCanExecuteChanged: IsMeasuring is true for
                     // the whole run, which is what actually gates every measurement command's canExecute.
                     CurrentStep = step;
-                    StatusText = $"Replaying {StepTitleText(step, ScrewLabels)}...";
+                    StatusText = $"Replaying {StepTitleText(step, ScrewLabels, IsStepperAdjustment)}...";
                     // Capture-time modes ("use captured in memory" and "update profile") replay each step with its own
                     // detached capture-time star-detection snapshot as an override, so the live profile is untouched
                     // during the replay. "Use current settings" passes null and uses the current profile.

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/TiltAdapterWizard/TiltAdapterWizardVM.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/TiltAdapterWizard/TiltAdapterWizardVM.cs
@@ -448,6 +448,13 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
                     RaisePropertyChanged(nameof(IsCalibrationValid));
                     RaisePropertyChanged(nameof(AutomationTrustBannerVisible));
                 }
+                // The banner reads both automation markers directly, so it must re-raise when they change --
+                // structurally, not by relying on every writer to also move a watched property or raise it by
+                // hand. Cheap, and it makes a future writer correct by default.
+                if (e.PropertyName == nameof(ITiltAdapterOptions.DeviceLinkedCalibrationDeviceName) ||
+                    e.PropertyName == nameof(ITiltAdapterOptions.CalibrationIsReliable)) {
+                    RaisePropertyChanged(nameof(AutomationTrustBannerVisible));
+                }
                 if (e.PropertyName == nameof(ITiltAdapterOptions.ScrewCount) ||
                     e.PropertyName == nameof(ITiltAdapterOptions.IsCalibrated) ||
                     e.PropertyName == nameof(ITiltAdapterOptions.CalibratedScrewCount)) {
@@ -844,18 +851,30 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
         }
 
         /// <summary>
-        /// [CRITICAL GATE] Shown when a saved calibration cannot drive Automatic Adjustment because it is not
-        /// linked to the selected device preset, or did not pass its own confidence check — the exact pair
+        /// [CRITICAL GATE] Shown when a HAND-ENTERED calibration cannot drive Automatic Adjustment because it is
+        /// not linked to the selected device preset, or did not pass its own confidence check — the exact pair
         /// InspectorVM.CanExecuteAutomaticAdjustment requires. Gated on a motorized preset because there is
         /// nothing to automate otherwise.
         ///
         /// This exists because clearing those markers used to be completely silent: a user who corrected one
         /// angle by hand after a device-driven run lost Automatic Adjustment with no message, no cause named,
         /// and no remedy short of repeating the whole calibration.
+        ///
+        /// CalibrationIsManual is load-bearing, not decoration. Without it this is also true for three states
+        /// that are NOT hand-entry — a device-driven run that completed but was low-confidence, a replay, and a
+        /// disconnected live run — where the banner's "entered or edited by hand" copy would simply be false.
+        ///
+        /// Deliberately NOT offered for the low-confidence case, and do not widen it back: Trust writes
+        /// CalibrationIsReliable = true, which overrides the noise-vs-signal QUALITY check, not the device link.
+        /// The verification the risk copy asks for — move one screw, watch which corner moves — can confirm a
+        /// screw numbering, but it cannot detect a noise-dominated calibration, which has correct numbering and
+        /// wrong angles. Consenting to that would be uninformed consent, and the Inspector already prescribes
+        /// the right remedy ("Re-run calibration to enable Automatic Adjustment").
         /// </summary>
         public bool AutomationTrustBannerVisible =>
             IsCalibrationValid
             && IsMotorizedDevice
+            && tiltAdapterOptions.CalibrationIsManual
             && !(InspectorVM.IsCalibrationDeviceLinked(tiltAdapterOptions) && tiltAdapterOptions.CalibrationIsReliable);
 
         /// <summary>

--- a/docs/tilt-adapter-ui-review-design.md
+++ b/docs/tilt-adapter-ui-review-design.md
@@ -80,7 +80,7 @@ confirmed.
    Optionally append the variant: "Step 3 of 6 (direction measurement included)".
 
 2. **[H] Per-step header (request b).** Add a short `StepTitle` above the instruction paragraph: Baseline →
-   "Baseline Measurement", AllInward → "All Screws Clockwise" / "All Motors + Steps", ReBaseline → "Return to Baseline", Screw1/2 →
+   "Baseline Measurement", AllInward → "All Screws Clockwise" / "All Motors Positive Steps", ReBaseline → "Return to Baseline", Screw1/2 →
    "Move Screw 1/2", Complete → "Calibration Complete". Render bold, mirroring Panel C's existing bold header.
 
 3. **[H] Auto-Run-All copy (request c).** `DeviceStepInstructionsText` always ends "Click Run Measurement (or

--- a/docs/tilt-adapter-ui-review-design.md
+++ b/docs/tilt-adapter-ui-review-design.md
@@ -80,7 +80,7 @@ confirmed.
    Optionally append the variant: "Step 3 of 6 (direction measurement included)".
 
 2. **[H] Per-step header (request b).** Add a short `StepTitle` above the instruction paragraph: Baseline →
-   "Baseline Measurement", AllInward → "All Screws Inward", ReBaseline → "Return to Baseline", Screw1/2 →
+   "Baseline Measurement", AllInward → "All Screws Clockwise" / "All Motors + Steps", ReBaseline → "Return to Baseline", Screw1/2 →
    "Move Screw 1/2", Complete → "Calibration Complete". Render bold, mirroring Panel C's existing bold header.
 
 3. **[H] Auto-Run-All copy (request c).** `DeviceStepInstructionsText` always ends "Click Run Measurement (or

--- a/docs/tilt-calibration-ux-feedback-design.md
+++ b/docs/tilt-calibration-ux-feedback-design.md
@@ -221,7 +221,9 @@ violate that rule, and they are the only reason the run looks wrong.
 
 Wording only; no behavior change, no math change.
 
-1. `TiltAdapterWizardVM.StepTitleText` gains a `bool isStepper = false` parameter:
+1. `TiltAdapterWizardVM.StepTitleText` gains a **required** `bool isStepper` parameter (no default — its two
+   sibling methods `StepInstructionsText` and `BaselineRecoveryText` already require it, and that is what forces
+   every call site to make an explicit choice; a defaulted bool silently gives a stepper rig screw wording):
    - screws → `"All Screws Clockwise"`
    - steppers → `"All Motors Positive Steps"`
 

--- a/docs/tilt-calibration-ux-feedback-design.md
+++ b/docs/tilt-calibration-ux-feedback-design.md
@@ -1,0 +1,328 @@
+# Tilt Adapter Calibration — UX Feedback Design
+
+Three user-reported problems with the Tilt Adapter Calibration wizard, addressed together because two of them
+(the illegible alert text and the missing explanation for a blocked automation gate) are the same failure:
+the plugin knows something the user needs and fails to put it on screen legibly.
+
+| # | Reported as | Actual defect |
+|---|---|---|
+| 1 | "Red alert text during tilt calibration is very difficult to see against dark themes" | NINA's `NotificationError/WarningBrush` are **background** colors used as `Foreground` at 27 sites. 1.06–1.9:1 contrast on every dark schema. |
+| 2 | "Wizard says it moves screws/steppers inwards, but moves EAT motors positive, which would be outwards" | **No motion defect.** The step is titled `"All Screws Inward"` while it applies `+N` to every motor — and `+N`'s physical direction is precisely what the step *measures*. Stale label, contradicting the plugin's own naming rule. |
+| 3 | "I forced the rotation angle to the one I know is true… then it said it can't do automation because my calibration didn't fit this setup" | `ApplyManualCalibration()` silently clears both automation gates. Correct safety behavior, zero communication, and no way back short of a full re-run. |
+
+---
+
+## Part 1 — Accessible alert badges
+
+### The defect
+
+NINA's color schemas define `NotificationErrorColor` / `NotificationWarningColor` as **fills** to be paired with
+`NotificationErrorTextColor` / `NotificationWarningTextColor`. NINA itself only ever uses them as `Background`
+(`NINA.Sequencer/Trigger/Datatemplates.xaml`, `MiniSequenceItem.xaml`, `ProgressStyle.xaml`).
+
+HocusFocus uses them as `Foreground` in 27 places. In 14 of the 16 built-in schemas that color is `#FF700000`
+(error) and `#FF5E330B` (warning) — near-black reds — so against a dark page background the text is invisible:
+
+| Schema | page bg | red text on page (today) |
+|---|---|---|
+| Persian / Persian Faint | `#263238` | **1.06:1** |
+| Vivid Malachite | `#34403A` | **1.15:1** |
+| Arsenic | `#394648` | **1.27:1** |
+| Dark | `#02010A` | **1.67:1** |
+| High Contrast | `#000000` | **1.69:1** |
+
+WCAG AA body text wants 4.5:1.
+
+### Why the plain NINA badge is not enough
+
+Switching to NINA's own convention (fill = alert brush, text = `NotificationErrorTextBrush`) fixes 11 schemas but
+**not the ones that matter most**, because several schemas pair a dark fill with near-black text:
+
+| Schema | `NotificationErrorTextColor` on `NotificationErrorColor` |
+|---|---|
+| **Dark** | `#02010A` on `#700000` → **1.67:1** |
+| **Classic** | `#000000` on `#700000` → **1.69:1** |
+| **Navy** | `#6FC3DF` on `#DB0606` → **2.61:1** |
+
+"Dark" is the likeliest schema for a user reporting a dark-theme problem, so a plain badge would not fix the
+report. The badge therefore keeps NINA's fill (native look, follows custom schemes) but computes its **text**
+color instead of reading it.
+
+### Design
+
+**`Converters/ContrastMath.cs`** — pure static, no WPF plumbing, directly unit-testable:
+
+- `RelativeLuminance(Color)` — WCAG 2.x sRGB linearization.
+- `ContrastRatio(Color a, Color b)` — `(L_hi + 0.05) / (L_lo + 0.05)`.
+- `BestContrastText(Color fill)` → `Colors.Black` or `Colors.White`, whichever contrasts more with `fill`.
+- `AccessibleAccent(Color alert, Color pageBackground)` → the alert color adjusted to clear the ratio target
+  **in HSL, preserving hue and saturation, moving only lightness**, by binary search (24 iterations, evaluated on
+  the byte-rounded color so the returned value is the one actually rendered).
+  - Moving in HSL rather than lerping toward white matters: `#700000` lerped toward white only reaches 4.5:1 at
+    `#A96666` (a washed-out rose), while raising HSL lightness reaches it at `#EF0000` — still obviously red.
+  - Direction: whichever pole (lighter/darker) can reach the target; if both can, away from the background's
+    luminance. If neither can, fall back to `BestContrastText(pageBackground)`.
+
+**Ratio target is 4.6 internally, asserted at ≥ 4.5 in tests.** The 0.1 margin absorbs byte rounding and
+float differences; targeting 4.5 exactly lands results at 4.50–4.53 with no headroom.
+
+**`Converters/BadgeTextColorConverter.cs`** (`IValueConverter`, `Color → Color`) and
+**`Converters/AccessibleAccentColorConverter.cs`** (`IMultiValueConverter`, `[alertColor, backgroundColor] → Color`).
+Thin wrappers; all logic stays in `ContrastMath`.
+
+**`Resources/AlertBrushes.xaml`** — a new `ResourceDictionary` defining four brushes, using the same
+bound-`SolidColorBrush.Color` shape NINA uses in `NINA.WPF.Base/Resources/StaticResources/Brushes.xaml`, so they
+re-evaluate when the user changes color schema at runtime:
+
+| Key | Bound to | Role |
+|---|---|---|
+| `HF_AlertErrorTextBrush` | `NotificationErrorBrush.Color` → `BadgeTextColorConverter` | text **on** an error badge |
+| `HF_AlertWarningTextBrush` | `NotificationWarningBrush.Color` → `BadgeTextColorConverter` | text **on** a warning badge |
+| `HF_AlertErrorAccentBrush` | `[NotificationErrorBrush.Color, BackgroundBrush.Color]` → `AccessibleAccentColorConverter` | inline error text **on the page** |
+| `HF_AlertWarningAccentBrush` | `[NotificationWarningBrush.Color, BackgroundBrush.Color]` → `AccessibleAccentColorConverter` | inline warning text **on the page** |
+
+Plus two `Border` styles, `HF_AlertErrorBadge` / `HF_AlertWarningBadge`: `Background` = the NINA alert brush,
+`BorderBrush` = same, `BorderThickness=1`, `CornerRadius=3`, `Padding=6,4`.
+
+Dictionary-level `{StaticResource NotificationErrorBrush}` lookup into `Application.Resources` is already proven
+in this plugin (e.g. `TiltAdapterWizard/DataTemplates.xaml:228` resolves `ButtonForegroundBrush` inside a
+dictionary-level `Style`), so no `ProfileService` binding proxy is needed.
+
+`AlertBrushes.xaml` is merged into each of the five dictionaries that need it.
+
+### Verified output
+
+Computed for every built-in NINA schema (`ColorSchemas.ReadColorSchemas()`):
+
+| Schema | page bg | error accent | ratio | warning accent | ratio | badge text ratio (err / warn) |
+|---|---|---|---|---|---|---|
+| Light / Classic / Seance | `#FFFFFF` | `#700000` (unchanged) | 12.43 | `#5E330B` (unchanged) | 10.75 | 12.43 / 10.75 |
+| Dark | `#02010A` | `#EF0000` | 4.62 | `#B46115` | 4.61 | 12.43 / 10.75 |
+| High Contrast | `#000000` | `#ED0000` | 4.60 | `#B26115` | 4.61 | 12.43 / 10.75 |
+| Persian / Persian Faint | `#263238` | `#FF6666` | 4.60 | `#E57F1F` | 4.63 | 12.43 / 10.75 |
+| Black Coral | `#545E75` | `#FFCECE` | 4.63 | `#F6D3B3` | 4.60 | 12.43 / 10.75 |
+| Arsenic | `#394648` | `#FF9494` | 4.63 | `#ECA25C` | 4.61 | 12.43 / 10.75 |
+| Vivid Malachite | `#34403A` | `#FF8585` | 4.61 | `#EA9647` | 4.61 | 12.43 / 10.75 |
+| Shark | `#36393E` | `#FF7B7B` | 4.62 | `#E88E39` | 4.61 | 12.43 / 10.75 |
+| Slate | `#1E2129` | `#FF3E3E` | 4.61 | `#CF7118` | 4.62 | 12.43 / 10.75 |
+| Wisteria | `#2D0D25` | `#FF2222` | 4.60 | `#C66B17` | 4.61 | 12.43 / 10.75 |
+| Navy | `#0C141F` | `#F91E1E` | 4.61 | `#EA3F1E` | 4.60 | 5.20 / 5.10 |
+| Dark Nebula / Dichromacy | `#191A1C` | `#FF2626` | 4.61 | `#CD6808` | 4.63 | 12.43 / 4.69 |
+
+Worst case across 16 schemas × 4 roles: **4.60:1**. Light-background schemas are left untouched, because the
+existing color already passes there.
+
+### Call-site changes
+
+27 `Foreground=` sites across five dictionaries, plus the 5 existing (already-badge-shaped) sites:
+
+| File | error fg | warning fg | notes |
+|---|---|---|---|
+| `TiltAdapterWizard/DataTemplates.xaml` | 10 | 5 | the reported surface |
+| `AutoFocus/DataTemplates.xaml` | 1 | 3 | + 3 existing badge sites to re-point |
+| `StarDetection/Optimization/DataTemplates.xaml` | 1 | 4 | |
+| `CameraSimulator/TiltAdapter/TiltAdapterDataTemplates.xaml` | 0 | 1 | + 3 existing badge sites to re-point |
+| `Resources/OptionsDataTemplates.xaml` | 0 | 2 | |
+
+Assignment rule:
+
+- **Block-level alerts become filled badges.** Multi-line warning/error paragraphs and boxed banners. Most
+  already sit inside a `<Border BorderBrush="{StaticResource NotificationErrorBrush}">`, so the change is adding
+  `Background` (via the badge style) and swapping the inner `Foreground` to `HF_AlertErrorTextBrush`.
+- **Inline in-row tags keep being text**, switched to `HF_AlertErrorAccentBrush` / `HF_AlertWarningAccentBrush`:
+  the plan-preview `LimitTag` (wizard `DataTemplates.xaml:372,378`), the twist `WillReachText` (`:510`), and the
+  short optimizer notes. Filling these would turn dense grids into a wall of pills.
+- **The 5 existing badge sites** switch `NotificationWarningTextBrush` → `HF_AlertWarningTextBrush`; they read at
+  1.93:1 on the Dark schema today.
+
+**Explicitly out of scope:** the 11 chart `Fill` / `Stroke` / `ErrorBarColor` sites that bind
+`NotificationErrorBrush.Color`. NINA's own `NINA/View/AutoFocusChart.xaml` uses the identical brush for error
+bars; matching NINA's chart is worth more there than a contrast bump, and these are plot marks, not alert text.
+
+### Tests — `Tests/Converters/ContrastMathTests.cs`
+
+- `RelativeLuminance` / `ContrastRatio` against published WCAG reference pairs (black/white = 21:1, etc.).
+- **Schema sweep:** iterate `ColorSchemas.ReadColorSchemas()` (public, pure in-memory) and assert, for every
+  schema, that `BestContrastText(errorFill)` on the fill and `AccessibleAccent(errorFill, pageBg)` on the page
+  both clear 4.5:1 — and the same for warning. This is the regression that would have caught the original bug,
+  and it will also catch NINA adding a new schema with unusable colors.
+- `AccessibleAccent` returns the input unchanged when it already passes (keeps light themes byte-identical).
+- `AccessibleAccent` preserves hue: assert the returned color's HSL hue is within a degree of the input's.
+- Converter wrappers: null/wrong-type inputs return `Binding.DoNothing`-safe values rather than throwing.
+
+---
+
+## Part 2 — "Inward" wording
+
+### Finding: the motion is correct
+
+`EatWizardMapping.MoveForStep(WizardStep.AllInward, N)` returns `TiltAdapterMove(TiltMoveAxis.Backfocus, +N, …)`
+— `+N` on all four motors. That matches the instruction paragraph the user is reading
+(`"Apply +N steps to EVERY motor"`), and it matches `EatWizardMappingTests`' full-sequence trace, which pins that
+the six moves sum to `(0,0,0,0)` per corner.
+
+Nothing in the plugin claims `+N` is physically inward. It cannot: `docs/asg-eat-serial-protocol-design.md` §162
+records that per-motor directions were never confirmed on hardware, and determining that direction is the entire
+purpose of this step — it is what sets `ScrewInwardCurvatureSign`, reported afterwards as "measured" rather than
+"assumed".
+
+The wizard's own source states the rule being broken, at `TiltAdapterWizardVM.cs:1089`:
+
+> Screw motion is worded as CLOCKWISE/COUNTER-CLOCKWISE (tighten/loosen) — never "inward/outward", which this
+> plugin reserves for adapter-plate motion.
+
+`StepTitleText` returns `"All Screws Inward"` and `MoveForStep` labels the move `"Wizard All Inward"`. Both
+violate that rule, and they are the only reason the run looks wrong.
+
+### Design
+
+Wording only; no behavior change, no math change.
+
+1. `TiltAdapterWizardVM.StepTitleText` gains a `bool isStepper = false` parameter:
+   - screws → `"All Screws Clockwise"`
+   - steppers → `"All Motors + Steps"`
+
+   Callers: `StepTitle` (passes `IsStepperAdjustment`) and `ReplayStepInstructionsText` (threads it through).
+2. `EatWizardMapping.MoveForStep`: `"Wizard All Inward: +150 backfocus"` → `"Wizard All Motors: +150 backfocus"`.
+3. New tooltip on the step title, shown for this step only:
+   > This step measures which way the adapter plate actually moves. `+` steps are not assumed to be inward —
+   > determining that direction is the point of the step.
+4. Reword the stale `WizardStep.AllInward` enum comment (`"all screws inward once"`) and the reference in
+   `docs/tilt-adapter-ui-review-design.md:83`.
+
+**`WizardStep.AllInward` keeps its name.** It is persisted in saved replay runs and referenced across
+`TiltCalibrationCalculator`, `EatWizardMapping` and four test files; renaming it would need a serialization shim
+for no user-visible gain.
+
+### Tests
+
+- `TiltAdapterWizardVMTests:689` currently asserts `[TestCase(WizardStep.AllInward, "All Screws Inward")]` —
+  update to the two new titles, one case per `isStepper` value.
+- Add a guard test asserting no user-facing wizard string for a *screw/stepper move* contains "inward" or
+  "outward" (`StepTitleText`, `StepInstructionsText`, `BaselineRecoveryText`, `StepDescription` and every
+  `MoveForStep` description, across both screw counts and both adjustment types). This pins the naming rule the
+  code comment states but nothing enforced.
+
+---
+
+## Part 3 — Explicit opt-in re-link for hand-entered calibration
+
+### The defect
+
+`TiltAdapterWizardVM.ApplyManualCalibration()` ends with two `[CRITICAL GATE]` writes:
+
+```csharp
+tiltAdapterOptions.DeviceLinkedCalibrationDeviceName = string.Empty;  // :1375
+tiltAdapterOptions.CalibrationIsReliable = false;                     // :1379
+```
+
+Both are required by `InspectorVM.CanExecuteAutomaticAdjustment`, so hand-editing the calibration disables
+Automatic Adjustment. The safety reason is real — a hand-entered screw numbering is not guaranteed to match how
+the device's motors are wired, and a 90°/180° rotated correction applied unattended makes tilt worse.
+
+What is wrong is everything around it:
+
+- **Nothing says it happened.** No notification, no wizard-side indication.
+- **The one explanation lives elsewhere.** `InspectorVM.AutomaticAdjustmentRemediationText` shows
+  *"This calibration is not linked to the connected device"* — in the Inspector, only while a device is
+  connected, and it never mentions manual entry as the cause.
+- **The only remedy offered is a full re-run**, which is an entire imaging session's worth of work to undo a
+  deliberate one-number correction.
+
+### Design
+
+Keep the gate closed by default; add a deliberate, warned, reversible way to re-arm it.
+
+**Wizard — a new alert block** in the saved-calibration sub-panel of Panel A (`TiltAdapterWizard/DataTemplates.xaml`,
+the `IsCalibrationValid` `StackPanel` that currently holds the "Manually entered calibration" note and the
+`Clear Calibration` button), rendered with Part 1's `HF_AlertWarningBadge`. Shown when all of:
+`IsCalibrationValid` ∧ ¬(device-linked ∧ reliable) ∧ a motorized device preset is selected.
+
+> **Automatic Adjustment is disabled.** This calibration was entered or edited by hand, so HocusFocus cannot
+> verify that your screw numbering matches the device's motor wiring. Re-run the wizard with the device
+> connected, or trust this calibration explicitly.
+
+with a **`Trust This Calibration for Automation`** button.
+
+**Confirmation before trusting — the in-pane two-step pattern**, not a modal. This mirrors
+`SimulatedTiltAdapterVM`'s `CopyToAdapterCommand` / `IsCopyToAdapterPending` /
+`ConfirmCopyToAdapterCommand` / `CancelCopyToAdapterCommand` trio, which already guards the structurally
+identical decision ("overwrite a calibration the user cannot cheaply repeat"). A modal `MyMessageBox` — the
+wizard's other confirmation style, at `TiltAdapterWizardVM.cs:1936` — would put the whole decision out of reach
+of unit tests, and this one has enough branches to be worth testing.
+
+`TrustCalibrationCommand` sets `IsTrustCalibrationPending = true`, which reveals the risk copy and a
+Confirm / Cancel pair inside the same badge:
+
+> If your screw numbering does not match the device's motor wiring, Automatic Adjustment will drive the adapter
+> unattended in the wrong direction and make tilt worse. Verify with a single manual adjustment before leaving
+> it unattended.
+
+`ConfirmTrustCalibrationCommand` then performs the writes and clears the pending flag:
+
+```csharp
+tiltAdapterOptions.DeviceLinkedCalibrationDeviceName = tiltAdapterOptions.DeviceName;
+tiltAdapterOptions.CalibrationIsReliable = true;
+```
+
+`CancelTrustCalibrationCommand` clears the pending flag and writes nothing.
+
+**No new persisted option.** `CalibrationIsManual == true` together with a device link already means exactly
+"manually trusted" — every surface that needs to distinguish it can read those two. This keeps the change out of
+`Resources/OptionsDataTemplates.xaml`, consistent with both markers being deliberately absent from the options UI.
+
+**Trust revokes itself.** Everything that already invalidates the correspondence continues to:
+
+- `ApplyManualCalibration()` clears both markers (unchanged) — editing the angle again requires re-trusting.
+- Changing the device preset invalidates it for free: `IsCalibrationDeviceLinked` compares the stored name
+  against the *current* `DeviceName`.
+- `ClearCalibration()` **now also clears both markers.** It does not today — a latent bug, harmless only because
+  clearing the angles also removes the numeric guidance the gate requires, but wrong the moment Trust can set
+  them deliberately.
+- `SimulatedTiltAdapterVM.ConfirmCopyToAdapter()` gets the same two lines. It currently relies on setting
+  `DeviceName = ManualName` to break the link implicitly; making it explicit matches the other two paths.
+
+**Tell the user at the moment it happens.** `ApplyManualCalibration()` checks whether it actually revoked
+anything (were the markers set before?) and, if so, raises `Notification.ShowWarning` naming the consequence and
+pointing at the Trust button.
+
+**Name the real cause in the Inspector.** `AutomaticAdjustmentRemediationText` gains a manual-entry branch:
+
+> This calibration was entered by hand, so Automatic Adjustment is disabled — HocusFocus can't confirm your screw
+> numbering matches the device's motor wiring. Re-run calibration with the device connected, or trust it
+> explicitly in the Tilt Adapter Wizard.
+
+The existing not-linked and low-confidence branches are unchanged.
+
+### Tests
+
+- `ApplyManualCalibration` still clears both markers (existing behavior, re-pinned).
+- `ApplyManualCalibration` warns only when it actually revoked something — not on a first-ever manual entry.
+- `TrustCalibrationCommand` alone writes nothing — it only sets `IsTrustCalibrationPending`.
+- `ConfirmTrustCalibrationCommand` sets both markers, using the *current* `DeviceName`, and clears the pending flag.
+- `CancelTrustCalibrationCommand` clears the pending flag and leaves both markers untouched.
+- The Trust commands are unavailable when no motorized preset is selected or no calibration is saved.
+- After trusting, `InspectorVM.CanExecuteAutomaticAdjustment` returns true with everything else held equal.
+- `ClearCalibration` clears both markers.
+- Changing `DeviceName` after trusting makes `IsCalibrationDeviceLinked` false again.
+- The banner's visibility predicate: hidden for a wizard-measured device-linked calibration, hidden with no
+  calibration, hidden on a non-motorized preset, shown for a manual calibration on a motorized preset.
+- `AutomaticAdjustmentRemediationText` returns the manual-entry wording when `CalibrationIsManual`, and the
+  existing wording otherwise.
+
+---
+
+## Out of scope
+
+- Renaming `WizardStep.AllInward` (persisted; see Part 2).
+- Chart mark colors (`Fill` / `Stroke` / `ErrorBarColor`) — see Part 1.
+- Any change to the calibration math, the move sequence, or the automation gate's *conditions*. Part 3 adds a way
+  for the user to satisfy the existing gate deliberately; it does not weaken it.
+- `TiltAdapterDevices/Prompt/TiltDeviceAdjustmentPromptControl.xaml` — already carries a self-contained,
+  theme-independent palette (`WarnFg`, `DangerFg`) and is unaffected.
+
+## Verification
+
+- `dotnet test Joko.NINA.Plugins/Joko.NINA.Plugins.sln -c Debug --nologo` green.
+- Live check in NINA on the **Dark** schema: wizard alert text legible, step titled "All Motors + Steps" on an
+  EAT preset, Trust button appears after a manual entry and re-enables Automatic Adjustment.

--- a/docs/tilt-calibration-ux-feedback-design.md
+++ b/docs/tilt-calibration-ux-feedback-design.md
@@ -223,7 +223,7 @@ Wording only; no behavior change, no math change.
 
 1. `TiltAdapterWizardVM.StepTitleText` gains a `bool isStepper = false` parameter:
    - screws → `"All Screws Clockwise"`
-   - steppers → `"All Motors + Steps"`
+   - steppers → `"All Motors Positive Steps"`
 
    Callers: `StepTitle` (passes `IsStepperAdjustment`) and `ReplayStepInstructionsText` (threads it through).
 2. `EatWizardMapping.MoveForStep`: `"Wizard All Inward: +150 backfocus"` → `"Wizard All Motors: +150 backfocus"`.
@@ -367,5 +367,5 @@ The existing not-linked and low-confidence branches are unchanged.
 ## Verification
 
 - `dotnet test Joko.NINA.Plugins/Joko.NINA.Plugins.sln -c Debug --nologo` green.
-- Live check in NINA on the **Dark** schema: wizard alert text legible, step titled "All Motors + Steps" on an
+- Live check in NINA on the **Dark** schema: wizard alert text legible, step titled "All Motors Positive Steps" on an
   EAT preset, Trust button appears after a manual entry and re-enables Automatic Adjustment.

--- a/docs/tilt-calibration-ux-feedback-design.md
+++ b/docs/tilt-calibration-ux-feedback-design.md
@@ -20,8 +20,9 @@ NINA's color schemas define `NotificationErrorColor` / `NotificationWarningColor
 `NotificationErrorTextColor` / `NotificationWarningTextColor`. NINA itself only ever uses them as `Background`
 (`NINA.Sequencer/Trigger/Datatemplates.xaml`, `MiniSequenceItem.xaml`, `ProgressStyle.xaml`).
 
-HocusFocus uses them as `Foreground` in 27 places. In 14 of the 16 built-in schemas that color is `#FF700000`
-(error) and `#FF5E330B` (warning) — near-black reds — so against a dark page background the text is invisible:
+HocusFocus uses them as `Foreground` in 27 places. 13 of NINA's 18 built-in schemas use the near-black pair
+`#FF700000` (error) and `#FF5E330B` (warning), and against a dark page background that text is invisible — 15 of
+the 18 schemas render error text below 4.5:1 today, and 14 render warning text below it:
 
 | Schema | page bg | red text on page (today) |
 |---|---|---|
@@ -92,7 +93,8 @@ dictionary-level `Style`), so no `ProfileService` binding proxy is needed.
 
 ### Verified output
 
-Computed for every built-in NINA schema (`ColorSchemas.ReadColorSchemas()`):
+Computed for every built-in NINA schema (`ColorSchemas.ReadColorSchemas()`, which returns 18 — the 16 named
+themes plus the editable "Custom" and "Alternative Custom" defaults; the table groups schemas that share a row):
 
 | Schema | page bg | error accent | ratio | warning accent | ratio | badge text ratio (err / warn) |
 |---|---|---|---|---|---|---|
@@ -107,10 +109,12 @@ Computed for every built-in NINA schema (`ColorSchemas.ReadColorSchemas()`):
 | Slate | `#1E2129` | `#FF3E3E` | 4.61 | `#CF7118` | 4.62 | 12.43 / 10.75 |
 | Wisteria | `#2D0D25` | `#FF2222` | 4.60 | `#C66B17` | 4.61 | 12.43 / 10.75 |
 | Navy | `#0C141F` | `#F91E1E` | 4.61 | `#EA3F1E` | 4.60 | 5.20 / 5.10 |
-| Dark Nebula / Dichromacy | `#191A1C` | `#FF2626` | 4.61 | `#CD6808` | 4.63 | 12.43 / 4.69 |
+| Dark Nebula / Dichromacy / Custom | `#191A1C` | `#FF2626` | 4.61 | `#CD6808` | 4.63 | 12.43 / 4.69 |
+| Alternative Custom | `#02010A` | `#EE0707` | 4.62 | `#F5A300` (unchanged) | 10.01 | 5.20 / 10.12 |
 
-Worst case across 16 schemas × 4 roles: **4.60:1**. Light-background schemas are left untouched, because the
-existing color already passes there.
+Worst case across 18 schemas × 4 roles (72 checks): **4.60:1**. Light-background schemas are left untouched, because the
+existing color already passes there — as is Alternative Custom's warning, the one dark-schema alert colour NINA
+already ships bright enough to read.
 
 ### Call-site changes
 

--- a/docs/tilt-calibration-ux-feedback-design.md
+++ b/docs/tilt-calibration-ux-feedback-design.md
@@ -85,9 +85,24 @@ re-evaluate when the user changes color schema at runtime:
 Plus two `Border` styles, `HF_AlertErrorBadge` / `HF_AlertWarningBadge`: `Background` = the NINA alert brush,
 `BorderBrush` = same, `BorderThickness=1`, `CornerRadius=3`, `Padding=6,4`.
 
-Dictionary-level `{StaticResource NotificationErrorBrush}` lookup into `Application.Resources` is already proven
-in this plugin (e.g. `TiltAdapterWizard/DataTemplates.xaml:228` resolves `ButtonForegroundBrush` inside a
-dictionary-level `Style`), so no `ProfileService` binding proxy is needed.
+These brushes reference `NotificationErrorBrush`, `NotificationWarningBrush` and `BackgroundBrush`, which are
+defined only in NINA's `Application.Resources` (`NINA.WPF.Base/Resources/StaticResources/Brushes.xaml`, merged by
+`App.xaml` at startup). A `StaticResource` that cannot be found throws at dictionary-load time and would break a
+whole panel without failing the build, so it is worth being precise about why this resolves:
+
+- **Not** by the mechanism the plugin's existing alert usages rely on. Every current use sits inside a
+  `Setter.Value` or a `DataTemplate`'s visual tree — deferred content, resolved at apply time by walking the live
+  tree via `FindResource`. The brushes here are *eager*, dictionary-level values, which is a different path.
+- The path that actually applies is WPF's `StaticResourceExtension` fallback: when a key is absent from the
+  ambient dictionary chain it calls `FindResourceInAppOrSystem`, which consults `Application.Current.Resources`
+  directly. `NINA.Plugin/PluginLoader.cs:477` composes plugin dictionaries (running `InitializeComponent`, which
+  is when this file parses) only after `App.xaml` has already merged NINA's brushes, so the keys are present.
+- This is also already guarded. `Tests/CameraSimulator/XamlResourceResolutionTests.cs` exists because of a real
+  past incident — `NotificationSuccessBrush`, a key NINA never defines, silently broke the camera setup dialog,
+  since `StaticResource` throws at parse time and `WindowService.Show` swallowed it. That test scans the
+  plugin's XAML for unresolvable keys and covers `AlertBrushes.xaml` automatically.
+
+No `ProfileService` binding proxy is needed.
 
 `AlertBrushes.xaml` is merged into each of the five dictionaries that need it.
 

--- a/docs/tilt-calibration-ux-feedback-design.md
+++ b/docs/tilt-calibration-ux-feedback-design.md
@@ -124,16 +124,40 @@ existing color already passes there.
 | `CameraSimulator/TiltAdapter/TiltAdapterDataTemplates.xaml` | 0 | 1 | + 3 existing badge sites to re-point |
 | `Resources/OptionsDataTemplates.xaml` | 0 | 2 | |
 
-Assignment rule:
+Assignment rule. The codebase already documents the distinction this follows, at
+`AutoFocus/DataTemplates.xaml:120`:
 
-- **Block-level alerts become filled badges.** Multi-line warning/error paragraphs and boxed banners. Most
-  already sit inside a `<Border BorderBrush="{StaticResource NotificationErrorBrush}">`, so the change is adding
-  `Background` (via the badge style) and swapping the inner `Foreground` to `HF_AlertErrorTextBrush`.
-- **Inline in-row tags keep being text**, switched to `HF_AlertErrorAccentBrush` / `HF_AlertWarningAccentBrush`:
-  the plan-preview `LimitTag` (wizard `DataTemplates.xaml:372,378`), the twist `WillReachText` (`:510`), and the
-  short optimizer notes. Filling these would turn dense grids into a wall of pills.
+> FILLED warning colour rather than the quiet bordered style used for advisory text: this has a deadline and
+> disconnects on inaction, so it earns the heavier weight.
+
+and again at `:2967`:
+
+> BorderThickness 1 with `NotificationErrorBrush` is the house style for a red box that CARRIES AN ACTION.
+
+So:
+
+- **Short, single-paragraph alerts become filled badges** (10 sites). Seven already sit inside a
+  `<Border BorderBrush="{StaticResource NotificationErrorBrush}">` whose only child is the alert `TextBlock`, so
+  the change is `BasedOn="{StaticResource HF_AlertErrorBadge}"` on the existing `<Border.Style>` plus swapping
+  the `Foreground` to `HF_AlertErrorTextBrush`. Two bare alert `TextBlock`s
+  (wizard `ConnectionWarningText`, optimizer `ErrorMessage`) get wrapped in a new badge `Border` — with the
+  visibility trigger moved onto the `Border`, or the pill renders empty when the text is blank.
+- **Long, action-carrying banners keep their outlined house style**, with only the alert text switched to the
+  accent brush: the wizard's measurement-failure block (`:1984`) and the Inspector's "Tilt got worse" banner
+  (`:2972`). Both wrap a paragraph plus buttons plus plain sibling `TextBlock`s; filling them would contradict
+  the documented `:2967` rule and would force every plain child onto the badge brush for no legibility gain —
+  those children are already readable.
+- **Advisory and inline text keeps being text**, switched to `HF_AlertErrorAccentBrush` /
+  `HF_AlertWarningAccentBrush` (17 sites): the plan-preview `LimitTag` (`:372,378`), the twist `WillReachText`
+  (`:510`), the disabled-reason lines (`:403,420,569`), the `⚠ differs from the focuser driver` markers, and the
+  optimizer notes — one of which is explicitly documented at `Optimization/DataTemplates.xaml:782` as *"the
+  page's ONLY colored element"*, a deliberate restraint a pill would break.
 - **The 5 existing badge sites** switch `NotificationWarningTextBrush` → `HF_AlertWarningTextBrush`; they read at
   1.93:1 on the Dark schema today.
+
+**Whenever a `Border` does become a filled badge, every `TextBlock` inside it must take the badge text brush** —
+including children that carry no explicit `Foreground` today, since they would otherwise inherit `PrimaryBrush`
+onto the fill. This is why the two long banners are left outlined rather than filled.
 
 **Explicitly out of scope:** the 11 chart `Fill` / `Stroke` / `ErrorBarColor` sites that bind
 `NotificationErrorBrush.Color`. NINA's own `NINA/View/AutoFocusChart.xaml` uses the identical brush for error

--- a/plans/tilt-calibration-ux-feedback-plan.md
+++ b/plans/tilt-calibration-ux-feedback-plan.md
@@ -601,6 +601,14 @@ Create `PLUGIN/Resources/AlertBrushes.xaml`:
 
         When a Border becomes a filled badge, EVERY TextBlock inside it needs the badge text brush — children
         with no explicit Foreground otherwise inherit PrimaryBrush onto the fill.
+
+        Mode=OneWay is stated EXPLICITLY on every binding below, and is not decoration. Both converters throw
+        NotSupportedException from ConvertBack, and WPF does NOT catch exceptions thrown out of a converter's
+        ConvertBack — unlike a failed Convert, which it logs and leaves the target unset, a throwing ConvertBack
+        propagates and can take the application down. These bindings resolve to OneWay implicitly today only
+        because SolidColorBrush.ColorProperty is registered through Animatable.RegisterProperty, which carries no
+        BindsTwoWayByDefault. Saying OneWay outright makes the guarantee structural instead of incidental, so it
+        survives someone re-pointing a converter at a target property whose metadata does default to two-way.
     -->
 
     <hfconverters:BadgeTextColorConverter x:Key="HF_BadgeTextColorConverter" />
@@ -610,28 +618,30 @@ Create `PLUGIN/Resources/AlertBrushes.xaml`:
         x:Key="HF_AlertErrorTextBrush"
         Color="{Binding Source={StaticResource NotificationErrorBrush},
                         Path=Color,
+                        Mode=OneWay,
                         Converter={StaticResource HF_BadgeTextColorConverter}}" />
 
     <SolidColorBrush
         x:Key="HF_AlertWarningTextBrush"
         Color="{Binding Source={StaticResource NotificationWarningBrush},
                         Path=Color,
+                        Mode=OneWay,
                         Converter={StaticResource HF_BadgeTextColorConverter}}" />
 
     <SolidColorBrush x:Key="HF_AlertErrorAccentBrush">
         <SolidColorBrush.Color>
-            <MultiBinding Converter="{StaticResource HF_AccessibleAccentColorConverter}">
-                <Binding Path="Color" Source="{StaticResource NotificationErrorBrush}" />
-                <Binding Path="Color" Source="{StaticResource BackgroundBrush}" />
+            <MultiBinding Converter="{StaticResource HF_AccessibleAccentColorConverter}" Mode="OneWay">
+                <Binding Path="Color" Source="{StaticResource NotificationErrorBrush}" Mode="OneWay" />
+                <Binding Path="Color" Source="{StaticResource BackgroundBrush}" Mode="OneWay" />
             </MultiBinding>
         </SolidColorBrush.Color>
     </SolidColorBrush>
 
     <SolidColorBrush x:Key="HF_AlertWarningAccentBrush">
         <SolidColorBrush.Color>
-            <MultiBinding Converter="{StaticResource HF_AccessibleAccentColorConverter}">
-                <Binding Path="Color" Source="{StaticResource NotificationWarningBrush}" />
-                <Binding Path="Color" Source="{StaticResource BackgroundBrush}" />
+            <MultiBinding Converter="{StaticResource HF_AccessibleAccentColorConverter}" Mode="OneWay">
+                <Binding Path="Color" Source="{StaticResource NotificationWarningBrush}" Mode="OneWay" />
+                <Binding Path="Color" Source="{StaticResource BackgroundBrush}" Mode="OneWay" />
             </MultiBinding>
         </SolidColorBrush.Color>
     </SolidColorBrush>

--- a/plans/tilt-calibration-ux-feedback-plan.md
+++ b/plans/tilt-calibration-ux-feedback-plan.md
@@ -794,9 +794,7 @@ Worked example — the block at 2244–2260 becomes:
 ```xml
                     <Border
                         Margin="0,5"
-                        Padding="5"
-                        BorderBrush="{StaticResource NotificationErrorBrush}"
-                        BorderThickness="1">
+                        Padding="5">
                         <Border.Style>
                             <Style TargetType="Border" BasedOn="{StaticResource HF_AlertErrorBadge}">
                                 <Setter Property="Visibility" Value="Collapsed" />
@@ -814,7 +812,20 @@ Worked example — the block at 2244–2260 becomes:
                     </Border>
 ```
 
-The local `Padding="5"` / `BorderThickness="1"` attributes stay: a local value beats a style setter in WPF, so they keep their existing spacing and only `Background` + `CornerRadius` come from the style. That is intended.
+**Delete the local `BorderBrush` and `BorderThickness` attributes; keep `Margin` and `Padding`.** WPF's
+dependency-property precedence puts a local value (rank 3) above a style setter (rank 8), so anything left on the
+element pins itself and stops following the style. `Padding="5"` is a genuine override worth keeping — the style
+says `6,4` and these blocks should keep their existing spacing. But `BorderThickness="1"` and
+`BorderBrush="{StaticResource NotificationErrorBrush}"` are byte-identical to what `HF_AlertErrorBadge` already
+sets, so leaving them changes nothing today while silently pinning those six Borders against any future central
+change to the badge style — a footgun that would not show up in a diff. Remove them.
+
+**Invariant, and it is counter-intuitive — do not break it.** Local value also outranks *style triggers* (rank 6),
+not just plain setters. So an element must **never** carry a local `Visibility` attribute when its `Style` sets
+`Visibility` from a `DataTrigger`: the local value wins permanently and the trigger becomes dead code, with no
+error and no warning. That is why every badge in this task keeps `Visibility` inside `<Border.Style>` and sets
+none on the element, while Tasks 7 and 10 — which apply `Style="{StaticResource HF_Alert*Badge}"` directly and set
+`Visibility` locally — are safe only because those shared styles set no `Visibility` at all.
 
 ### 4b. Wrap the bare connection warning (line 1875)
 

--- a/plans/tilt-calibration-ux-feedback-plan.md
+++ b/plans/tilt-calibration-ux-feedback-plan.md
@@ -26,12 +26,13 @@ Key facts an engineer new to this codebase will otherwise get wrong:
    ```
    Allow up to 600 s. A single flaky test, `SendAsync_WritesOnABackgroundThread`, is known-unrelated — if it is the only failure, re-run it alone to confirm and move on.
 6. **Building deploys the plugin** into NINA's plugin folder via a PostBuild `xcopy`. Close NINA before running tests.
-7. **Commit identity** — every commit in this plan must use:
+7. **NSubstitute gotcha, verified in this repo (5.3.0).** A plain property *setter* call on a substitute **does** feed its own getter, and it wins even over an earlier explicit `.Returns(...)`. Two consequences: a test that writes a marker can assert on the getter directly (no re-stubbing), and production code that writes a property onto the substitute — e.g. the wizard ctor's `ApplyDevice` writing the selected preset's own `ScrewCount` — is visible to every later read. A calibrated test fixture must therefore be self-consistent with the preset it selects: a 4-screw preset needs `screwCount: 4`, or `IsCalibrationValid` goes false for a reason unrelated to what the test is about.
+8. **Commit identity** — every commit in this plan must use:
    ```bash
    GIT_COMMITTER_NAME="George Hilios" GIT_COMMITTER_EMAIL="322725+ghilios@users.noreply.github.com" \
      git commit --author="George Hilios <322725+ghilios@users.noreply.github.com>" -m "..."
    ```
-8. **Branch:** `ghilios/tilt-calibration-ux-feedback` (already created, spec already committed). Never push to `develop`.
+9. **Branch:** `ghilios/tilt-calibration-ux-feedback` (already created, spec already committed). Never push to `develop`.
 
 **Paths are relative to the repo root** `/home/ghilios/src/hocus-focus`. The plugin lives at `Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/`, abbreviated **`PLUGIN/`** below. Tests live at `Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/`, abbreviated **`TESTS/`**.
 
@@ -1488,9 +1489,9 @@ then the tests:
             var (vm, options) = BuildCalibrated();
             vm.TrustCalibrationCommand.Execute(null);
             vm.ConfirmTrustCalibrationCommand.Execute(null);
-            // NSubstitute property setters do not feed the getters back, so mirror what was written.
-            options.DeviceLinkedCalibrationDeviceName.Returns(MotorizedPreset);
-            options.CalibrationIsReliable.Returns(true);
+            // No re-stubbing needed: an NSubstitute property setter feeds its own getter, so the getters
+            // below return exactly what ConfirmTrustCalibration just wrote. That is the point — the assertion
+            // reads production state, not test state.
 
             Assert.Multiple(() => {
                 Assert.That(InspectorVM.IsCalibrationDeviceLinked(options), Is.True);

--- a/plans/tilt-calibration-ux-feedback-plan.md
+++ b/plans/tilt-calibration-ux-feedback-plan.md
@@ -1150,7 +1150,7 @@ with the two adjustment-type variants (keep every other `[TestCase]` on that tes
 
 ```csharp
     [TestCase(WizardStep.AllInward, false, "All Screws Clockwise")]
-    [TestCase(WizardStep.AllInward, true, "All Motors + Steps")]
+    [TestCase(WizardStep.AllInward, true, "All Motors Positive Steps")]
 ```
 
 Then add a new guard test to the same fixture:
@@ -1225,12 +1225,14 @@ Line 67 — the enum comment:
 
 Line 756 — inside `StepTitleText`, whose signature gains a parameter:
 ```csharp
-        internal static string StepTitleText(WizardStep step, IScrewLabelProvider labels = null, bool isStepper = false) {
+        internal static string StepTitleText(WizardStep step, IScrewLabelProvider labels, bool isStepper) {
             switch (step) {
                 case WizardStep.Baseline: return "Baseline Measurement";
                 // NOT "All Screws Inward": the wizard applies +N to every motor and MEASURES which way the
                 // adapter plate goes. Naming the direction here contradicts the step and misreads as a bug.
-                case WizardStep.AllInward: return isStepper ? "All Motors + Steps" : "All Screws Clockwise";
+                // "Positive Steps", not "+ Steps": the latter parses as two nouns ("motors AND steps") rather
+                // than naming the sign the instruction body actually uses ("Apply +N steps to EVERY motor").
+                case WizardStep.AllInward: return isStepper ? "All Motors Positive Steps" : "All Screws Clockwise";
 ```
 
 Line 752 — the `StepTitle` property:
@@ -1240,7 +1242,7 @@ Line 752 — the `StepTitle` property:
 
 Line 1051 — `ReplayStepInstructionsText` threads the flag through:
 ```csharp
-        internal static string ReplayStepInstructionsText(WizardStep step, IScrewLabelProvider labels = null, bool isStepper = false) =>
+        internal static string ReplayStepInstructionsText(WizardStep step, IScrewLabelProvider labels, bool isStepper) =>
             $"Replaying — re-analyzing the saved frames for {StepTitleText(step, labels, isStepper)}. No action needed: nothing is " +
             "captured and the tilt adapter is not moved during a replay.";
 ```
@@ -1250,7 +1252,26 @@ Line 1042 — its call site inside `StepInstructions`:
                 ? ReplayStepInstructionsText(currentStep, ScrewLabels, IsStepperAdjustment)
 ```
 
-Line 484 — the adjustment-type change handler already raises `StepInstructions`; add the title beside it:
+**`isStepper` must NOT have a default on either method.** `StepInstructionsText` and `BaselineRecoveryText` in the
+same file already make it required, and that stricter convention is what forces every call site to make an explicit
+choice. A defaulted bool here silently gives a stepper rig screw wording at any call site that forgets it, and the
+suite stays green. Update the few test call sites that relied on the default.
+
+**`StepTitle` now depends on `IsStepperAdjustment`, so every place that invalidates its siblings must invalidate it
+too.** There are TWO such places, not one:
+
+Line ~484 — the adjustment-type change handler, which already raises `StepInstructions`:
+```csharp
+                    RaisePropertyChanged(nameof(StepInstructions));
+                    RaisePropertyChanged(nameof(StepTitle));
+                    RaisePropertyChanged(nameof(BaselineRecoveryInstructions));
+```
+
+Line ~543 — the `profileService.ProfileChanged` handler, which separately re-raises the same siblings. A profile
+switch can change the adjustment type, and until the next `CurrentStep` transition the bold title would otherwise go
+stale while the instruction paragraph directly below it updates — title and body visibly disagreeing, which is the
+exact failure this task exists to remove:
+
 ```csharp
                     RaisePropertyChanged(nameof(StepInstructions));
                     RaisePropertyChanged(nameof(StepTitle));
@@ -1279,7 +1300,21 @@ In `PLUGIN/TiltAdapterWizard/DataTemplates.xaml` at line 1755-1757, add a `ToolT
                         Margin="0,1,0,6"
                         FontWeight="Bold"
                         Text="{Binding StepTitle}"
-                        ToolTip="Moving every screw or motor together changes backfocus, and this step measures which way the adapter plate actually travels. A '+' step is not assumed to be inward — determining that direction is the point of the step." />
+                        Text="{Binding StepTitle}">
+                        <!--  The tooltip is about the all-motors step SPECIFICALLY, and this one TextBlock renders
+                              every step's title, so it must be scoped. Unscoped it would tell a user hovering
+                              "Move Screw 1" about a different step's mechanics — a smaller version of the
+                              text-does-not-match-the-hardware confusion this task exists to remove.  -->
+                        <TextBlock.Style>
+                            <Style BasedOn="{StaticResource StandardTextBlock}" TargetType="TextBlock">
+                                <Style.Triggers>
+                                    <DataTrigger Binding="{Binding CurrentStep}" Value="{x:Static local:WizardStep.AllInward}">
+                                        <Setter Property="ToolTip" Value="Moving every screw or motor together changes backfocus, and this step measures which way the adapter plate actually travels. A '+' step is not assumed to be inward — determining that direction is the point of the step." />
+                                    </DataTrigger>
+                                </Style.Triggers>
+                            </Style>
+                        </TextBlock.Style>
+                    </TextBlock>
 ```
 
 - [ ] **Step 5: Run the tests and verify they pass**
@@ -1292,7 +1327,7 @@ Expected: PASS. `EatWizardMappingTests`' existing full-sequence regressions must
 
 - [ ] **Step 6: Update the stale doc reference**
 
-In `docs/tilt-adapter-ui-review-design.md` line 83, change `AllInward → "All Screws Inward"` to `AllInward → "All Screws Clockwise" / "All Motors + Steps"`.
+In `docs/tilt-adapter-ui-review-design.md` line 83, change `AllInward → "All Screws Inward"` to `AllInward → "All Screws Clockwise" / "All Motors Positive Steps"`.
 
 - [ ] **Step 7: Commit**
 
@@ -2046,7 +2081,7 @@ Append to `.claude/docs/tilt-domain.md`:
 ## Wording: "inward/outward" is adapter-plate motion only
 
 Screw and motor moves are worded CLOCKWISE / COUNTER-CLOCKWISE or as signed steps — never "inward/outward".
-The wizard's all-motors step is titled "All Screws Clockwise" / "All Motors + Steps", never "All Screws
+The wizard's all-motors step is titled "All Screws Clockwise" / "All Motors Positive Steps", never "All Screws
 Inward": it applies `+N` to every motor and **measures** which way the plate travels (that is what sets
 `ScrewInwardCurvatureSign`). `WizardStep.AllInward` keeps its historical enum name because it is persisted in
 saved replay runs. `TiltAdapterWizardVMTests.NoUserFacingMoveWording_ClaimsInwardOrOutward` is the guard.
@@ -2077,7 +2112,7 @@ Switch the colour schema to **Dark** (Options → General → Colors), then conf
 
 1. Tilt Adapter Wizard → the alert badges are legible: white text on the red/amber fills, no near-black text.
 2. Options and the Aberration Inspector → the `⚠ differs from the focuser driver` markers and the guidance notices are legible red/amber on the dark background.
-3. Select an EAT preset → the wizard's all-motors step reads **"All Motors + Steps"**, and its tooltip explains that `+` is not assumed to be inward. Select a screw preset → **"All Screws Clockwise"**.
+3. Select an EAT preset → the wizard's all-motors step reads **"All Motors Positive Steps"**, and its tooltip explains that `+` is not assumed to be inward. Select a screw preset → **"All Screws Clockwise"**.
 4. Apply a Manual Calibration Entry over a device-linked calibration → a warning notification appears, and the "Automatic Adjustment is disabled" badge shows in the saved-calibration pane.
 5. Click **Trust This Calibration for Automation** → the risk copy and Yes/Cancel appear; Cancel changes nothing; Yes hides the badge and re-enables the Inspector's Automatic Adjustment button.
 6. Switch to the **Light** schema and confirm nothing regressed — accent colours should be unchanged from before this work, because `AccessibleAccent` returns light-theme colours untouched.

--- a/plans/tilt-calibration-ux-feedback-plan.md
+++ b/plans/tilt-calibration-ux-feedback-plan.md
@@ -571,7 +571,22 @@ GIT_COMMITTER_NAME="George Hilios" GIT_COMMITTER_EMAIL="322725+ghilios@users.nor
 - Modify: `PLUGIN/Resources/OptionsDataTemplates.xaml` (add `MergedDictionaries`)
 - Modify: `PLUGIN/CameraSimulator/TiltAdapter/TiltAdapterDataTemplates.xaml` (add `MergedDictionaries`)
 
-There is no unit test here — WPF resource resolution is verified by the build plus the live check in Task 12.
+WPF resource resolution has no dedicated unit test, but it is **not** unguarded. `AlertBrushes.xaml` references
+`NotificationErrorBrush`, `NotificationWarningBrush` and `BackgroundBrush`, which live only in NINA's
+`Application.Resources`. A `StaticResource` that resolves nowhere throws at dictionary-load time — it does not
+fail the build, it breaks a whole panel at runtime. Two things cover that:
+
+- `Tests/CameraSimulator/XamlResourceResolutionTests.cs` scans the plugin's XAML for unresolvable `StaticResource`
+  keys and picks up this new file automatically. It exists because of a real past incident: `NotificationSuccessBrush`,
+  a key NINA never defines, silently broke the camera setup dialog, because `StaticResource` throws at parse time
+  and `WindowService.Show` swallowed the exception. **Run it in Step 4.**
+- WPF's `StaticResourceExtension` falls back to `FindResourceInAppOrSystem` (i.e. `Application.Current.Resources`)
+  when a key is not in the ambient chain, and `NINA.Plugin/PluginLoader.cs:477` composes plugin dictionaries only
+  after `App.xaml` has merged NINA's brushes — so the keys are present when this file parses.
+
+Note this is a *different* mechanism from the plugin's existing alert usages, which all sit inside a `Setter.Value`
+or a `DataTemplate` visual tree and are resolved lazily at apply time via `FindResource`. Do not reason from those
+as precedent; they are deferred content, these brushes are eager.
 
 - [ ] **Step 1: Create the dictionary**
 
@@ -714,7 +729,15 @@ Replace with:
 ```bash
 dotnet.exe build "$(wslpath -w Joko.NINA.Plugins/Joko.NINA.Plugins.sln)" -c Debug --nologo
 ```
-Expected: `Build succeeded`, 0 errors. A `MC3074` (unknown type) means the `hfconverters` namespace is wrong; an `MC3000` means malformed XAML. `AlertBrushes.xaml` needs no csproj entry — the WPF SDK auto-includes `**/*.xaml` as `Page`.
+Expected: `Build succeeded`, 0 errors. A `MC3074` (unknown type) means the `hfconverters` namespace is wrong; an `MC3000` means malformed XAML. `AlertBrushes.xaml` needs no csproj entry — the WPF SDK auto-includes `**/*.xaml` as `Page`; confirm it really was picked up rather than assuming (`obj/Debug/net8.0-windows7.0/Resources/AlertBrushes.baml` should exist).
+
+Then run the resolution guard and the converter tests:
+
+```bash
+dotnet.exe test "$(wslpath -w Joko.NINA.Plugins/Joko.NINA.Plugins.sln)" -c Debug --nologo --filter "FullyQualifiedName~XamlResourceResolutionTests"
+dotnet.exe test "$(wslpath -w Joko.NINA.Plugins/Joko.NINA.Plugins.sln)" -c Debug --nologo --filter "FullyQualifiedName~Converters"
+```
+Expected: both green. A failure in the first means a key in `AlertBrushes.xaml` resolves nowhere — fix the key, do not suppress the test.
 
 - [ ] **Step 5: Commit**
 

--- a/plans/tilt-calibration-ux-feedback-plan.md
+++ b/plans/tilt-calibration-ux-feedback-plan.md
@@ -1,0 +1,1941 @@
+# Tilt Calibration UX Feedback Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Fix three reported problems with the Tilt Adapter Calibration wizard — alert text that is unreadable on dark NINA themes, a step title that claims "Inward" while the device moves `+N`, and a hand-entered calibration that silently and permanently disables Automatic Adjustment.
+
+**Architecture:** Part 1 adds a small pure contrast library plus two WPF converters, exposes four derived brushes in a new merged `ResourceDictionary`, and re-points 27 XAML sites at them. Part 2 is a wording-only change to two files. Part 3 adds a three-command in-pane confirmation to `TiltAdapterWizardVM` that lets the user deliberately re-arm the two existing automation markers, plus honest messaging everywhere those markers get cleared.
+
+**Tech Stack:** C# / .NET 8.0-windows, WPF, NUnit 4.4.0 + NSubstitute, NINA plugin (MEF). Spec: `docs/tilt-calibration-ux-feedback-design.md`.
+
+---
+
+## Background you need before starting
+
+**Read `docs/tilt-calibration-ux-feedback-design.md` first.** It contains the measured contrast numbers this plan implements against.
+
+Key facts an engineer new to this codebase will otherwise get wrong:
+
+1. **NINA's `NotificationErrorBrush` / `NotificationWarningBrush` are FILL colors, not text colors.** In 14 of the 16 built-in schemas they are `#FF700000` and `#FF5E330B` — near-black. NINA only ever uses them as `Background`. This plugin used them as `Foreground`, which is the bug.
+2. **`NotificationErrorTextBrush` is not a safe fix either.** On the "Dark" schema it is `#FF02010A` — near-black text on near-black-red fill, 1.67:1. That is why this plan computes the badge text color instead of reading it.
+3. **`WizardStep.AllInward` keeps its enum name.** It is persisted in saved replay runs. Only user-facing strings change.
+4. **The wizard's motion is correct.** Do not "fix" any sign, axis, or move. Part 2 is wording only.
+5. **Test command** (there is no `dotnet` in WSL; use the Windows host binary):
+   ```bash
+   dotnet.exe test "$(wslpath -w Joko.NINA.Plugins/Joko.NINA.Plugins.sln)" -c Debug --nologo
+   ```
+   Allow up to 600 s. A single flaky test, `SendAsync_WritesOnABackgroundThread`, is known-unrelated — if it is the only failure, re-run it alone to confirm and move on.
+6. **Building deploys the plugin** into NINA's plugin folder via a PostBuild `xcopy`. Close NINA before running tests.
+7. **Commit identity** — every commit in this plan must use:
+   ```bash
+   GIT_COMMITTER_NAME="George Hilios" GIT_COMMITTER_EMAIL="322725+ghilios@users.noreply.github.com" \
+     git commit --author="George Hilios <322725+ghilios@users.noreply.github.com>" -m "..."
+   ```
+8. **Branch:** `ghilios/tilt-calibration-ux-feedback` (already created, spec already committed). Never push to `develop`.
+
+**Paths are relative to the repo root** `/home/ghilios/src/hocus-focus`. The plugin lives at `Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/`, abbreviated **`PLUGIN/`** below. Tests live at `Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/`, abbreviated **`TESTS/`**.
+
+---
+
+## File Structure
+
+**Created:**
+
+| File | Responsibility |
+|---|---|
+| `PLUGIN/Converters/ContrastMath.cs` | Pure WCAG contrast math + the two color decisions. No WPF binding concerns. |
+| `PLUGIN/Converters/BadgeTextColorConverter.cs` | `IValueConverter`: badge fill color → black or white text. |
+| `PLUGIN/Converters/AccessibleAccentColorConverter.cs` | `IMultiValueConverter`: (alert color, page background) → readable accent. |
+| `PLUGIN/Resources/AlertBrushes.xaml` | The four derived brushes + two badge `Border` styles. The single place alert chrome is defined. |
+| `TESTS/Converters/ContrastMathTests.cs` | Contrast math + the all-schemas regression sweep. |
+| `TESTS/Converters/AlertColorConverterTests.cs` | The two converters' binding-edge behavior. |
+
+**Modified:**
+
+| File | Change |
+|---|---|
+| `PLUGIN/Resources/OptionsDataTemplates.xaml` | Merge `AlertBrushes.xaml`; 2 accent swaps. |
+| `PLUGIN/TiltAdapterWizard/DataTemplates.xaml` | 15 alert sites; the new Part 3 banner. |
+| `PLUGIN/AutoFocus/DataTemplates.xaml` | 4 alert sites + 2 existing badge texts re-pointed. |
+| `PLUGIN/StarDetection/Optimization/DataTemplates.xaml` | 5 alert sites. |
+| `PLUGIN/CameraSimulator/TiltAdapter/TiltAdapterDataTemplates.xaml` | Merge `AlertBrushes.xaml`; 1 alert site + 3 existing badge texts re-pointed. |
+| `PLUGIN/TiltAdapterWizard/TiltAdapterWizardVM.cs` | Part 2 titles; Part 3 commands, banner state, notification, `ClearCalibration` fix. |
+| `PLUGIN/TiltAdapterDevices/AsgEat/EatWizardMapping.cs` | Part 2 move description. |
+| `PLUGIN/AutoFocus/InspectorVM.cs` | Part 3 remediation text branch. |
+| `PLUGIN/CameraSimulator/TiltAdapter/SimulatedTiltAdapterVM.cs` | Part 3 marker hygiene. |
+| `TESTS/TiltAdapterWizard/TiltAdapterWizardVMTests.cs` | Part 2 title cases + naming guard; Part 3 command tests. |
+| `TESTS/TiltAdapterDevices/AsgEat/EatWizardMappingTests.cs` | Part 2 description assertion. |
+| `TESTS/AutoFocus/` (inspector tests) | Part 3 remediation-text test. |
+| `docs/tilt-adapter-ui-review-design.md` | Stale "All Screws Inward" reference. |
+| `.claude/docs/tilt-domain.md` | Record the alert-brush rule so it is not re-broken. |
+
+---
+
+## Task 1: Contrast math
+
+**Files:**
+- Create: `PLUGIN/Converters/ContrastMath.cs`
+- Test: `TESTS/Converters/ContrastMathTests.cs`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `TESTS/Converters/ContrastMathTests.cs`:
+
+```csharp
+using System;
+using NINA.Core.Utility.ColorSchema;
+using NINA.Joko.Plugins.HocusFocus.Converters;
+using NUnit.Framework;
+using Color = System.Windows.Media.Color;
+using Colors = System.Windows.Media.Colors;
+
+namespace NINA.Joko.Plugins.HocusFocus.Tests.Converters;
+
+[TestFixture]
+public class ContrastMathTests {
+
+    private static Color Hex(string rgb) => Color.FromRgb(
+        System.Convert.ToByte(rgb.Substring(0, 2), 16),
+        System.Convert.ToByte(rgb.Substring(2, 2), 16),
+        System.Convert.ToByte(rgb.Substring(4, 2), 16));
+
+    [Test]
+    public void ContrastRatio_BlackOnWhite_Is21() {
+        Assert.That(ContrastMath.ContrastRatio(Colors.Black, Colors.White), Is.EqualTo(21.0).Within(1e-9));
+    }
+
+    [Test]
+    public void ContrastRatio_IsSymmetric() {
+        var a = Hex("700000");
+        var b = Hex("02010A");
+        Assert.That(ContrastMath.ContrastRatio(a, b), Is.EqualTo(ContrastMath.ContrastRatio(b, a)).Within(1e-12));
+    }
+
+    [Test]
+    public void RelativeLuminance_MatchesWcagReferenceValues() {
+        Assert.Multiple(() => {
+            Assert.That(ContrastMath.RelativeLuminance(Colors.White), Is.EqualTo(1.0).Within(1e-9));
+            Assert.That(ContrastMath.RelativeLuminance(Colors.Black), Is.EqualTo(0.0).Within(1e-9));
+            // NINA's default error fill; hand-computed from the WCAG formula.
+            Assert.That(ContrastMath.RelativeLuminance(Hex("700000")), Is.EqualTo(0.034452).Within(1e-5));
+        });
+    }
+
+    [Test]
+    public void BestContrastText_PicksWhiteOnNinaDefaultErrorFill() {
+        Assert.That(ContrastMath.BestContrastText(Hex("700000")), Is.EqualTo(Colors.White));
+    }
+
+    [Test]
+    public void BestContrastText_PicksBlackOnALightFill() {
+        Assert.That(ContrastMath.BestContrastText(Hex("FFD54F")), Is.EqualTo(Colors.Black));
+    }
+
+    [Test]
+    public void AccessibleAccent_LeavesAnAlreadyReadableColorUntouched() {
+        // #700000 on white is 12.4:1 — light themes must stay byte-identical to today.
+        var alert = Hex("700000");
+        Assert.That(ContrastMath.AccessibleAccent(alert, Colors.White), Is.EqualTo(alert));
+    }
+
+    [Test]
+    public void AccessibleAccent_PreservesHueAndAlpha() {
+        var alert = Color.FromArgb(0xCC, 0x70, 0x00, 0x00);
+        var accent = ContrastMath.AccessibleAccent(alert, Hex("02010A"));
+        Assert.Multiple(() => {
+            Assert.That(accent.A, Is.EqualTo(0xCC), "alpha must be carried through");
+            Assert.That(accent.R, Is.GreaterThan(accent.G), "must still read as red");
+            Assert.That(accent.G, Is.EqualTo(accent.B), "pure-red hue has equal green and blue");
+        });
+    }
+
+    // The regression that would have caught the original bug: every built-in NINA schema, both roles.
+    [Test]
+    public void EveryBuiltInNinaSchema_ClearsWcagAaForBadgeTextAndAccent() {
+        var schemas = ColorSchemas.ReadColorSchemas().Items;
+        Assert.That(schemas, Is.Not.Empty, "NINA must expose its built-in schemas");
+        Assert.Multiple(() => {
+            foreach (var s in schemas) {
+                var bg = s.BackgroundColor;
+                foreach (var (role, fill) in new[] {
+                    ("error", s.NotificationErrorColor),
+                    ("warning", s.NotificationWarningColor)
+                }) {
+                    var badgeText = ContrastMath.BestContrastText(fill);
+                    Assert.That(ContrastMath.ContrastRatio(badgeText, fill),
+                        Is.GreaterThanOrEqualTo(ContrastMath.MinContrastRatio),
+                        $"{s.Name}: {role} badge text on fill");
+
+                    var accent = ContrastMath.AccessibleAccent(fill, bg);
+                    Assert.That(ContrastMath.ContrastRatio(accent, bg),
+                        Is.GreaterThanOrEqualTo(ContrastMath.MinContrastRatio),
+                        $"{s.Name}: {role} accent on page background");
+                }
+            }
+        });
+    }
+}
+```
+
+- [ ] **Step 2: Run the test and verify it fails**
+
+```bash
+dotnet.exe test "$(wslpath -w Joko.NINA.Plugins/Joko.NINA.Plugins.sln)" -c Debug --nologo \
+  --filter "FullyQualifiedName~ContrastMathTests"
+```
+Expected: build FAILS with `CS0103`/`CS0246` — the name `ContrastMath` does not exist.
+
+- [ ] **Step 3: Write the implementation**
+
+Create `PLUGIN/Converters/ContrastMath.cs`:
+
+```csharp
+#region "copyright"
+
+/*
+    Copyright © 2021 - 2026 George Hilios <ghilios+NINA@googlemail.com>
+
+    This Source Code Form is subject to the terms of the Mozilla Public
+    License, v. 2.0. If a copy of the MPL was not distributed with this
+    file, You can obtain one at http://mozilla.org/MPL/2.0/.
+*/
+
+#endregion "copyright"
+
+using System;
+using System.Windows.Media;
+
+namespace NINA.Joko.Plugins.HocusFocus.Converters {
+
+    /// <summary>
+    /// WCAG 2.x contrast math, and the two color decisions the alert brushes are built from.
+    ///
+    /// WHY THIS EXISTS: NINA's ColorSchema exposes NotificationErrorColor / NotificationWarningColor as FILL
+    /// colors (it only ever uses them as a Background), and 14 of its 16 built-in schemas set them to near-black
+    /// #FF700000 / #FF5E330B. Used as a Foreground — which this plugin did in 27 places — they land at 1.06:1
+    /// against a dark page background. Its paired NotificationErrorTextColor is not a way out either: the "Dark"
+    /// schema sets it to #FF02010A, i.e. near-black text on near-black-red fill, 1.67:1. So both alert text
+    /// colors are COMPUTED here rather than read from the schema.
+    ///
+    /// Pure and WPF-binding-free on purpose: the all-schemas regression sweep in ContrastMathTests runs directly
+    /// against this, with no converter or dispatcher in the way.
+    /// </summary>
+    internal static class ContrastMath {
+
+        /// <summary>WCAG AA for body text. What the tests assert.</summary>
+        internal const double MinContrastRatio = 4.5;
+
+        /// <summary>
+        /// What <see cref="AccessibleAccent"/> actually searches for. Deliberately above
+        /// <see cref="MinContrastRatio"/>: the search evaluates byte-rounded colors, and landing exactly on 4.5
+        /// leaves no headroom for that rounding.
+        /// </summary>
+        private const double TargetContrastRatio = 4.6;
+
+        private static double Linearize(byte channel) {
+            double c = channel / 255.0;
+            return c <= 0.04045 ? c / 12.92 : Math.Pow((c + 0.055) / 1.055, 2.4);
+        }
+
+        internal static double RelativeLuminance(Color c) =>
+            0.2126 * Linearize(c.R) + 0.7152 * Linearize(c.G) + 0.0722 * Linearize(c.B);
+
+        internal static double ContrastRatio(Color a, Color b) {
+            double la = RelativeLuminance(a);
+            double lb = RelativeLuminance(b);
+            double hi = Math.Max(la, lb);
+            double lo = Math.Min(la, lb);
+            return (hi + 0.05) / (lo + 0.05);
+        }
+
+        /// <summary>Black or white — whichever is more readable ON <paramref name="fill"/>.</summary>
+        internal static Color BestContrastText(Color fill) =>
+            ContrastRatio(Colors.Black, fill) >= ContrastRatio(Colors.White, fill) ? Colors.Black : Colors.White;
+
+        /// <summary>
+        /// <paramref name="alert"/> made readable against <paramref name="pageBackground"/>, keeping its HUE and
+        /// SATURATION and moving only HSL lightness.
+        ///
+        /// Moving in HSL rather than lerping toward white is the point: #700000 lerped toward white only reaches
+        /// 4.5:1 at roughly #A96666, a washed-out rose that no longer reads as an error, while raising its HSL
+        /// lightness reaches the same ratio at #EF0000 — still unmistakably red. Returned unchanged when it
+        /// already passes, so light-background schemas stay byte-identical to their previous appearance.
+        /// </summary>
+        internal static Color AccessibleAccent(Color alert, Color pageBackground) {
+            if (ContrastRatio(alert, pageBackground) >= TargetContrastRatio) {
+                return alert;
+            }
+
+            RgbToHsl(alert, out double h, out double s, out double l);
+
+            bool lighterReaches = ContrastRatio(FromHsl(h, s, 1.0, alert.A), pageBackground) >= TargetContrastRatio;
+            bool darkerReaches = ContrastRatio(FromHsl(h, s, 0.0, alert.A), pageBackground) >= TargetContrastRatio;
+
+            bool goLighter;
+            if (lighterReaches && darkerReaches) {
+                // Both poles work, so head for the one the background is furthest from.
+                goLighter = ContrastRatio(Colors.White, pageBackground) >= ContrastRatio(Colors.Black, pageBackground);
+            } else if (lighterReaches) {
+                goLighter = true;
+            } else if (darkerReaches) {
+                goLighter = false;
+            } else {
+                // A fully saturated hue cannot reach the target against this background (only possible for an
+                // exotic custom schema). Legibility beats hue: fall back to plain black or white.
+                var fallback = BestContrastText(pageBackground);
+                return Color.FromArgb(alert.A, fallback.R, fallback.G, fallback.B);
+            }
+
+            // Contrast is monotonic in lightness once we are moving away from the background, so bisect.
+            double lo = goLighter ? l : 0.0;
+            double hi = goLighter ? 1.0 : l;
+            for (int i = 0; i < 24; i++) {
+                double mid = (lo + hi) / 2.0;
+                bool reaches = ContrastRatio(FromHsl(h, s, mid, alert.A), pageBackground) >= TargetContrastRatio;
+                if (goLighter) {
+                    if (reaches) { hi = mid; } else { lo = mid; }
+                } else {
+                    if (reaches) { lo = mid; } else { hi = mid; }
+                }
+            }
+            return FromHsl(h, s, goLighter ? hi : lo, alert.A);
+        }
+
+        private static void RgbToHsl(Color c, out double h, out double s, out double l) {
+            double r = c.R / 255.0, g = c.G / 255.0, b = c.B / 255.0;
+            double max = Math.Max(r, Math.Max(g, b));
+            double min = Math.Min(r, Math.Min(g, b));
+            l = (max + min) / 2.0;
+            double delta = max - min;
+            if (delta <= double.Epsilon) {
+                h = 0.0;
+                s = 0.0;
+                return;
+            }
+            s = l > 0.5 ? delta / (2.0 - max - min) : delta / (max + min);
+            if (max == r) {
+                h = ((g - b) / delta + (g < b ? 6.0 : 0.0)) / 6.0;
+            } else if (max == g) {
+                h = ((b - r) / delta + 2.0) / 6.0;
+            } else {
+                h = ((r - g) / delta + 4.0) / 6.0;
+            }
+        }
+
+        private static Color FromHsl(double h, double s, double l, byte alpha) {
+            l = Math.Max(0.0, Math.Min(1.0, l));
+            if (s <= double.Epsilon) {
+                byte v = (byte)Math.Round(l * 255.0);
+                return Color.FromArgb(alpha, v, v, v);
+            }
+            double q = l < 0.5 ? l * (1.0 + s) : l + s - l * s;
+            double p = 2.0 * l - q;
+            return Color.FromArgb(
+                alpha,
+                (byte)Math.Round(HueToChannel(p, q, h + 1.0 / 3.0) * 255.0),
+                (byte)Math.Round(HueToChannel(p, q, h) * 255.0),
+                (byte)Math.Round(HueToChannel(p, q, h - 1.0 / 3.0) * 255.0));
+        }
+
+        private static double HueToChannel(double p, double q, double t) {
+            if (t < 0.0) { t += 1.0; }
+            if (t > 1.0) { t -= 1.0; }
+            if (t < 1.0 / 6.0) { return p + (q - p) * 6.0 * t; }
+            if (t < 1.0 / 2.0) { return q; }
+            if (t < 2.0 / 3.0) { return p + (q - p) * (2.0 / 3.0 - t) * 6.0; }
+            return p;
+        }
+    }
+}
+```
+
+- [ ] **Step 4: Run the test and verify it passes**
+
+```bash
+dotnet.exe test "$(wslpath -w Joko.NINA.Plugins/Joko.NINA.Plugins.sln)" -c Debug --nologo \
+  --filter "FullyQualifiedName~ContrastMathTests"
+```
+Expected: PASS, 8 tests. If `EveryBuiltInNinaSchema_...` fails, the failure message names the schema and role — do not lower `MinContrastRatio` to make it pass; fix `AccessibleAccent`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/Converters/ContrastMath.cs \
+        Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/Converters/ContrastMathTests.cs
+GIT_COMMITTER_NAME="George Hilios" GIT_COMMITTER_EMAIL="322725+ghilios@users.noreply.github.com" \
+  git commit --author="George Hilios <322725+ghilios@users.noreply.github.com>" \
+  -m "Add WCAG contrast math for accessible alert colors"
+```
+
+---
+
+## Task 2: The two color converters
+
+**Files:**
+- Create: `PLUGIN/Converters/BadgeTextColorConverter.cs`
+- Create: `PLUGIN/Converters/AccessibleAccentColorConverter.cs`
+- Test: `TESTS/Converters/AlertColorConverterTests.cs`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `TESTS/Converters/AlertColorConverterTests.cs`:
+
+```csharp
+using System.Globalization;
+using NINA.Joko.Plugins.HocusFocus.Converters;
+using NUnit.Framework;
+using Color = System.Windows.Media.Color;
+using Colors = System.Windows.Media.Colors;
+
+namespace NINA.Joko.Plugins.HocusFocus.Tests.Converters;
+
+[TestFixture]
+public class AlertColorConverterTests {
+
+    private static Color Hex(string rgb) => Color.FromRgb(
+        System.Convert.ToByte(rgb.Substring(0, 2), 16),
+        System.Convert.ToByte(rgb.Substring(2, 2), 16),
+        System.Convert.ToByte(rgb.Substring(4, 2), 16));
+
+    [Test]
+    public void BadgeText_OnNinaDefaultErrorFill_IsWhite() {
+        var converter = new BadgeTextColorConverter();
+        var result = converter.Convert(Hex("700000"), typeof(Color), null, CultureInfo.InvariantCulture);
+        Assert.That(result, Is.EqualTo(Colors.White));
+    }
+
+    // WPF pushes DependencyProperty.UnsetValue on the first pass of a resource-level binding. Returning
+    // Binding.DoNothing would leave SolidColorBrush.Color at Transparent, i.e. invisible text; white is the
+    // right answer for 15 of the 16 built-in schemas anyway.
+    [Test]
+    public void BadgeText_OnNonColourInput_FallsBackToWhite() {
+        var converter = new BadgeTextColorConverter();
+        var result = converter.Convert(System.Windows.DependencyProperty.UnsetValue, typeof(Color), null, CultureInfo.InvariantCulture);
+        Assert.That(result, Is.EqualTo(Colors.White));
+    }
+
+    [Test]
+    public void Accent_LightensTheErrorFillAgainstADarkBackground() {
+        var converter = new AccessibleAccentColorConverter();
+        var result = (Color)converter.Convert(
+            new object[] { Hex("700000"), Hex("02010A") }, typeof(Color), null, CultureInfo.InvariantCulture);
+        Assert.That(ContrastMath.ContrastRatio(result, Hex("02010A")),
+            Is.GreaterThanOrEqualTo(ContrastMath.MinContrastRatio));
+    }
+
+    [Test]
+    public void Accent_WithoutAUsableBackground_DegradesToTheRawAlertColour() {
+        var converter = new AccessibleAccentColorConverter();
+        var result = converter.Convert(
+            new object[] { Hex("700000"), System.Windows.DependencyProperty.UnsetValue },
+            typeof(Color), null, CultureInfo.InvariantCulture);
+        Assert.That(result, Is.EqualTo(Hex("700000")), "no background yet means today's behaviour, not a crash");
+    }
+
+    [Test]
+    public void Accent_WithNoUsableValuesAtAll_FallsBackToWhite() {
+        var converter = new AccessibleAccentColorConverter();
+        Assert.Multiple(() => {
+            Assert.That(converter.Convert(null, typeof(Color), null, CultureInfo.InvariantCulture), Is.EqualTo(Colors.White));
+            Assert.That(converter.Convert(new object[0], typeof(Color), null, CultureInfo.InvariantCulture), Is.EqualTo(Colors.White));
+        });
+    }
+}
+```
+
+- [ ] **Step 2: Run the test and verify it fails**
+
+```bash
+dotnet.exe test "$(wslpath -w Joko.NINA.Plugins/Joko.NINA.Plugins.sln)" -c Debug --nologo \
+  --filter "FullyQualifiedName~AlertColorConverterTests"
+```
+Expected: build FAILS — `BadgeTextColorConverter` / `AccessibleAccentColorConverter` do not exist.
+
+- [ ] **Step 3: Write the implementation**
+
+Create `PLUGIN/Converters/BadgeTextColorConverter.cs`:
+
+```csharp
+#region "copyright"
+
+/*
+    Copyright © 2021 - 2026 George Hilios <ghilios+NINA@googlemail.com>
+
+    This Source Code Form is subject to the terms of the Mozilla Public
+    License, v. 2.0. If a copy of the MPL was not distributed with this
+    file, You can obtain one at http://mozilla.org/MPL/2.0/.
+*/
+
+#endregion "copyright"
+
+using System;
+using System.Globalization;
+using System.Windows.Data;
+using System.Windows.Media;
+
+namespace NINA.Joko.Plugins.HocusFocus.Converters {
+
+    /// <summary>
+    /// Text color for a FILLED alert badge: black or white, whichever is readable on the badge's own fill.
+    /// Deliberately not NINA's NotificationErrorTextColor — see the note on <see cref="ContrastMath"/>.
+    /// </summary>
+    public class BadgeTextColorConverter : IValueConverter {
+
+        public object Convert(object value, Type targetType, object parameter, CultureInfo culture) {
+            // The first pass of a resource-level binding arrives as DependencyProperty.UnsetValue. White rather
+            // than Binding.DoNothing: DoNothing would leave SolidColorBrush.Color at Transparent (invisible
+            // text), and white is correct on 15 of the 16 built-in schemas.
+            return value is Color fill ? ContrastMath.BestContrastText(fill) : Colors.White;
+        }
+
+        public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture) {
+            throw new NotSupportedException();
+        }
+    }
+}
+```
+
+Create `PLUGIN/Converters/AccessibleAccentColorConverter.cs`:
+
+```csharp
+#region "copyright"
+
+/*
+    Copyright © 2021 - 2026 George Hilios <ghilios+NINA@googlemail.com>
+
+    This Source Code Form is subject to the terms of the Mozilla Public
+    License, v. 2.0. If a copy of the MPL was not distributed with this
+    file, You can obtain one at http://mozilla.org/MPL/2.0/.
+*/
+
+#endregion "copyright"
+
+using System;
+using System.Globalization;
+using System.Windows.Data;
+using System.Windows.Media;
+
+namespace NINA.Joko.Plugins.HocusFocus.Converters {
+
+    /// <summary>
+    /// Foreground for INLINE alert text drawn straight on the page: the schema's alert color, hue preserved,
+    /// lightened or darkened only as far as WCAG AA needs against the page background.
+    /// values[0] = alert color, values[1] = page background color.
+    /// </summary>
+    public class AccessibleAccentColorConverter : IMultiValueConverter {
+
+        public object Convert(object[] values, Type targetType, object parameter, CultureInfo culture) {
+            if (values == null || values.Length < 1 || !(values[0] is Color alert)) {
+                return Colors.White;
+            }
+            // Background not resolved yet: degrade to the raw alert color (exactly today's behaviour) rather
+            // than guessing. The real value arrives on the next pass.
+            if (values.Length < 2 || !(values[1] is Color background)) {
+                return alert;
+            }
+            return ContrastMath.AccessibleAccent(alert, background);
+        }
+
+        public object[] ConvertBack(object value, Type[] targetTypes, object parameter, CultureInfo culture) {
+            throw new NotSupportedException();
+        }
+    }
+}
+```
+
+- [ ] **Step 4: Run the test and verify it passes**
+
+```bash
+dotnet.exe test "$(wslpath -w Joko.NINA.Plugins/Joko.NINA.Plugins.sln)" -c Debug --nologo \
+  --filter "FullyQualifiedName~AlertColorConverterTests"
+```
+Expected: PASS, 5 tests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/Converters/BadgeTextColorConverter.cs \
+        Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/Converters/AccessibleAccentColorConverter.cs \
+        Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/Converters/AlertColorConverterTests.cs
+GIT_COMMITTER_NAME="George Hilios" GIT_COMMITTER_EMAIL="322725+ghilios@users.noreply.github.com" \
+  git commit --author="George Hilios <322725+ghilios@users.noreply.github.com>" \
+  -m "Add badge-text and accessible-accent colour converters"
+```
+
+---
+
+## Task 3: The alert brush dictionary
+
+**Files:**
+- Create: `PLUGIN/Resources/AlertBrushes.xaml`
+- Modify: `PLUGIN/Resources/OptionsDataTemplates.xaml` (add `MergedDictionaries`)
+- Modify: `PLUGIN/CameraSimulator/TiltAdapter/TiltAdapterDataTemplates.xaml` (add `MergedDictionaries`)
+
+There is no unit test here — WPF resource resolution is verified by the build plus the live check in Task 12.
+
+- [ ] **Step 1: Create the dictionary**
+
+Create `PLUGIN/Resources/AlertBrushes.xaml`:
+
+```xml
+<ResourceDictionary
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:hfconverters="clr-namespace:NINA.Joko.Plugins.HocusFocus.Converters">
+
+    <!--
+        Accessible alert chrome. NINA's NotificationError/WarningBrush are FILL colours (it only ever uses them
+        as a Background) and are near-black in 14 of its 16 built-in schemas, so using them as a Foreground
+        renders at 1.06-1.9:1 on every dark theme. Its paired NotificationErrorTextBrush is no better — the
+        "Dark" schema sets it to #FF02010A, near-black on near-black-red, 1.67:1. Both text colours are
+        therefore COMPUTED (see Converters/ContrastMath.cs), which holds >= 4.5:1 on all 16 built-in schemas and
+        on custom ones.
+
+        The Color properties are BOUND rather than fixed so a live colour-schema change flows through, the same
+        shape NINA uses in NINA.WPF.Base/Resources/StaticResources/Brushes.xaml.
+
+        USAGE:
+          HF_Alert*TextBrush   -> text INSIDE a filled badge
+          HF_Alert*AccentBrush -> alert text drawn straight on the page background
+          HF_Alert*Badge       -> the filled Border itself (BasedOn-able, so a local Style can add triggers)
+
+        When a Border becomes a filled badge, EVERY TextBlock inside it needs the badge text brush — children
+        with no explicit Foreground otherwise inherit PrimaryBrush onto the fill.
+    -->
+
+    <hfconverters:BadgeTextColorConverter x:Key="HF_BadgeTextColorConverter" />
+    <hfconverters:AccessibleAccentColorConverter x:Key="HF_AccessibleAccentColorConverter" />
+
+    <SolidColorBrush
+        x:Key="HF_AlertErrorTextBrush"
+        Color="{Binding Source={StaticResource NotificationErrorBrush},
+                        Path=Color,
+                        Converter={StaticResource HF_BadgeTextColorConverter}}" />
+
+    <SolidColorBrush
+        x:Key="HF_AlertWarningTextBrush"
+        Color="{Binding Source={StaticResource NotificationWarningBrush},
+                        Path=Color,
+                        Converter={StaticResource HF_BadgeTextColorConverter}}" />
+
+    <SolidColorBrush x:Key="HF_AlertErrorAccentBrush">
+        <SolidColorBrush.Color>
+            <MultiBinding Converter="{StaticResource HF_AccessibleAccentColorConverter}">
+                <Binding Path="Color" Source="{StaticResource NotificationErrorBrush}" />
+                <Binding Path="Color" Source="{StaticResource BackgroundBrush}" />
+            </MultiBinding>
+        </SolidColorBrush.Color>
+    </SolidColorBrush>
+
+    <SolidColorBrush x:Key="HF_AlertWarningAccentBrush">
+        <SolidColorBrush.Color>
+            <MultiBinding Converter="{StaticResource HF_AccessibleAccentColorConverter}">
+                <Binding Path="Color" Source="{StaticResource NotificationWarningBrush}" />
+                <Binding Path="Color" Source="{StaticResource BackgroundBrush}" />
+            </MultiBinding>
+        </SolidColorBrush.Color>
+    </SolidColorBrush>
+
+    <Style x:Key="HF_AlertErrorBadge" TargetType="Border">
+        <Setter Property="Background" Value="{StaticResource NotificationErrorBrush}" />
+        <Setter Property="BorderBrush" Value="{StaticResource NotificationErrorBrush}" />
+        <Setter Property="BorderThickness" Value="1" />
+        <Setter Property="CornerRadius" Value="3" />
+        <Setter Property="Padding" Value="6,4" />
+    </Style>
+
+    <Style x:Key="HF_AlertWarningBadge" TargetType="Border">
+        <Setter Property="Background" Value="{StaticResource NotificationWarningBrush}" />
+        <Setter Property="BorderBrush" Value="{StaticResource NotificationWarningBrush}" />
+        <Setter Property="BorderThickness" Value="1" />
+        <Setter Property="CornerRadius" Value="3" />
+        <Setter Property="Padding" Value="6,4" />
+    </Style>
+</ResourceDictionary>
+```
+
+- [ ] **Step 2: Merge it into `OptionsDataTemplates.xaml`**
+
+`PLUGIN/Resources/OptionsDataTemplates.xaml` currently has no `MergedDictionaries`. Insert one immediately after the root element's closing `>` (after the `mc:Ignorable="d">` line, before the first `<hfconverters:...>` resource).
+
+Find:
+```xml
+    mc:Ignorable="d">
+    <hfconverters:ShowStructureMapToVisibilityConverter x:Key="HF_ShowStructureMapToVisibilityConverter" />
+```
+Replace with:
+```xml
+    mc:Ignorable="d">
+    <!--  Alert chrome. Merged (not cross-dictionary StaticResource) so the keys resolve at parse time in every
+          dictionary that merges this one: AutoFocus, TiltAdapterWizard and StarDetection/Optimization all merge
+          OptionsDataTemplates already, so they inherit it for free.  -->
+    <ResourceDictionary.MergedDictionaries>
+        <ResourceDictionary Source="AlertBrushes.xaml" />
+    </ResourceDictionary.MergedDictionaries>
+    <hfconverters:ShowStructureMapToVisibilityConverter x:Key="HF_ShowStructureMapToVisibilityConverter" />
+```
+
+- [ ] **Step 3: Merge it into the camera-simulator dictionary**
+
+`PLUGIN/CameraSimulator/TiltAdapter/TiltAdapterDataTemplates.xaml` deliberately has no merges and declares its resources locally — its header comment warns that reaching across *separately-exported plugin dictionaries* with `StaticResource` is a load-order race. Merging is not that: merged keys resolve inside this dictionary's own scope at parse time. Merge only `AlertBrushes.xaml`, not the large `OptionsDataTemplates.xaml`.
+
+Find:
+```xml
+    xmlns:rules="clr-namespace:NINA.Core.Utility.ValidationRules;assembly=NINA.Core">
+
+    <!--  Declared locally rather than reached for across dictionaries: StaticResource resolves at parse time and
+```
+Replace with:
+```xml
+    xmlns:rules="clr-namespace:NINA.Core.Utility.ValidationRules;assembly=NINA.Core">
+
+    <!--  MERGED, not reached for: a merged dictionary's keys resolve inside this dictionary's own parse-time
+          scope, so it is not the cross-dictionary load-order race the note below is about. Only AlertBrushes is
+          merged, not the large OptionsDataTemplates.  -->
+    <ResourceDictionary.MergedDictionaries>
+        <ResourceDictionary Source="../../Resources/AlertBrushes.xaml" />
+    </ResourceDictionary.MergedDictionaries>
+
+    <!--  Declared locally rather than reached for across dictionaries: StaticResource resolves at parse time and
+```
+
+- [ ] **Step 4: Build and verify the XAML compiles**
+
+```bash
+dotnet.exe build "$(wslpath -w Joko.NINA.Plugins/Joko.NINA.Plugins.sln)" -c Debug --nologo
+```
+Expected: `Build succeeded`, 0 errors. A `MC3074` (unknown type) means the `hfconverters` namespace is wrong; an `MC3000` means malformed XAML. `AlertBrushes.xaml` needs no csproj entry — the WPF SDK auto-includes `**/*.xaml` as `Page`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/Resources/AlertBrushes.xaml \
+        Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/Resources/OptionsDataTemplates.xaml \
+        Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/CameraSimulator/TiltAdapter/TiltAdapterDataTemplates.xaml
+GIT_COMMITTER_NAME="George Hilios" GIT_COMMITTER_EMAIL="322725+ghilios@users.noreply.github.com" \
+  git commit --author="George Hilios <322725+ghilios@users.noreply.github.com>" \
+  -m "Add accessible alert brush dictionary and merge it where needed"
+```
+
+---
+
+## Task 4: Wizard XAML — filled badges
+
+**Files:**
+- Modify: `PLUGIN/TiltAdapterWizard/DataTemplates.xaml`
+
+**Line numbers below are from the pre-edit file.** Each edit shifts later lines, so work **bottom-up** (highest line number first) or re-locate each site by its `Text="{Binding …}"` binding, which is unique.
+
+### 4a. The six single-child alert Borders
+
+These all have the identical shape: a `Border` with `BorderBrush="{StaticResource NotificationErrorBrush}"` and a `<Border.Style>` carrying only the visibility trigger, whose sole child is the alert `TextBlock`.
+
+| Border | Text | Binding |
+|---|---|---|
+| 2045 | 2058 | `DeviceLinkDroppedWarningText` |
+| 2067 | 2080 | `MeasurementConsistencyWarningText` |
+| 2221 | 2234 | `DeviceLinkDroppedWarningText` |
+| 2244 | 2257 | `MeasurementConsistencyWarningText` |
+| 2266 | 2279 | `RebaselineDriftWarningText` |
+| 2288 | 2301 | `ConfidenceWarningText` |
+
+- [ ] **Step 1: Apply the badge transformation to all six**
+
+For each, make exactly two changes. Add `BasedOn` to the `<Style TargetType="Border">`:
+
+```xml
+<Style TargetType="Border" BasedOn="{StaticResource HF_AlertErrorBadge}">
+```
+
+and swap the child `TextBlock`'s foreground:
+
+```xml
+<TextBlock
+    Foreground="{StaticResource HF_AlertErrorTextBrush}"
+    Text="{Binding DeviceLinkDroppedWarningText}"
+    TextWrapping="Wrap" />
+```
+
+Worked example — the block at 2244–2260 becomes:
+
+```xml
+                    <Border
+                        Margin="0,5"
+                        Padding="5"
+                        BorderBrush="{StaticResource NotificationErrorBrush}"
+                        BorderThickness="1">
+                        <Border.Style>
+                            <Style TargetType="Border" BasedOn="{StaticResource HF_AlertErrorBadge}">
+                                <Setter Property="Visibility" Value="Collapsed" />
+                                <Style.Triggers>
+                                    <DataTrigger Binding="{Binding HasMeasurementConsistencyWarning}" Value="True">
+                                        <Setter Property="Visibility" Value="Visible" />
+                                    </DataTrigger>
+                                </Style.Triggers>
+                            </Style>
+                        </Border.Style>
+                        <TextBlock
+                            Foreground="{StaticResource HF_AlertErrorTextBrush}"
+                            Text="{Binding MeasurementConsistencyWarningText}"
+                            TextWrapping="Wrap" />
+                    </Border>
+```
+
+The local `Padding="5"` / `BorderThickness="1"` attributes stay: a local value beats a style setter in WPF, so they keep their existing spacing and only `Background` + `CornerRadius` come from the style. That is intended.
+
+### 4b. Wrap the bare connection warning (line 1875)
+
+`ConnectionWarningText` is a bare `TextBlock` with its own visibility `Style`. Wrapping it means the **`Border`** must own the visibility, or an empty red pill shows whenever the text is blank.
+
+- [ ] **Step 2: Replace the block at 1872–1893**
+
+Find:
+```xml
+                    <!--  Device connection warning: shown when Run Measurement is visible but devices are not connected  -->
+                    <TextBlock
+                        Margin="0,0,0,4"
+                        Foreground="{StaticResource NotificationErrorBrush}"
+                        Text="{Binding ConnectionWarningText}"
+                        TextWrapping="Wrap">
+                        <TextBlock.Style>
+                            <Style BasedOn="{StaticResource StandardTextBlock}" TargetType="TextBlock">
+                                <Setter Property="Visibility" Value="Collapsed" />
+                                <Style.Triggers>
+                                    <MultiDataTrigger>
+                                        <MultiDataTrigger.Conditions>
+                                            <Condition Binding="{Binding IsOnMeasurementStep}" Value="True" />
+                                            <Condition Binding="{Binding IsMeasuring}" Value="False" />
+                                            <Condition Binding="{Binding AreDevicesConnected}" Value="False" />
+                                        </MultiDataTrigger.Conditions>
+                                        <Setter Property="Visibility" Value="Visible" />
+                                    </MultiDataTrigger>
+                                </Style.Triggers>
+                            </Style>
+                        </TextBlock.Style>
+                    </TextBlock>
+```
+
+Replace with:
+```xml
+                    <!--  Device connection warning: shown when Run Measurement is visible but devices are not
+                          connected. The BORDER owns the visibility trigger, not the TextBlock — otherwise the
+                          filled badge would render as an empty red pill whenever the text is blank.  -->
+                    <Border Margin="0,0,0,4">
+                        <Border.Style>
+                            <Style TargetType="Border" BasedOn="{StaticResource HF_AlertErrorBadge}">
+                                <Setter Property="Visibility" Value="Collapsed" />
+                                <Style.Triggers>
+                                    <MultiDataTrigger>
+                                        <MultiDataTrigger.Conditions>
+                                            <Condition Binding="{Binding IsOnMeasurementStep}" Value="True" />
+                                            <Condition Binding="{Binding IsMeasuring}" Value="False" />
+                                            <Condition Binding="{Binding AreDevicesConnected}" Value="False" />
+                                        </MultiDataTrigger.Conditions>
+                                        <Setter Property="Visibility" Value="Visible" />
+                                    </MultiDataTrigger>
+                                </Style.Triggers>
+                            </Style>
+                        </Border.Style>
+                        <TextBlock
+                            Foreground="{StaticResource HF_AlertErrorTextBrush}"
+                            Text="{Binding ConnectionWarningText}"
+                            TextWrapping="Wrap" />
+                    </Border>
+```
+
+- [ ] **Step 3: Build**
+
+```bash
+dotnet.exe build "$(wslpath -w Joko.NINA.Plugins/Joko.NINA.Plugins.sln)" -c Debug --nologo
+```
+Expected: `Build succeeded`, 0 errors.
+
+- [ ] **Step 4: Verify all seven badge sites landed**
+
+```bash
+grep -c 'BasedOn="{StaticResource HF_AlertErrorBadge}"' \
+  Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/TiltAdapterWizard/DataTemplates.xaml
+```
+Expected: `7`
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/TiltAdapterWizard/DataTemplates.xaml
+GIT_COMMITTER_NAME="George Hilios" GIT_COMMITTER_EMAIL="322725+ghilios@users.noreply.github.com" \
+  git commit --author="George Hilios <322725+ghilios@users.noreply.github.com>" \
+  -m "Render wizard alert banners as filled badges"
+```
+
+---
+
+## Task 5: Wizard XAML — inline accents
+
+**Files:**
+- Modify: `PLUGIN/TiltAdapterWizard/DataTemplates.xaml`
+
+Eight sites keep being plain text and only change brush. Seven were alert-coloured; the eighth (`:1999`) is the long measurement-failure banner, which stays **outlined** per the house rule at `AutoFocus/DataTemplates.xaml:2967` — it wraps a paragraph, two sibling plain `TextBlock`s and a `Button`, so filling it would force every child onto the badge brush for no legibility gain.
+
+| Line | Binding / context | New brush |
+|---|---|---|
+| 372 | `LimitTag` default setter | `HF_AlertWarningAccentBrush` |
+| 378 | `LimitTag` `IsBlocking` trigger | `HF_AlertErrorAccentBrush` |
+| 403 | `PositionsUnknownAdvisory` | `HF_AlertWarningAccentBrush` |
+| 420 | `SendDisabledReason` | `HF_AlertWarningAccentBrush` |
+| 510 | `WillReachText` | `HF_AlertWarningAccentBrush` |
+| 537 | `TargetHintIsError` trigger | `HF_AlertErrorAccentBrush` |
+| 569 | `ReviewDisabledReason` | `HF_AlertWarningAccentBrush` |
+| 1999 | `MeasurementFailureText` | `HF_AlertErrorAccentBrush` |
+
+- [ ] **Step 1: Swap the eight brushes**
+
+Each is a single-token substitution on that line only:
+
+```xml
+<!-- line 372, inside <Style TargetType="TextBlock" BasedOn="{StaticResource StandardTextBlock}"> -->
+<Setter Property="Foreground" Value="{StaticResource HF_AlertWarningAccentBrush}" />
+
+<!-- line 378, inside the IsBlocking DataTrigger -->
+<Setter Property="Foreground" Value="{StaticResource HF_AlertErrorAccentBrush}" />
+
+<!-- lines 403, 420, 510, 569 — element attributes -->
+Foreground="{StaticResource HF_AlertWarningAccentBrush}"
+
+<!-- line 537, inside the TargetHintIsError DataTrigger -->
+<Setter Property="Foreground" Value="{StaticResource HF_AlertErrorAccentBrush}" />
+
+<!-- line 1999 — element attribute -->
+Foreground="{StaticResource HF_AlertErrorAccentBrush}"
+```
+
+Do **not** touch the `BorderBrush` at 488, 548, 643, 649, 1984, 2201 — those are outlines and text-box error states, both already readable.
+
+- [ ] **Step 2: Verify no alert `Foreground` remains in this file**
+
+```bash
+grep -n 'Foreground.*StaticResource Notification\(Error\|Warning\)Brush' \
+  Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/TiltAdapterWizard/DataTemplates.xaml
+```
+Expected: no output (exit status 1). Any hit is a missed site.
+
+- [ ] **Step 3: Build**
+
+```bash
+dotnet.exe build "$(wslpath -w Joko.NINA.Plugins/Joko.NINA.Plugins.sln)" -c Debug --nologo
+```
+Expected: `Build succeeded`, 0 errors.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/TiltAdapterWizard/DataTemplates.xaml
+GIT_COMMITTER_NAME="George Hilios" GIT_COMMITTER_EMAIL="322725+ghilios@users.noreply.github.com" \
+  git commit --author="George Hilios <322725+ghilios@users.noreply.github.com>" \
+  -m "Use accessible accent brushes for wizard advisory text"
+```
+
+---
+
+## Task 6: AutoFocus / Inspector XAML
+
+**Files:**
+- Modify: `PLUGIN/AutoFocus/DataTemplates.xaml`
+
+- [ ] **Step 1: Re-point the two existing badge texts (lines 135, 143)**
+
+The idle-countdown badge already fills correctly but reads its text colour from the schema, which is 1.93:1 on the Dark schema. Both lines currently say `Foreground="{StaticResource NotificationWarningTextBrush}"`; change both to:
+
+```xml
+Foreground="{StaticResource HF_AlertWarningTextBrush}"
+```
+
+Leave line 127 (`Background="{StaticResource NotificationWarningBrush}"`) exactly as it is — the fill is correct.
+
+- [ ] **Step 2: Swap the four alert foregrounds to accents**
+
+| Line | Context | New brush |
+|---|---|---|
+| 1845 | `⚠ differs from the focuser driver` | `HF_AlertWarningAccentBrush` |
+| 2981 | `Tilt got worse after the last adjustment` | `HF_AlertErrorAccentBrush` |
+| 3037 | `ViewingPastRunNotice` | `HF_AlertWarningAccentBrush` |
+| 3373 | `AutomaticAdjustmentRemediationText` | `HF_AlertWarningAccentBrush` |
+
+Line 2981 stays inside its **outlined** border — the comment directly above it at 2967 documents that `BorderThickness 1` with `NotificationErrorBrush` is the house style for a red box that carries an action, and this one wraps a paragraph plus two buttons.
+
+Do **not** touch:
+- lines 229/242/265/338/340 — chart `ErrorBarColor` / `Fill` / `Stroke`, which match NINA's own `AutoFocusChart.xaml`;
+- lines 2252/3773/4269 — literal `BorderBrush="Red"`, already ~5:1 and not text;
+- lines 3300/4236 — warning-outlined borders whose children are plain, already readable.
+
+- [ ] **Step 3: Verify**
+
+```bash
+grep -n 'Foreground.*StaticResource Notification\(Error\|Warning\)\(Text\)\?Brush' \
+  Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/AutoFocus/DataTemplates.xaml
+```
+Expected: no output (exit status 1).
+
+- [ ] **Step 4: Build**
+
+```bash
+dotnet.exe build "$(wslpath -w Joko.NINA.Plugins/Joko.NINA.Plugins.sln)" -c Debug --nologo
+```
+Expected: `Build succeeded`, 0 errors.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/AutoFocus/DataTemplates.xaml
+GIT_COMMITTER_NAME="George Hilios" GIT_COMMITTER_EMAIL="322725+ghilios@users.noreply.github.com" \
+  git commit --author="George Hilios <322725+ghilios@users.noreply.github.com>" \
+  -m "Make Inspector alert text readable on dark themes"
+```
+
+---
+
+## Task 7: Optimizer, options and camera-simulator XAML
+
+**Files:**
+- Modify: `PLUGIN/StarDetection/Optimization/DataTemplates.xaml`
+- Modify: `PLUGIN/Resources/OptionsDataTemplates.xaml`
+- Modify: `PLUGIN/CameraSimulator/TiltAdapter/TiltAdapterDataTemplates.xaml`
+
+- [ ] **Step 1: Optimizer — wrap `ErrorMessage` (line 1218) as a badge**
+
+This is a real failure banner and is short, so it earns the fill. It is a bare `TextBlock` with a `Visibility` **attribute** (no `Style`), so the wrapping `Border` takes the same converter binding.
+
+Find:
+```xml
+                <TextBlock
+                    Margin="0,8,0,0"
+                    Foreground="{StaticResource NotificationErrorBrush}"
+                    Text="{Binding ErrorMessage}"
+                    TextWrapping="Wrap"
+                    Visibility="{Binding HasError, Converter={StaticResource BooleanToVisibilityCollapsedConverter}}" />
+```
+Replace with:
+```xml
+                <!--  The BORDER carries the visibility, not the TextBlock: a filled badge whose text is blank
+                      would otherwise render as an empty red pill.  -->
+                <Border
+                    Margin="0,8,0,0"
+                    Style="{StaticResource HF_AlertErrorBadge}"
+                    Visibility="{Binding HasError, Converter={StaticResource BooleanToVisibilityCollapsedConverter}}">
+                    <TextBlock
+                        Foreground="{StaticResource HF_AlertErrorTextBrush}"
+                        Text="{Binding ErrorMessage}"
+                        TextWrapping="Wrap" />
+                </Border>
+```
+
+- [ ] **Step 2: Optimizer — swap the four advisory notes to accents**
+
+Lines 782 (`LowSignalChartNote`), 795 (`UndersampledStarsChartNote`), 1227 (`RecoveryWidenedNotice`), 1238 (`MinHfrRescueNotice`) all become:
+
+```xml
+Foreground="{StaticResource HF_AlertWarningAccentBrush}"
+```
+
+Keep these as text. The comment above line 782 states it is deliberately *"the page's ONLY colored element"* and deliberately the warning rather than the error brush — a pill would break that restraint.
+
+Do **not** touch lines 97/108/121/123/187/189 — chart colours.
+
+- [ ] **Step 3: Options — swap two accents**
+
+`PLUGIN/Resources/OptionsDataTemplates.xaml` lines 2616 (`PerFilterEditBinder.ActiveFilterWarning`) and 3359 (`⚠ differs from the focuser driver`):
+
+```xml
+Foreground="{StaticResource HF_AlertWarningAccentBrush}"
+```
+
+- [ ] **Step 4: Camera simulator — one accent, three badge texts**
+
+`PLUGIN/CameraSimulator/TiltAdapter/TiltAdapterDataTemplates.xaml`:
+
+- Line 327 (`ExtremeTiltText`) → `Foreground="{StaticResource HF_AlertWarningAccentBrush}"`
+- Lines 227, 275, 290 — currently `Foreground="{StaticResource NotificationWarningTextBrush}"` inside already-filled badges → `Foreground="{StaticResource HF_AlertWarningTextBrush}"`
+- Leave lines 220, 269, 284 (`Background="{StaticResource NotificationWarningBrush}"`) unchanged.
+
+- [ ] **Step 5: Verify every file is clean**
+
+```bash
+grep -rn 'Foreground.*StaticResource Notification\(Error\|Warning\)\(Text\)\?Brush' \
+  Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus --include=*.xaml
+```
+Expected: no output (exit status 1). This is the completion check for the whole of Part 1 — every alert foreground in the plugin now goes through the computed brushes.
+
+- [ ] **Step 6: Build**
+
+```bash
+dotnet.exe build "$(wslpath -w Joko.NINA.Plugins/Joko.NINA.Plugins.sln)" -c Debug --nologo
+```
+Expected: `Build succeeded`, 0 errors.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/DataTemplates.xaml \
+        Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/Resources/OptionsDataTemplates.xaml \
+        Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/CameraSimulator/TiltAdapter/TiltAdapterDataTemplates.xaml
+GIT_COMMITTER_NAME="George Hilios" GIT_COMMITTER_EMAIL="322725+ghilios@users.noreply.github.com" \
+  git commit --author="George Hilios <322725+ghilios@users.noreply.github.com>" \
+  -m "Make optimizer, options and simulator alert text readable on dark themes"
+```
+
+---
+
+## Task 8: Stop calling a `+N` move "Inward"
+
+**Files:**
+- Modify: `PLUGIN/TiltAdapterWizard/TiltAdapterWizardVM.cs` (lines 67, 756, 1040-1047, 1051-1053)
+- Modify: `PLUGIN/TiltAdapterDevices/AsgEat/EatWizardMapping.cs`
+- Modify: `PLUGIN/TiltAdapterWizard/DataTemplates.xaml` (line 1757)
+- Test: `TESTS/TiltAdapterWizard/TiltAdapterWizardVMTests.cs`, `TESTS/TiltAdapterDevices/AsgEat/EatWizardMappingTests.cs`
+
+**Behaviour must not change.** No sign, axis, amount or sequence is touched.
+
+- [ ] **Step 1: Write the failing tests**
+
+In `TESTS/TiltAdapterWizard/TiltAdapterWizardVMTests.cs`, replace the existing case at line 689:
+
+```csharp
+    [TestCase(WizardStep.AllInward, "All Screws Inward")]
+```
+
+with the two adjustment-type variants (keep every other `[TestCase]` on that test as-is, and add `isStepper` to the test signature and the `StepTitleText` call — the other cases pass `false`):
+
+```csharp
+    [TestCase(WizardStep.AllInward, false, "All Screws Clockwise")]
+    [TestCase(WizardStep.AllInward, true, "All Motors + Steps")]
+```
+
+Then add a new guard test to the same fixture:
+
+```csharp
+    // The wizard reserves "inward"/"outward" for ADAPTER-PLATE motion; screw and motor moves are worded
+    // clockwise/counter-clockwise or as signed steps. A step titled "All Screws Inward" while the device
+    // applies +N to every motor is what made a correct move look like a bug — and "+N is inward" is not
+    // something the wizard knows, it is what this very step measures.
+    [Test]
+    public void NoUserFacingMoveWording_ClaimsInwardOrOutward() {
+        var offenders = new List<string>();
+        foreach (var step in Enum.GetValues<WizardStep>()) {
+            foreach (var isStepper in new[] { false, true }) {
+                foreach (var screwCount in new[] { 3, 4 }) {
+                    offenders.AddRange(new[] {
+                        TiltAdapterWizardVM.StepTitleText(step, null, isStepper),
+                        TiltAdapterWizardVM.StepInstructionsText(step, screwCount, isStepper, 1.0),
+                        TiltAdapterWizardVM.BaselineRecoveryText(step, screwCount, isStepper, 1.0),
+                    }.Where(t => t != null &&
+                        (t.IndexOf("inward", StringComparison.OrdinalIgnoreCase) >= 0 ||
+                         t.IndexOf("outward", StringComparison.OrdinalIgnoreCase) >= 0)));
+                }
+            }
+            var move = EatWizardMapping.MoveForStep(step, 150);
+            if (move?.Description != null &&
+                (move.Description.IndexOf("inward", StringComparison.OrdinalIgnoreCase) >= 0 ||
+                 move.Description.IndexOf("outward", StringComparison.OrdinalIgnoreCase) >= 0)) {
+                offenders.Add(move.Description);
+            }
+        }
+        Assert.That(offenders, Is.Empty, "user-facing move wording must not claim a direction the wizard has not measured");
+    }
+```
+
+Add `using NINA.Joko.Plugins.HocusFocus.TiltAdapterDevices.AsgEat;`, `using System.Linq;` and `using System.Collections.Generic;` to the file's usings if absent.
+
+In `TESTS/TiltAdapterDevices/AsgEat/EatWizardMappingTests.cs`, add to the fixture:
+
+```csharp
+    [Test]
+    public void AllInward_DescriptionDoesNotClaimAPhysicalDirection() {
+        var move = EatWizardMapping.MoveForStep(WizardStep.AllInward, 150);
+        Assert.Multiple(() => {
+            Assert.That(move.Description, Does.Contain("All Motors"));
+            Assert.That(move.Description, Does.Not.Contain("Inward"));
+            Assert.That(move.Steps, Is.EqualTo(150), "wording only — the move itself is unchanged");
+            Assert.That(move.Axis, Is.EqualTo(TiltMoveAxis.Backfocus), "wording only — the axis is unchanged");
+        });
+    }
+```
+
+- [ ] **Step 2: Run the tests and verify they fail**
+
+```bash
+dotnet.exe test "$(wslpath -w Joko.NINA.Plugins/Joko.NINA.Plugins.sln)" -c Debug --nologo \
+  --filter "FullyQualifiedName~EatWizardMappingTests|FullyQualifiedName~TiltAdapterWizardVMTests"
+```
+Expected: FAIL — `StepTitleText` has no `isStepper` parameter; `Expected: String containing "All Motors"` but was `"Wizard All Inward: +150 backfocus"`.
+
+- [ ] **Step 3: Change the wording**
+
+In `PLUGIN/TiltAdapterWizard/TiltAdapterWizardVM.cs`:
+
+Line 67 — the enum comment:
+```csharp
+        AllInward = 1,    // b: all screws clockwise / all motors +N once (curvature/backfocus sign via a→b;
+                          // the NAME is historical and stays — it is persisted in saved replay runs — but no
+                          // user-facing string may claim "+N" is physically inward: measuring that is the
+                          // whole purpose of this step.
+```
+
+Line 756 — inside `StepTitleText`, whose signature gains a parameter:
+```csharp
+        internal static string StepTitleText(WizardStep step, IScrewLabelProvider labels = null, bool isStepper = false) {
+            switch (step) {
+                case WizardStep.Baseline: return "Baseline Measurement";
+                // NOT "All Screws Inward": the wizard applies +N to every motor and MEASURES which way the
+                // adapter plate goes. Naming the direction here contradicts the step and misreads as a bug.
+                case WizardStep.AllInward: return isStepper ? "All Motors + Steps" : "All Screws Clockwise";
+```
+
+Line 752 — the `StepTitle` property:
+```csharp
+        public string StepTitle => StepTitleText(currentStep, ScrewLabels, IsStepperAdjustment);
+```
+
+Line 1051 — `ReplayStepInstructionsText` threads the flag through:
+```csharp
+        internal static string ReplayStepInstructionsText(WizardStep step, IScrewLabelProvider labels = null, bool isStepper = false) =>
+            $"Replaying — re-analyzing the saved frames for {StepTitleText(step, labels, isStepper)}. No action needed: nothing is " +
+            "captured and the tilt adapter is not moved during a replay.";
+```
+
+Line 1042 — its call site inside `StepInstructions`:
+```csharp
+                ? ReplayStepInstructionsText(currentStep, ScrewLabels, IsStepperAdjustment)
+```
+
+Line 484 — the adjustment-type change handler already raises `StepInstructions`; add the title beside it:
+```csharp
+                    RaisePropertyChanged(nameof(StepInstructions));
+                    RaisePropertyChanged(nameof(StepTitle));
+                    RaisePropertyChanged(nameof(BaselineRecoveryInstructions));
+```
+
+In `PLUGIN/TiltAdapterDevices/AsgEat/EatWizardMapping.cs`, in the `WizardStep.AllInward` case:
+```csharp
+                case WizardStep.AllInward:
+                    // "Apply +N steps to EVERY motor, then click Run Measurement." -> all four wizard
+                    // screws +N -> (+N,+N,+N,+N) = Backfocus(+N). Described as "All Motors", never "Inward":
+                    // whether +N is physically inward is exactly what this step measures.
+                    return new TiltAdapterMove(
+                        TiltMoveAxis.Backfocus, appliedSteps, TiltMoveGroup.Backfocus,
+                        $"Wizard All Motors: {FormatSigned(appliedSteps)} backfocus");
+```
+
+Also update the class-level doc comment on `EatWizardMapping` where it lists `AllInward` in the sequence prose: change the words "AllInward" to "AllInward (all motors)" so the enum reference stays greppable while the prose no longer asserts a direction.
+
+- [ ] **Step 4: Add the explanatory tooltip**
+
+In `PLUGIN/TiltAdapterWizard/DataTemplates.xaml` at line 1755-1757, add a `ToolTip` to the step-title `TextBlock`:
+
+```xml
+                    <TextBlock
+                        Margin="0,1,0,6"
+                        FontWeight="Bold"
+                        Text="{Binding StepTitle}"
+                        ToolTip="Moving every screw or motor together changes backfocus, and this step measures which way the adapter plate actually travels. A '+' step is not assumed to be inward — determining that direction is the point of the step." />
+```
+
+- [ ] **Step 5: Run the tests and verify they pass**
+
+```bash
+dotnet.exe test "$(wslpath -w Joko.NINA.Plugins/Joko.NINA.Plugins.sln)" -c Debug --nologo \
+  --filter "FullyQualifiedName~EatWizardMappingTests|FullyQualifiedName~TiltAdapterWizardVMTests"
+```
+Expected: PASS. `EatWizardMappingTests`' existing full-sequence regressions must still pass untouched — they pin that the moves sum to `(0,0,0,0)`, which proves this change was wording-only.
+
+- [ ] **Step 6: Update the stale doc reference**
+
+In `docs/tilt-adapter-ui-review-design.md` line 83, change `AllInward → "All Screws Inward"` to `AllInward → "All Screws Clockwise" / "All Motors + Steps"`.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/TiltAdapterWizard/TiltAdapterWizardVM.cs \
+        Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/TiltAdapterDevices/AsgEat/EatWizardMapping.cs \
+        Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/TiltAdapterWizard/DataTemplates.xaml \
+        Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/TiltAdapterWizard/TiltAdapterWizardVMTests.cs \
+        Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/TiltAdapterDevices/AsgEat/EatWizardMappingTests.cs \
+        docs/tilt-adapter-ui-review-design.md
+GIT_COMMITTER_NAME="George Hilios" GIT_COMMITTER_EMAIL="322725+ghilios@users.noreply.github.com" \
+  git commit --author="George Hilios <322725+ghilios@users.noreply.github.com>" \
+  -m "Stop calling the all-motors calibration step 'Inward'"
+```
+
+---
+
+## Task 9: Opt-in re-link — view model
+
+**Files:**
+- Modify: `PLUGIN/TiltAdapterWizard/TiltAdapterWizardVM.cs`
+- Modify: `PLUGIN/CameraSimulator/TiltAdapter/SimulatedTiltAdapterVM.cs`
+- Test: `TESTS/TiltAdapterWizard/TiltAdapterWizardVMTests.cs`
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to `TESTS/TiltAdapterWizard/TiltAdapterWizardVMTests.cs`, using the fixture's **existing** `Build` helper (line 62) — do not invent a new one:
+
+First add one private helper beside the fixture's other helpers — the only new setup this task needs:
+
+```csharp
+        // A saved, valid calibration on a motorized preset — the state the Trust banner is about.
+        // "ASG Electronic EAT - 90mm" is a real registered preset name; TiltMotionControllerRegistry.IsMotorized
+        // does an exact-name lookup, so an invented name would silently make every banner test pass vacuously.
+        private const string MotorizedPreset = "ASG Electronic EAT - 90mm";
+
+        private static (TiltAdapterWizardVM vm, ITiltAdapterOptions options) BuildCalibrated(
+            string deviceName = MotorizedPreset, string linkedDevice = "", bool reliable = false) {
+            var (vm, options, _, _) = Build(screwCount: 3, configureOptions: o => {
+                o.DeviceName.Returns(deviceName);
+                o.IsCalibrated.Returns(true);
+                o.CalibratedScrewCount.Returns(3);
+                o.DeviceLinkedCalibrationDeviceName.Returns(linkedDevice);
+                o.CalibrationIsReliable.Returns(reliable);
+            });
+            return (vm, options);
+        }
+```
+
+then the tests:
+
+```csharp
+        [Test]
+        public void TrustCalibration_AloneWritesNothing() {
+            var (vm, options) = BuildCalibrated();
+            options.ClearReceivedCalls();
+
+            vm.TrustCalibrationCommand.Execute(null);
+
+            Assert.Multiple(() => {
+                Assert.That(vm.IsTrustCalibrationPending, Is.True, "the button only arms the confirmation");
+                options.DidNotReceive().DeviceLinkedCalibrationDeviceName = Arg.Any<string>();
+                options.DidNotReceive().CalibrationIsReliable = Arg.Any<bool>();
+            });
+        }
+
+        [Test]
+        public void ConfirmTrustCalibration_ArmsBothAutomationMarkersForTheCurrentDevice() {
+            var (vm, options) = BuildCalibrated();
+            options.ClearReceivedCalls();
+
+            vm.TrustCalibrationCommand.Execute(null);
+            vm.ConfirmTrustCalibrationCommand.Execute(null);
+
+            Assert.Multiple(() => {
+                options.Received().DeviceLinkedCalibrationDeviceName = MotorizedPreset;
+                options.Received().CalibrationIsReliable = true;
+                Assert.That(vm.IsTrustCalibrationPending, Is.False);
+            });
+        }
+
+        [Test]
+        public void CancelTrustCalibration_WritesNothing() {
+            var (vm, options) = BuildCalibrated();
+            options.ClearReceivedCalls();
+
+            vm.TrustCalibrationCommand.Execute(null);
+            vm.CancelTrustCalibrationCommand.Execute(null);
+
+            Assert.Multiple(() => {
+                Assert.That(vm.IsTrustCalibrationPending, Is.False);
+                options.DidNotReceive().DeviceLinkedCalibrationDeviceName = Arg.Any<string>();
+                options.DidNotReceive().CalibrationIsReliable = Arg.Any<bool>();
+            });
+        }
+
+        [Test]
+        public void ApplyManualCalibration_DisarmsAPendingTrustConfirmation() {
+            // A stale confirmation must not survive the state change that invalidated it.
+            var (vm, options) = BuildCalibrated(linkedDevice: MotorizedPreset, reliable: true);
+            options.ScrewInwardCurvatureSign.Returns(1);
+            vm.TrustCalibrationCommand.Execute(null);
+            vm.ManualScrew1AngleDegrees = 30;
+
+            vm.ApplyManualCalibration();
+
+            Assert.Multiple(() => {
+                Assert.That(vm.IsTrustCalibrationPending, Is.False);
+                options.Received().DeviceLinkedCalibrationDeviceName = string.Empty;
+                options.Received().CalibrationIsReliable = false;
+            });
+        }
+
+        [Test]
+        public void ClearCalibration_AlsoClearsTheAutomationMarkers() {
+            var (vm, options) = BuildCalibrated(linkedDevice: MotorizedPreset, reliable: true);
+            options.ClearReceivedCalls();
+
+            vm.ClearCalibrationCommand.Execute(null);
+
+            Assert.Multiple(() => {
+                options.Received().DeviceLinkedCalibrationDeviceName = string.Empty;
+                options.Received().CalibrationIsReliable = false;
+            });
+        }
+
+        [Test]
+        public void AutomationTrustBanner_IsHiddenForADeviceLinkedReliableCalibration() {
+            var (vm, _) = BuildCalibrated(linkedDevice: MotorizedPreset, reliable: true);
+            Assert.That(vm.AutomationTrustBannerVisible, Is.False);
+        }
+
+        [Test]
+        public void AutomationTrustBanner_IsShownForAManualCalibrationOnAMotorizedPreset() {
+            var (vm, _) = BuildCalibrated();
+            Assert.That(vm.AutomationTrustBannerVisible, Is.True);
+        }
+
+        [Test]
+        public void AutomationTrustBanner_IsHiddenOnANonMotorizedPreset() {
+            var (vm, _) = BuildCalibrated(deviceName: TiltAdapterDevicePreset.ManualName);
+            Assert.That(vm.AutomationTrustBannerVisible, Is.False,
+                "there is nothing to automate without a motorized device");
+        }
+
+        [Test]
+        public void AutomationTrustBanner_IsHiddenWithNoSavedCalibration() {
+            var (vm, _, _, _) = Build(screwCount: 3, configureOptions: o => {
+                o.DeviceName.Returns(MotorizedPreset);
+                o.IsCalibrated.Returns(false);
+            });
+            Assert.That(vm.AutomationTrustBannerVisible, Is.False);
+        }
+
+        [Test]
+        public void ConfirmedTrust_SatisfiesTheAutomaticAdjustmentGate() {
+            // The point of the whole feature: the Inspector's gate reads exactly these two markers.
+            var (vm, options) = BuildCalibrated();
+            vm.TrustCalibrationCommand.Execute(null);
+            vm.ConfirmTrustCalibrationCommand.Execute(null);
+            // NSubstitute property setters do not feed the getters back, so mirror what was written.
+            options.DeviceLinkedCalibrationDeviceName.Returns(MotorizedPreset);
+            options.CalibrationIsReliable.Returns(true);
+
+            Assert.Multiple(() => {
+                Assert.That(InspectorVM.IsCalibrationDeviceLinked(options), Is.True);
+                Assert.That(InspectorVM.CanExecuteAutomaticAdjustment(
+                    serviceConnected: true, controllerAvailable: true,
+                    deviceLinked: InspectorVM.IsCalibrationDeviceLinked(options),
+                    calibrationIsReliable: options.CalibrationIsReliable,
+                    hasNumericGuidance: true, isOperationActive: false,
+                    currentGeneration: 2, lastExecutedGeneration: 1), Is.True);
+                Assert.That(vm.AutomationTrustBannerVisible, Is.False, "the banner retires once trust is granted");
+            });
+        }
+
+        [Test]
+        public void SelectingADifferentDevicePreset_RevokesTheTrust() {
+            // No explicit revoke needed: IsCalibrationDeviceLinked compares against the CURRENT DeviceName.
+            var (vm, options) = BuildCalibrated(linkedDevice: MotorizedPreset, reliable: true);
+            Assert.That(vm.AutomationTrustBannerVisible, Is.False, "precondition: trusted");
+
+            options.DeviceName.Returns("ASG Electronic EAT - ZWO 461");
+
+            Assert.Multiple(() => {
+                Assert.That(InspectorVM.IsCalibrationDeviceLinked(options), Is.False);
+                Assert.That(vm.AutomationTrustBannerVisible, Is.True);
+            });
+        }
+```
+
+Add `using NINA.Joko.Plugins.HocusFocus.AutoFocus;` to the file's usings if absent (for `InspectorVM`).
+
+- [ ] **Step 2: Run the tests and verify they fail**
+
+```bash
+dotnet.exe test "$(wslpath -w Joko.NINA.Plugins/Joko.NINA.Plugins.sln)" -c Debug --nologo \
+  --filter "FullyQualifiedName~TiltAdapterWizardVMTests"
+```
+Expected: build FAILS — `TrustCalibrationCommand`, `IsTrustCalibrationPending`, `AutomationTrustBannerVisible` do not exist.
+
+- [ ] **Step 3: Add the state, banner and commands**
+
+In `PLUGIN/TiltAdapterWizard/TiltAdapterWizardVM.cs`, beside the other `ICommand` declarations (around line 1230), add:
+
+```csharp
+        public ICommand TrustCalibrationCommand { get; }
+        public ICommand ConfirmTrustCalibrationCommand { get; }
+        public ICommand CancelTrustCalibrationCommand { get; }
+```
+
+and in the constructor, beside the other command wiring:
+
+```csharp
+            // No canExecute predicate on purpose: the whole banner that hosts these buttons is collapsed
+            // unless AutomationTrustBannerVisible, so gating them again would only add a second source of
+            // truth that NotifyCommandsCanExecuteChangedCore does not know to refresh.
+            TrustCalibrationCommand = new RelayCommand(() => IsTrustCalibrationPending = true);
+            ConfirmTrustCalibrationCommand = new RelayCommand(ConfirmTrustCalibration);
+            CancelTrustCalibrationCommand = new RelayCommand(() => IsTrustCalibrationPending = false);
+```
+
+Add the state and the gate near `IsCalibrationValid` (around line 797):
+
+```csharp
+        private bool isTrustCalibrationPending;
+
+        /// <summary>
+        /// True once the user has asked to trust a hand-entered calibration and the in-pane confirmation is
+        /// showing. Two-step rather than a modal, mirroring SimulatedTiltAdapterVM's CopyToAdapter trio, which
+        /// guards the structurally identical decision — and unlike a MyMessageBox it stays unit-testable.
+        /// </summary>
+        public bool IsTrustCalibrationPending {
+            get => isTrustCalibrationPending;
+            private set {
+                if (isTrustCalibrationPending != value) {
+                    isTrustCalibrationPending = value;
+                    RaisePropertyChanged();
+                }
+            }
+        }
+
+        /// <summary>
+        /// [CRITICAL GATE] Shown when a saved calibration cannot drive Automatic Adjustment because it is not
+        /// linked to the selected device preset, or did not pass its own confidence check — the exact pair
+        /// InspectorVM.CanExecuteAutomaticAdjustment requires. Gated on a motorized preset because there is
+        /// nothing to automate otherwise.
+        ///
+        /// This exists because clearing those markers used to be completely silent: a user who corrected one
+        /// angle by hand after a device-driven run lost Automatic Adjustment with no message, no cause named,
+        /// and no remedy short of repeating the whole calibration.
+        /// </summary>
+        public bool AutomationTrustBannerVisible =>
+            IsCalibrationValid
+            && IsMotorizedDevice
+            && !(InspectorVM.IsCalibrationDeviceLinked(tiltAdapterOptions) && tiltAdapterOptions.CalibrationIsReliable);
+
+        private void ConfirmTrustCalibration() {
+            IsTrustCalibrationPending = false;
+            // Deliberately re-arming the two markers ApplyManualCalibration cleared. The user has been told,
+            // in the confirmation copy, exactly what goes wrong if the screw numbering does not match the
+            // device's wiring. Both markers are re-cleared by every path that invalidates the correspondence:
+            // a fresh manual entry, ClearCalibration, or selecting a different device preset (which
+            // IsCalibrationDeviceLinked invalidates for free by comparing against the CURRENT DeviceName).
+            tiltAdapterOptions.DeviceLinkedCalibrationDeviceName = tiltAdapterOptions.DeviceName;
+            tiltAdapterOptions.CalibrationIsReliable = true;
+            RaisePropertyChanged(nameof(AutomationTrustBannerVisible));
+        }
+```
+
+- [ ] **Step 4: Warn when a manual entry revokes automation**
+
+In `ApplyManualCalibration()`, capture the prior state before the `[CRITICAL GATE]` clears at line 1375, and warn after them. Insert immediately before `tiltAdapterOptions.DeviceLinkedCalibrationDeviceName = string.Empty;`:
+
+```csharp
+            // Whether this entry actually TAKES automation away, so a first-ever manual entry (which never had
+            // it) does not warn about losing something the user never had.
+            bool revokedAutomation =
+                InspectorVM.IsCalibrationDeviceLinked(tiltAdapterOptions) || tiltAdapterOptions.CalibrationIsReliable;
+```
+
+and immediately after `tiltAdapterOptions.CalibrationIsReliable = false;`:
+
+```csharp
+            // A stale confirmation must not survive the state change that invalidated it.
+            IsTrustCalibrationPending = false;
+            if (revokedAutomation) {
+                Notification.ShowWarning(
+                    "Automatic Adjustment is now disabled: a hand-entered calibration can't be checked against the " +
+                    "device's motor wiring. Use \"Trust This Calibration for Automation\" in the wizard to re-enable it, " +
+                    "or re-run calibration with the device connected.");
+            }
+```
+
+At the end of the method, beside the existing `RaiseHardwareSummaryChanged(); RebuildDiagram();`, add:
+
+```csharp
+            RaisePropertyChanged(nameof(AutomationTrustBannerVisible));
+```
+
+- [ ] **Step 5: Fix `ClearCalibration`'s missing marker clears**
+
+`ClearCalibration()` clears the angles and flags but leaves `DeviceLinkedCalibrationDeviceName` and `CalibrationIsReliable` set. Harmless before this task only because clearing the angles also removes the numeric guidance the gate needs — but wrong now that Trust can set them deliberately. After `tiltAdapterOptions.CalibrationIsManual = false;` add:
+
+```csharp
+            // [CRITICAL GATE] Clearing the calibration must also clear what made it automation-trusted; leaving
+            // these set would let a later Trust-free calibration inherit a stale link.
+            tiltAdapterOptions.DeviceLinkedCalibrationDeviceName = string.Empty;
+            tiltAdapterOptions.CalibrationIsReliable = false;
+            IsTrustCalibrationPending = false;
+```
+
+and at the end, beside `RebuildDiagram();`:
+
+```csharp
+            RaisePropertyChanged(nameof(AutomationTrustBannerVisible));
+```
+
+- [ ] **Step 6: Raise the banner on the options that gate it**
+
+In the `tiltAdapterOptions.PropertyChanged` handler (around line 438-460), extend the two existing blocks:
+
+```csharp
+                if (e.PropertyName == nameof(ITiltAdapterOptions.CalibrationIsManual)) {
+                    RaisePropertyChanged(nameof(IsCalibrationValid));
+                    RaisePropertyChanged(nameof(AutomationTrustBannerVisible));
+                }
+                if (e.PropertyName == nameof(ITiltAdapterOptions.ScrewCount) ||
+                    e.PropertyName == nameof(ITiltAdapterOptions.IsCalibrated) ||
+                    e.PropertyName == nameof(ITiltAdapterOptions.CalibratedScrewCount)) {
+                    RaisePropertyChanged(nameof(IsCalibrationValid));
+                    RaisePropertyChanged(nameof(AutomationTrustBannerVisible));
+                    RebuildDiagram();
+                }
+```
+
+and add the banner to the `DeviceName` block, which already raises `IsMotorizedDevice`:
+
+```csharp
+                    RaisePropertyChanged(nameof(IsMotorizedDevice));
+                    RaisePropertyChanged(nameof(AutomationTrustBannerVisible));
+```
+
+- [ ] **Step 7: Marker hygiene in the camera simulator**
+
+`SimulatedTiltAdapterVM.ConfirmCopyToAdapter()` writes a manual calibration over the real one and relies on setting `DeviceName = ManualName` to break the device link implicitly. Make it explicit, matching the other two paths. After `realAdapter.CalibrationIsManual = true;` add:
+
+```csharp
+            // [CRITICAL GATE] Same clears the wizard's manual-entry path makes. Setting DeviceName to Manual
+            // above already breaks IsCalibrationDeviceLinked implicitly, but leaving a stale device name in the
+            // marker is exactly the kind of thing that survives a later preset change.
+            realAdapter.DeviceLinkedCalibrationDeviceName = string.Empty;
+            realAdapter.CalibrationIsReliable = false;
+```
+
+- [ ] **Step 8: Run the tests and verify they pass**
+
+```bash
+dotnet.exe test "$(wslpath -w Joko.NINA.Plugins/Joko.NINA.Plugins.sln)" -c Debug --nologo \
+  --filter "FullyQualifiedName~TiltAdapterWizardVMTests|FullyQualifiedName~SimulatedTiltAdapterVMTests"
+```
+Expected: PASS. The pre-existing test at line 807 asserting `options.Received().CalibrationIsManual = true` must still pass.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/TiltAdapterWizard/TiltAdapterWizardVM.cs \
+        Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/CameraSimulator/TiltAdapter/SimulatedTiltAdapterVM.cs \
+        Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/TiltAdapterWizard/TiltAdapterWizardVMTests.cs
+GIT_COMMITTER_NAME="George Hilios" GIT_COMMITTER_EMAIL="322725+ghilios@users.noreply.github.com" \
+  git commit --author="George Hilios <322725+ghilios@users.noreply.github.com>" \
+  -m "Let a hand-entered calibration be trusted for automation, explicitly"
+```
+
+---
+
+## Task 10: Opt-in re-link — wizard UI
+
+**Files:**
+- Modify: `PLUGIN/TiltAdapterWizard/DataTemplates.xaml`
+
+- [ ] **Step 1: Add the banner to the saved-calibration sub-panel**
+
+Insert immediately **before** the `Clear Calibration` `Button` (originally at line 1656, inside the `IsCalibrationValid` `StackPanel`):
+
+```xml
+                        <!--  [CRITICAL GATE] Automation is blocked for a calibration that is not device-linked or
+                              not confidence-checked. Clearing those markers used to be entirely silent — a user
+                              who corrected one angle by hand after a device-driven run lost Automatic Adjustment
+                              with no message and no way back short of repeating the calibration. Filled badge
+                              rather than the quiet outlined style because this CARRIES AN ACTION and explains a
+                              capability that has disappeared (same reasoning as the idle-countdown banner in
+                              AutoFocus/DataTemplates.xaml).  -->
+                        <Border Margin="0,10,0,0" Visibility="{Binding AutomationTrustBannerVisible, Converter={StaticResource BooleanToVisibilityCollapsedConverter}}"
+                            Style="{StaticResource HF_AlertWarningBadge}">
+                            <StackPanel>
+                                <TextBlock
+                                    MaxWidth="520"
+                                    HorizontalAlignment="Left"
+                                    FontWeight="Bold"
+                                    Foreground="{StaticResource HF_AlertWarningTextBrush}"
+                                    Text="Automatic Adjustment is disabled"
+                                    TextWrapping="Wrap" />
+                                <TextBlock
+                                    MaxWidth="520"
+                                    Margin="0,3,0,0"
+                                    HorizontalAlignment="Left"
+                                    Foreground="{StaticResource HF_AlertWarningTextBrush}"
+                                    Text="This calibration was entered or edited by hand, so HocusFocus cannot verify that your screw numbering matches the device's motor wiring. Re-run the wizard with the device connected, or trust this calibration explicitly."
+                                    TextWrapping="Wrap" />
+
+                                <!--  Step 1: arm.  -->
+                                <Button
+                                    Margin="0,6,0,0"
+                                    HorizontalAlignment="Left"
+                                    Command="{Binding TrustCalibrationCommand}"
+                                    Visibility="{Binding IsTrustCalibrationPending, Converter={StaticResource InverseBooleanToVisibilityCollapsedConverter}}">
+                                    <TextBlock
+                                        Margin="10,5,10,5"
+                                        Foreground="{StaticResource ButtonForegroundBrush}"
+                                        Text="Trust This Calibration for Automation" />
+                                </Button>
+
+                                <!--  Step 2: the risk, then confirm or back out.  -->
+                                <StackPanel Visibility="{Binding IsTrustCalibrationPending, Converter={StaticResource BooleanToVisibilityCollapsedConverter}}">
+                                    <TextBlock
+                                        MaxWidth="520"
+                                        Margin="0,6,0,0"
+                                        HorizontalAlignment="Left"
+                                        FontWeight="Bold"
+                                        Foreground="{StaticResource HF_AlertWarningTextBrush}"
+                                        Text="If your screw numbering does not match the device's motor wiring, Automatic Adjustment will drive the adapter unattended in the wrong direction and make tilt worse. Verify with a single manual adjustment before leaving it unattended."
+                                        TextWrapping="Wrap" />
+                                    <WrapPanel Margin="0,6,0,0">
+                                        <Button Command="{Binding ConfirmTrustCalibrationCommand}">
+                                            <TextBlock
+                                                Margin="10,5,10,5"
+                                                Foreground="{StaticResource ButtonForegroundBrush}"
+                                                Text="Yes, trust it" />
+                                        </Button>
+                                        <Button Margin="6,0,0,0" Command="{Binding CancelTrustCalibrationCommand}">
+                                            <TextBlock
+                                                Margin="10,5,10,5"
+                                                Foreground="{StaticResource ButtonForegroundBrush}"
+                                                Text="Cancel" />
+                                        </Button>
+                                    </WrapPanel>
+                                </StackPanel>
+                            </StackPanel>
+                        </Border>
+```
+
+- [ ] **Step 2: Confirm both visibility converters resolve here**
+
+```bash
+grep -n 'InverseBooleanToVisibilityCollapsedConverter\|x:Key="BooleanToVisibilityCollapsedConverter"' \
+  Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/Resources/OptionsDataTemplates.xaml | head
+```
+Expected: both keys appear. The wizard dictionary merges `OptionsDataTemplates.xaml`, so they resolve. If `InverseBooleanToVisibilityCollapsedConverter` is not defined there, use NINA's `InverseBooleanToVisibilityCollapsedConverter` from `util:` instead, or swap the two `Visibility` bindings to use a single `DataTrigger`-based `Style` — do not add a duplicate converter key.
+
+- [ ] **Step 3: Build**
+
+```bash
+dotnet.exe build "$(wslpath -w Joko.NINA.Plugins/Joko.NINA.Plugins.sln)" -c Debug --nologo
+```
+Expected: `Build succeeded`, 0 errors.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/TiltAdapterWizard/DataTemplates.xaml
+GIT_COMMITTER_NAME="George Hilios" GIT_COMMITTER_EMAIL="322725+ghilios@users.noreply.github.com" \
+  git commit --author="George Hilios <322725+ghilios@users.noreply.github.com>" \
+  -m "Add the trust-this-calibration banner to the wizard"
+```
+
+---
+
+## Task 11: Name the real cause in the Inspector
+
+**Files:**
+- Modify: `PLUGIN/AutoFocus/InspectorVM.cs` (line 2502-2505)
+- Test: `TESTS/AutoFocus/InspectorVMAutomaticAdjustmentTests.cs`
+
+- [ ] **Step 1: Write the failing test**
+
+Add to the `#region IsCalibrationDeviceLinked` block of `TESTS/AutoFocus/InspectorVMAutomaticAdjustmentTests.cs` — the fixture that already covers `InspectorVM`'s pure gate helpers. It uses `"ASG Electronic EAT - 90mm"` as its preset name; keep that.
+
+```csharp
+    [Test]
+    public void RemediationText_ForAHandEnteredCalibration_NamesManualEntryAsTheCause() {
+        var options = Substitute.For<ITiltAdapterOptions>();
+        options.DeviceName.Returns("ASG Electronic EAT - 90mm");
+        options.DeviceLinkedCalibrationDeviceName.Returns(string.Empty);
+        options.CalibrationIsManual.Returns(true);
+
+        var text = InspectorVM.AutomaticAdjustmentRemediationTextFor(options);
+
+        Assert.Multiple(() => {
+            Assert.That(text, Does.Contain("by hand"));
+            Assert.That(text, Does.Contain("Tilt Adapter Wizard"), "the remedy must point at where the Trust button is");
+        });
+    }
+
+    [Test]
+    public void RemediationText_ForANonManualUnlinkedCalibration_KeepsTheExistingWording() {
+        var options = Substitute.For<ITiltAdapterOptions>();
+        options.DeviceName.Returns("ASG Electronic EAT - 90mm");
+        options.DeviceLinkedCalibrationDeviceName.Returns(string.Empty);
+        options.CalibrationIsManual.Returns(false);
+
+        Assert.That(InspectorVM.AutomaticAdjustmentRemediationTextFor(options),
+            Is.EqualTo("This calibration is not linked to the connected device. Re-run calibration with the device connected."));
+    }
+
+    [Test]
+    public void RemediationText_ForALinkedButLowConfidenceCalibration_KeepsTheExistingWording() {
+        var options = Substitute.For<ITiltAdapterOptions>();
+        options.DeviceName.Returns("ASG Electronic EAT - 90mm");
+        options.DeviceLinkedCalibrationDeviceName.Returns("ASG Electronic EAT - 90mm");
+        options.CalibrationIsReliable.Returns(false);
+        options.CalibrationIsManual.Returns(true);   // manual must NOT hijack the low-confidence branch
+
+        Assert.That(InspectorVM.AutomaticAdjustmentRemediationTextFor(options),
+            Is.EqualTo("This calibration is low-confidence (it did not pass quality validation). Re-run calibration to enable Automatic Adjustment."));
+    }
+```
+
+- [ ] **Step 2: Run the test and verify it fails**
+
+```bash
+dotnet.exe test "$(wslpath -w Joko.NINA.Plugins/Joko.NINA.Plugins.sln)" -c Debug --nologo \
+  --filter "FullyQualifiedName~RemediationText"
+```
+Expected: build FAILS — `AutomaticAdjustmentRemediationTextFor` does not exist.
+
+- [ ] **Step 3: Extract the pure helper and add the branch**
+
+In `PLUGIN/AutoFocus/InspectorVM.cs`, replace the property at line 2502-2505:
+
+```csharp
+        public string AutomaticAdjustmentRemediationText =>
+            !IsCalibrationDeviceLinked(tiltAdapterOptions)
+                ? "This calibration is not linked to the connected device. Re-run calibration with the device connected."
+                : "This calibration is low-confidence (it did not pass quality validation). Re-run calibration to enable Automatic Adjustment.";
+```
+
+with:
+
+```csharp
+        public string AutomaticAdjustmentRemediationText => AutomaticAdjustmentRemediationTextFor(tiltAdapterOptions);
+
+        /// <summary>
+        /// Pure form of <see cref="AutomaticAdjustmentRemediationText"/>, so the wording is unit-testable
+        /// without a live VM. Names MANUAL ENTRY explicitly when that is the cause: the previous copy said only
+        /// "not linked to the connected device", which is true but gave a user who had just corrected an angle
+        /// by hand no way to connect the message to what they did, and no remedy but a full re-run.
+        /// </summary>
+        internal static string AutomaticAdjustmentRemediationTextFor(ITiltAdapterOptions options) {
+            if (!IsCalibrationDeviceLinked(options)) {
+                return (options?.CalibrationIsManual ?? false)
+                    ? "This calibration was entered by hand, so Automatic Adjustment is disabled — HocusFocus can't " +
+                      "confirm your screw numbering matches the device's motor wiring. Re-run calibration with the " +
+                      "device connected, or trust it explicitly in the Tilt Adapter Wizard."
+                    : "This calibration is not linked to the connected device. Re-run calibration with the device connected.";
+            }
+            return "This calibration is low-confidence (it did not pass quality validation). Re-run calibration to enable Automatic Adjustment.";
+        }
+```
+
+- [ ] **Step 4: Run the test and verify it passes**
+
+```bash
+dotnet.exe test "$(wslpath -w Joko.NINA.Plugins/Joko.NINA.Plugins.sln)" -c Debug --nologo \
+  --filter "FullyQualifiedName~RemediationText"
+```
+Expected: PASS, 3 tests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/AutoFocus/InspectorVM.cs \
+        Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/
+GIT_COMMITTER_NAME="George Hilios" GIT_COMMITTER_EMAIL="322725+ghilios@users.noreply.github.com" \
+  git commit --author="George Hilios <322725+ghilios@users.noreply.github.com>" \
+  -m "Name manual entry as the cause when automation is blocked"
+```
+
+---
+
+## Task 12: Documentation, full suite, live verification
+
+**Files:**
+- Modify: `.claude/docs/tilt-domain.md`
+- Modify: `.claude/docs/wpf-xaml.md`
+
+- [ ] **Step 1: Record the alert-brush rule so it is not re-broken**
+
+Append to `.claude/docs/wpf-xaml.md`:
+
+```markdown
+## Alert colours — never use the NINA notification brushes as a Foreground
+
+`NotificationErrorBrush` / `NotificationWarningBrush` are **fill** colours. NINA only ever uses them as a
+`Background`, and 14 of its 16 built-in schemas set them to near-black (`#FF700000`, `#FF5E330B`). Used as a
+`Foreground` they render at 1.06–1.9:1 against a dark page background. Their paired
+`NotificationErrorTextBrush` is not a fix either — the "Dark" schema sets it to `#FF02010A`, i.e. near-black
+text on near-black-red fill, 1.67:1.
+
+Use `Resources/AlertBrushes.xaml` instead:
+
+| Need | Brush |
+|---|---|
+| Text inside a filled alert badge | `HF_AlertErrorTextBrush` / `HF_AlertWarningTextBrush` |
+| Alert text drawn on the page background | `HF_AlertErrorAccentBrush` / `HF_AlertWarningAccentBrush` |
+| The filled badge `Border` itself | `HF_AlertErrorBadge` / `HF_AlertWarningBadge` (both `BasedOn`-able) |
+
+Both text colours are computed by `Converters/ContrastMath.cs` and hold ≥ 4.5:1 on all 16 built-in schemas;
+`ContrastMathTests.EveryBuiltInNinaSchema_ClearsWcagAaForBadgeTextAndAccent` is the regression.
+
+Filled vs outlined follows the existing house rule (`AutoFocus/DataTemplates.xaml:120` and `:2967`): **filled**
+for a short alert that carries an action or announces a lost capability, **outlined with accent text** for
+advisory copy and for long banners that wrap paragraphs and buttons. When a `Border` does become filled, every
+`TextBlock` inside it needs the badge text brush — children with no explicit `Foreground` otherwise inherit
+`PrimaryBrush` onto the fill.
+```
+
+- [ ] **Step 2: Record the wording rule and the Trust path**
+
+Append to `.claude/docs/tilt-domain.md`:
+
+```markdown
+## Wording: "inward/outward" is adapter-plate motion only
+
+Screw and motor moves are worded CLOCKWISE / COUNTER-CLOCKWISE or as signed steps — never "inward/outward".
+The wizard's all-motors step is titled "All Screws Clockwise" / "All Motors + Steps", never "All Screws
+Inward": it applies `+N` to every motor and **measures** which way the plate travels (that is what sets
+`ScrewInwardCurvatureSign`). `WizardStep.AllInward` keeps its historical enum name because it is persisted in
+saved replay runs. `TiltAdapterWizardVMTests.NoUserFacingMoveWording_ClaimsInwardOrOutward` is the guard.
+
+## Trusting a hand-entered calibration for automation
+
+`ApplyManualCalibration` clears `DeviceLinkedCalibrationDeviceName` and `CalibrationIsReliable`, which blocks
+Automatic Adjustment — a hand-entered screw numbering is not guaranteed to match the device's motor wiring.
+The wizard now warns when that revokes something, and the saved-calibration pane offers **Trust This
+Calibration for Automation** (a two-step in-pane confirmation, `TrustCalibrationCommand` →
+`ConfirmTrustCalibrationCommand`) which re-arms both markers deliberately. There is no new persisted option:
+`CalibrationIsManual == true` together with a device link already means "manually trusted". The trust is
+revoked by a fresh manual entry, by `ClearCalibration`, and for free by a device-preset change.
+```
+
+- [ ] **Step 3: Run the full suite**
+
+```bash
+dotnet.exe test "$(wslpath -w Joko.NINA.Plugins/Joko.NINA.Plugins.sln)" -c Debug --nologo
+```
+Expected: `Passed!` with 0 failures. Do **not** pipe to `tail` — that masks the exit code. If `SendAsync_WritesOnABackgroundThread` is the only failure, re-run it alone to confirm it is the known flake; any other failure must be fixed, never skipped or marked expected-to-fail.
+
+- [ ] **Step 4: Live verification in NINA**
+
+Close NINA, rebuild (the PostBuild `xcopy` deploys the plugin), then launch NINA via `Start-Process` — not the MCP `launch_executable`.
+
+Switch the colour schema to **Dark** (Options → General → Colors), then confirm:
+
+1. Tilt Adapter Wizard → the alert badges are legible: white text on the red/amber fills, no near-black text.
+2. Options and the Aberration Inspector → the `⚠ differs from the focuser driver` markers and the guidance notices are legible red/amber on the dark background.
+3. Select an EAT preset → the wizard's all-motors step reads **"All Motors + Steps"**, and its tooltip explains that `+` is not assumed to be inward. Select a screw preset → **"All Screws Clockwise"**.
+4. Apply a Manual Calibration Entry over a device-linked calibration → a warning notification appears, and the "Automatic Adjustment is disabled" badge shows in the saved-calibration pane.
+5. Click **Trust This Calibration for Automation** → the risk copy and Yes/Cancel appear; Cancel changes nothing; Yes hides the badge and re-enables the Inspector's Automatic Adjustment button.
+6. Switch to the **Light** schema and confirm nothing regressed — accent colours should be unchanged from before this work, because `AccessibleAccent` returns light-theme colours untouched.
+
+- [ ] **Step 5: Commit and open the PR**
+
+```bash
+git add .claude/docs/tilt-domain.md .claude/docs/wpf-xaml.md
+GIT_COMMITTER_NAME="George Hilios" GIT_COMMITTER_EMAIL="322725+ghilios@users.noreply.github.com" \
+  git commit --author="George Hilios <322725+ghilios@users.noreply.github.com>" \
+  -m "Document the alert-brush, wording and calibration-trust rules"
+git push -u origin ghilios/tilt-calibration-ux-feedback
+gh pr create --base develop --title "Tilt calibration UX feedback: readable alerts, honest step wording, recoverable automation gate"
+```
+
+---
+
+## Notes for whoever executes this
+
+- **Do not weaken the automation gate.** Task 9 adds a way for the user to satisfy it deliberately. It does not change `CanExecuteAutomaticAdjustment`'s conditions.
+- **Do not touch calibration math.** Part 2 is wording; the `EatWizardMappingTests` full-sequence regressions are the proof and must pass unmodified.
+- **Do not lower `MinContrastRatio`** to make a test pass. If the sweep fails, the algorithm is wrong.
+- **Do not add a persisted option.** If you find yourself adding one, re-read the spec's Part 3 — it is deliberately avoided, and a new persisted option would also require a control in `Resources/OptionsDataTemplates.xaml` per the project invariants.

--- a/plans/tilt-calibration-ux-feedback-plan.md
+++ b/plans/tilt-calibration-ux-feedback-plan.md
@@ -1606,8 +1606,13 @@ In `ApplyManualCalibration()`, capture the prior state before the `[CRITICAL GAT
 ```csharp
             // Whether this entry actually TAKES automation away, so a first-ever manual entry (which never had
             // it) does not warn about losing something the user never had.
+            // AND, not OR: CanExecuteAutomaticAdjustment requires BOTH, so automation was only genuinely
+            // available — and therefore only genuinely revoked — when both held. With OR, a calibration that
+            // was reliable but never device-linked (a wizard run on the Manual preset, or a disconnected live
+            // run) warns about losing something it never had, and points at a Trust button the non-motorized
+            // banner never shows.
             bool revokedAutomation =
-                InspectorVM.IsCalibrationDeviceLinked(tiltAdapterOptions) || tiltAdapterOptions.CalibrationIsReliable;
+                InspectorVM.IsCalibrationDeviceLinked(tiltAdapterOptions) && tiltAdapterOptions.CalibrationIsReliable;
 ```
 
 and immediately after `tiltAdapterOptions.CalibrationIsReliable = false;`:

--- a/plans/tilt-calibration-ux-feedback-plan.md
+++ b/plans/tilt-calibration-ux-feedback-plan.md
@@ -1883,6 +1883,124 @@ GIT_COMMITTER_NAME="George Hilios" GIT_COMMITTER_EMAIL="322725+ghilios@users.nor
 
 ---
 
+## Task 11b: Button text that renders invisible on the Dark schema
+
+**Found during Task 6's review, not in the original spec.** Scoped in because it is the same defect class the whole
+plan exists to fix, and one instance sits *inside* the idle-countdown badge Task 6 just made readable.
+
+**Files:**
+- Modify: 16 sites across `PLUGIN/AutoFocus/DataTemplates.xaml`, `PLUGIN/AutoFocus/Replay/ReplaySettingsPromptControl.xaml`, `PLUGIN/CameraSimulator/TiltAdapter/TiltAdapterDataTemplates.xaml`, `PLUGIN/StarDetection/Optimization/DataTemplates.xaml`, `PLUGIN/TiltAdapterDevices/Prompt/TiltDeviceAdjustmentPromptControl.xaml`, `PLUGIN/TiltAdapterWizard/DataTemplates.xaml`
+
+### The defect
+
+A `TextBlock` used as `Button` content with **no explicit `Foreground` and no explicit `Style`** does not inherit the
+button's foreground. NINA.WPF.Base ships a **keyless** `TextBlock` style (`Resources/Styles/TextBlock.xaml`,
+`Foreground = PrimaryBrush`) in `Application.Resources`, and an implicit style beats an inherited value. So the text
+renders in `PrimaryBrush` on `ButtonBackgroundBrush`.
+
+On NINA's **Dark** and **Alternative Custom** schemas those two colours are the *same value* — `#FF550C18` — so the
+button label is **1.00:1: literally invisible**. `TiltAdapterWizard/DataTemplates.xaml` already documents this
+implicit-style hazard in its header comment; these 16 sites simply predate or missed it.
+
+The rest of the plugin already follows the correct convention, e.g. every button in the wizard sets
+`Foreground="{StaticResource ButtonForegroundBrush}"` on its content `TextBlock`.
+
+### What this task does and does not fix
+
+Adding `ButtonForegroundBrush` takes those two schemas from **1.00:1 to 1.44:1** and restores consistency with every
+other button in the plugin and in NINA. It does **not** make button text WCAG-legible, because NINA's own button
+palette is the limit: `ButtonForegroundColor` on `ButtonBackgroundColor` clears 4.5:1 on only **12 of 18** built-in
+schemas (Dark and Alternative Custom 1.44, Dark Nebula and Custom 4.01, High Contrast 4.00, Vivid Malachite 4.45).
+
+**Do not "fix" that by computing a contrast-safe button foreground.** Every button in this plugin would then look
+different from every other button in NINA, which is a product decision for the maintainer, not a bug fix. This task
+only removes the fully-invisible case.
+
+- [ ] **Step 1: Add the missing foreground at all 16 sites**
+
+Each is a one-attribute addition to a `TextBlock` that is the direct content of a `Button`:
+
+```xml
+<TextBlock Margin="6,2" Foreground="{StaticResource ButtonForegroundBrush}" Text="Stay connected" />
+```
+
+The 16 sites (line numbers are pre-edit; locate by button text, and note some files shift as you edit):
+
+| File | Line | Button text |
+|---|---|---|
+| `AutoFocus/DataTemplates.xaml` | 153 | Stay connected |
+| `AutoFocus/DataTemplates.xaml` | 724 | Review Frames |
+| `AutoFocus/DataTemplates.xaml` | 3367 | Automatic Adjustment |
+| `AutoFocus/Replay/ReplaySettingsPromptControl.xaml` | 135 | Cancel |
+| `CameraSimulator/TiltAdapter/TiltAdapterDataTemplates.xaml` | 211 | Copy from adapter settings |
+| `CameraSimulator/TiltAdapter/TiltAdapterDataTemplates.xaml` | 218 | Copy to adapter settings… |
+| `CameraSimulator/TiltAdapter/TiltAdapterDataTemplates.xaml` | 239 | Overwrite |
+| `CameraSimulator/TiltAdapter/TiltAdapterDataTemplates.xaml` | 245 | Cancel |
+| `CameraSimulator/TiltAdapter/TiltAdapterDataTemplates.xaml` | 306 | Enable |
+| `CameraSimulator/TiltAdapter/TiltAdapterDataTemplates.xaml` | 356 | Undo |
+| `CameraSimulator/TiltAdapter/TiltAdapterDataTemplates.xaml` | 491 | Re-zero |
+| `CameraSimulator/TiltAdapter/TiltAdapterDataTemplates.xaml` | 568 | Zero all aberrations |
+| `StarDetection/Optimization/DataTemplates.xaml` | 1002 | Capture a new sweep and optimize |
+| `StarDetection/Optimization/DataTemplates.xaml` | 1037 | (bound content) |
+| `TiltAdapterDevices/Prompt/TiltDeviceAdjustmentPromptControl.xaml` | 373 | Cancel |
+| `TiltAdapterWizard/DataTemplates.xaml` | 1660 | Clear Calibration |
+
+**Check `TiltDeviceAdjustmentPromptControl.xaml:373` before editing it.** That control deliberately carries its own
+self-contained, theme-independent palette (`Fg`, `FgDim`, `WarnFg`, `DangerFg`, fixed hex values) so it stays legible
+regardless of schema. If its buttons are styled from that local palette, use the local foreground key that matches its
+siblings rather than `ButtonForegroundBrush` — match the file, not this table.
+
+- [ ] **Step 2: Build**
+
+```bash
+dotnet.exe build "$(wslpath -w Joko.NINA.Plugins/Joko.NINA.Plugins.sln)" -c Debug --nologo
+```
+Expected: `Build succeeded`, 0 errors.
+
+- [ ] **Step 3: Verify no Button-content TextBlock is left without a foreground**
+
+```bash
+python3 - <<'SCAN'
+import re, glob
+root='Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus'
+def spans(src):
+    out=[]; depth=0; start=None
+    for m in re.finditer(r'<(/?)Button\b([^>]*?)(/?)>', src, re.S):
+        closing, _, selfclose = m.group(1), m.group(2), m.group(3)
+        if closing:
+            depth-=1
+            if depth==0 and start is not None: out.append((start,m.end())); start=None
+        elif selfclose: continue
+        else:
+            if depth==0: start=m.start()
+            depth+=1
+    return out
+bad=[]
+for f in sorted(glob.glob(root+'/**/*.xaml', recursive=True)):
+    if '/obj/' in f or '/bin/' in f: continue
+    src=open(f,encoding='utf-8-sig',errors='replace').read()
+    for s,e in spans(src):
+        for tb in re.finditer(r'<TextBlock\b[^>]*?/>|<TextBlock\b[^>]*?>.*?</TextBlock>', src[s:e], re.S):
+            t=tb.group(0)
+            if 'Foreground' in t or 'Style=' in t: continue
+            bad.append(f"{f}:{src[:s+tb.start()].count(chr(10))+1}")
+print("remaining:", len(bad))
+for b in bad: print("  ", b)
+SCAN
+```
+Expected: `remaining: 0`.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add -A
+GIT_COMMITTER_NAME="George Hilios" GIT_COMMITTER_EMAIL="322725+ghilios@users.noreply.github.com" \
+  git commit --author="George Hilios <322725+ghilios@users.noreply.github.com>" \
+  -m "Stop button labels rendering invisible on the Dark colour schema"
+```
+
+---
+
 ## Task 12: Documentation, full suite, live verification
 
 **Files:**

--- a/plans/tilt-calibration-ux-feedback-plan.md
+++ b/plans/tilt-calibration-ux-feedback-plan.md
@@ -16,7 +16,7 @@
 
 Key facts an engineer new to this codebase will otherwise get wrong:
 
-1. **NINA's `NotificationErrorBrush` / `NotificationWarningBrush` are FILL colors, not text colors.** In 14 of the 16 built-in schemas they are `#FF700000` and `#FF5E330B` — near-black. NINA only ever uses them as `Background`. This plugin used them as `Foreground`, which is the bug.
+1. **NINA's `NotificationErrorBrush` / `NotificationWarningBrush` are FILL colors, not text colors.** 13 of NINA's 18 built-in schemas use the near-black pair `#FF700000` / `#FF5E330B`, and 15 of the 18 render error text below 4.5:1 today. NINA only ever uses them as `Background`. This plugin used them as `Foreground`, which is the bug.
 2. **`NotificationErrorTextBrush` is not a safe fix either.** On the "Dark" schema it is `#FF02010A` — near-black text on near-black-red fill, 1.67:1. That is why this plan computes the badge text color instead of reading it.
 3. **`WizardStep.AllInward` keeps its enum name.** It is persisted in saved replay runs. Only user-facing strings change.
 4. **The wizard's motion is correct.** Do not "fix" any sign, axis, or move. Part 2 is wording only.
@@ -211,7 +211,7 @@ namespace NINA.Joko.Plugins.HocusFocus.Converters {
     /// WCAG 2.x contrast math, and the two color decisions the alert brushes are built from.
     ///
     /// WHY THIS EXISTS: NINA's ColorSchema exposes NotificationErrorColor / NotificationWarningColor as FILL
-    /// colors (it only ever uses them as a Background), and 14 of its 16 built-in schemas set them to near-black
+    /// colors (it only ever uses them as a Background), and 13 of its 18 built-in schemas set them to near-black
     /// #FF700000 / #FF5E330B. Used as a Foreground — which this plugin did in 27 places — they land at 1.06:1
     /// against a dark page background. Its paired NotificationErrorTextColor is not a way out either: the "Dark"
     /// schema sets it to #FF02010A, i.e. near-black text on near-black-red fill, 1.67:1. So both alert text
@@ -406,7 +406,7 @@ public class AlertColorConverterTests {
 
     // WPF pushes DependencyProperty.UnsetValue on the first pass of a resource-level binding. Returning
     // Binding.DoNothing would leave SolidColorBrush.Color at Transparent, i.e. invisible text; white is the
-    // right answer for 15 of the 16 built-in schemas anyway.
+    // answer on all 18 built-in schemas anyway.
     [Test]
     public void BadgeText_OnNonColourInput_FallsBackToWhite() {
         var converter = new BadgeTextColorConverter();
@@ -484,7 +484,7 @@ namespace NINA.Joko.Plugins.HocusFocus.Converters {
         public object Convert(object value, Type targetType, object parameter, CultureInfo culture) {
             // The first pass of a resource-level binding arrives as DependencyProperty.UnsetValue. White rather
             // than Binding.DoNothing: DoNothing would leave SolidColorBrush.Color at Transparent (invisible
-            // text), and white is correct on 15 of the 16 built-in schemas.
+            // text), and white is the computed answer on all 18 built-in schemas.
             return value is Color fill ? ContrastMath.BestContrastText(fill) : Colors.White;
         }
 
@@ -585,10 +585,10 @@ Create `PLUGIN/Resources/AlertBrushes.xaml`:
 
     <!--
         Accessible alert chrome. NINA's NotificationError/WarningBrush are FILL colours (it only ever uses them
-        as a Background) and are near-black in 14 of its 16 built-in schemas, so using them as a Foreground
+        as a Background) and are near-black in 13 of its 18 built-in schemas, so using them as a Foreground
         renders at 1.06-1.9:1 on every dark theme. Its paired NotificationErrorTextBrush is no better — the
         "Dark" schema sets it to #FF02010A, near-black on near-black-red, 1.67:1. Both text colours are
-        therefore COMPUTED (see Converters/ContrastMath.cs), which holds >= 4.5:1 on all 16 built-in schemas and
+        therefore COMPUTED (see Converters/ContrastMath.cs), which holds >= 4.5:1 on all 18 built-in schemas and
         on custom ones.
 
         The Color properties are BOUND rather than fixed so a live colour-schema change flows through, the same
@@ -1853,7 +1853,7 @@ Append to `.claude/docs/wpf-xaml.md`:
 ## Alert colours — never use the NINA notification brushes as a Foreground
 
 `NotificationErrorBrush` / `NotificationWarningBrush` are **fill** colours. NINA only ever uses them as a
-`Background`, and 14 of its 16 built-in schemas set them to near-black (`#FF700000`, `#FF5E330B`). Used as a
+`Background`, and 13 of its 18 built-in schemas set them to near-black (`#FF700000`, `#FF5E330B`). Used as a
 `Foreground` they render at 1.06–1.9:1 against a dark page background. Their paired
 `NotificationErrorTextBrush` is not a fix either — the "Dark" schema sets it to `#FF02010A`, i.e. near-black
 text on near-black-red fill, 1.67:1.
@@ -1866,7 +1866,7 @@ Use `Resources/AlertBrushes.xaml` instead:
 | Alert text drawn on the page background | `HF_AlertErrorAccentBrush` / `HF_AlertWarningAccentBrush` |
 | The filled badge `Border` itself | `HF_AlertErrorBadge` / `HF_AlertWarningBadge` (both `BasedOn`-able) |
 
-Both text colours are computed by `Converters/ContrastMath.cs` and hold ≥ 4.5:1 on all 16 built-in schemas;
+Both text colours are computed by `Converters/ContrastMath.cs` and hold ≥ 4.5:1 on all 18 built-in schemas;
 `ContrastMathTests.EveryBuiltInNinaSchema_ClearsWcagAaForBadgeTextAndAccent` is the regression.
 
 Filled vs outlined follows the existing house rule (`AutoFocus/DataTemplates.xaml:120` and `:2967`): **filled**


### PR DESCRIPTION
Addresses three user-reported problems with the Tilt Adapter Calibration wizard.

## 1. Alert text unreadable on dark themes

**Reported:** *"Red alert text displayed during tilt adapter calibration is very difficult to see against dark themes."*

NINA's `NotificationErrorBrush` / `NotificationWarningBrush` are **fill** colours — NINA itself only ever uses them as a `Background` — and 13 of its 18 built-in schemas set them to near-black (`#FF700000`, `#FF5E330B`). This plugin used them as a `Foreground` in 27 places, which renders as low as **1.06:1**.

NINA's paired `*TextBrush` colours are not a way out either: the "Dark" schema pairs near-black text with the near-black fill, giving **1.67:1 _inside_ a correctly-filled badge**. So both alert text colours are now computed rather than read:

- `Converters/ContrastMath.cs` — WCAG 2.x contrast, plus a hue- and saturation-preserving HSL-lightness search for on-page accent text. Pure and WPF-free, so it is directly testable.
- `Resources/AlertBrushes.xaml` — four derived brushes (badge text vs page accent) and two badge `Border` styles, bound so they follow a live colour-schema change.
- All 27 foreground sites re-pointed, plus 5 badge texts that were unreadable *inside* correctly-filled badges.

`ContrastMathTests.EveryBuiltInNinaSchema_ClearsWcagAaForBadgeTextAndAccent` sweeps every real schema in both roles and asserts ≥ 4.5:1. Worst case is now 4.60:1; light-background schemas are left byte-identical.

## 2. "Moving inwards" while the motors move `+N`

**Reported:** *"The wizard says it is moving screws/steppers inwards, but seems to move EAT stepper motors in the positive direction, which would be outwards."*

**There was no motion defect.** `MoveForStep` returns `Backfocus(+N)` — `+N` on all four motors — which matches the instruction text the user reads, and whether `+N` is physically inward is precisely what that step *measures* (it sets `ScrewInwardCurvatureSign`). Only the label was wrong, and it contradicted the plugin's own rule, stated in `TiltAdapterWizardVM`: screw motion is worded clockwise/counter-clockwise, *never* inward/outward, which is reserved for adapter-plate motion.

- `"All Screws Inward"` → `"All Screws Clockwise"` / `"All Motors Positive Steps"`.
- `"Wizard All Inward: +150 backfocus"` → `"Wizard All Motors: …"`.
- A tooltip, scoped to that step, explaining that `+` is not assumed to be inward.
- `WizardStep.AllInward` keeps its enum name — it is persisted in saved replay runs.

`NoUserFacingMoveWording_ClaimsInwardOrOutward` sweeps every step × adjustment type × screw count and every move description, so no user-facing move wording can claim an unmeasured direction again. The existing full-sequence regressions are untouched, which is what proves this was wording-only.

## 3. A hand-edited calibration silently disabling Automatic Adjustment

**Reported:** *"I tried to just force the rotation of that angle to the one I know is true… something I did caused it to say 'can't do automation' because my calibration didn't fit this setup."*

`ApplyManualCalibration` clears `DeviceLinkedCalibrationDeviceName` and `CalibrationIsReliable`, both required by `CanExecuteAutomaticAdjustment`. **That safety behaviour is correct and is unchanged** — a hand-entered screw numbering may not match the device's motor wiring, and a rotated correction applied unattended makes tilt worse. What was wrong is everything around it: nothing said it had happened, the only explanation lived in the Inspector and only while connected, and the only remedy was repeating an entire calibration.

- A warning at the moment a manual entry actually revokes automation — pinned by a test asserting the predicate agrees with the automation gate in all four marker combinations.
- A wizard banner naming the cause, with a two-step in-pane confirmation (`Trust` → risk copy → `Confirm`/`Cancel`) that re-arms both markers deliberately. The risk copy names a concrete check to run first.
- The Inspector's remediation line now names manual entry and points at that button.
- **No new persisted option** — `CalibrationIsManual` plus a device link already means "manually trusted".

Trust is offered **only** for a hand-entered calibration. A device-driven low-confidence run deliberately gets no Trust button: overriding a noise-dominated calibration is a categorically worse decision, and the prescribed wiring check cannot validate it.

Latent bugs fixed along the way: `ClearCalibration` never cleared the markers; a pending confirmation could outlive a manual re-entry, a preset change, a profile switch or a fresh run; and the camera simulator's copy-to-adapter path revoked automation silently.

## 4. Button labels invisible on the Dark schema (found in review)

A `TextBlock` used as `Button` content with no explicit `Foreground` does not inherit the button's — NINA ships a keyless implicit `TextBlock` style (`Foreground = PrimaryBrush`), and an implicit style beats an inherited value. On the Dark and Alternative Custom schemas `PrimaryColor == ButtonBackgroundColor == #FF550C18`, so the label is **1.00:1**. 16 sites fixed to the plugin's existing convention.

This restores consistency, **not** legibility: NINA's own button palette clears 4.5:1 on only 12 of 18 schemas. Fixing that properly means overriding NINA button styling plugin-wide — a product decision, deliberately not taken here. `.claude/docs/wpf-xaml.md` records the residual limit, and names 13 further `Content="…"` buttons in the Star Detection Optimizer that have the same defect through a `ContentPresenter` and are **not** fixed here.

## Test plan

- [x] Full suite green: **4402 passed, 0 failed**
- [x] `ContrastMathTests` — WCAG reference values, hue/alpha preservation, and the 18-schema sweep in both roles
- [x] `XamlResourceResolutionTests` 9/9 — guards the new `HF_Alert*` keys against the failure class that once silently broke the camera setup dialog
- [x] `NoUserFacingMoveWording_ClaimsInwardOrOutward` — verified load-bearing by reintroducing the bug
- [x] Trust-flow state machine — disarm on manual re-entry, preset change, profile switch and fresh run, each with a test verified to fail without its fix
- [ ] **Not yet verified in the running app.** This is a largely visual change across six XAML files; rendering (badge wrap, banner fit in Panel A) is not unit-testable. Worth one launch on the **Dark** schema before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QTNWdSNar6g3Nj5wXnLZc6