### PR TITLE
Fix tilt calibration under Auto Focus Binning; make the optimizer wizard's button labels visible

### DIFF
--- a/.claude/docs/tilt-domain.md
+++ b/.claude/docs/tilt-domain.md
@@ -98,3 +98,46 @@ Calibration for Automation** (a two-step in-pane confirmation, `TrustCalibration
 `ConfirmTrustCalibrationCommand`) which re-arms both markers deliberately. There is no new persisted option:
 `CalibrationIsManual == true` together with a device link already means "manually trusted". The trust is
 revoked by a fresh manual entry, by `ClearCalibration`, and for free by a device-preset change.
+
+## Auto Focus Binning: pair a binned frame with a binned pixel pitch
+
+The wizard's readings are `TiltPlaneModel.A`/`B` — focuser steps per **normalized** image coordinate. Turning
+those into a physical gradient (µm of focuser travel per µm of sensor displacement) needs the sensor's physical
+extent, `ImageSize.Width × pixelSizeMicrons`, and that product is only right when both factors describe the
+**same frame**.
+
+Under NINA's Auto Focus Binning of N (`FocuserSettings.AutoFocusBinning`, or a filter's `AutoFocusBinning`) the
+captured frame is N× smaller in each axis and each of its pixels is N× coarser. Star detection already accounts
+for this — `HocusFocusStarDetection.BuildResultHeader` sets `PixelSize = metadataPixelSize × BinX`, and the
+sensor model converts star positions with it — so the paraboloid's `Gx/Gy/Kx/Ky` and everything the Aberration
+Inspector computes from them (including the per-screw correction targets) are physically correct at any binning.
+
+The trap is the round trip back out of `(A, B)`. The wizard used to pair the model's **binned** `ImageSize` with
+the profile's **native** `CameraSettings.PixelSize`, understating the sensor by N. Consequences, measured by
+`TiltAdapterWizardVMTests.RunCalibrationForTest_AutoFocusBinning_*`:
+
+- **Recovered thread pitch / stepper step size inflated by exactly N** (2× at 2×2, 4× at 4×4). This is the
+  number `LastMeasuredThreadPitchMicrons` stores and every automated correction later divides a required µm
+  move by, so adopting it made every correction N× too small.
+- **The tilt-vs-piston agreement check fires on a perfect calibration.** `PistonImpliedMicronsPerStep` uses no
+  sensor geometry at all (mean focuser positions only), so it stayed honest while the tilt-derived pitch
+  doubled — a 50% disagreement at 2×2, well past the 20% warning threshold.
+- **Screw position angles were unaffected** on symmetric binning: `gx` and `gy` inflate by the same factor and
+  `atan2` is scale-invariant. That is why the diagram looked right while the pitch was silently wrong. It would
+  *not* survive asymmetric binning (`BinX ≠ BinY`) — but neither would the sensor model itself, which reads
+  `BinX` alone.
+
+The fix is structural: `TiltPlaneModel` carries the `PixelSizeMicrons` it was built from, and the wizard's
+`EffectivePixelSizeMicrons` prefers it over the profile value, so the pairing cannot be got wrong. Replays are
+covered for old and new saved runs alike, because the pitch is re-derived from the frames rather than read from
+`metadata.PixelSizeMicrons`.
+
+**Detection binning is a different setting and was never affected.** `StarDetectorParams.DetectionBinning` is
+software binning applied inside the detector; it scales every pixel-space output back to source pixels before
+returning (`stars.Select(s => s.ScaleToSourcePixels(binning))`, `metrics.ScaleBounds`), and the result header's
+`PixelSize`/`ImageSize` are built from the camera metadata and the source frame, never from it. `DetectionBinning`
+touches only `PixelScale`, which the tilt path does not read. `DetectionBinningTests` pins the scale-back.
+
+`TiltCalibrationMetadata.PixelSizeMicrons` is the **effective** (binning-scaled) pitch from schema 4 onward.
+Files written by schema ≤ 3 at a binning above 1×1 hold the native pitch; the headless `TestApp tilt` validator
+reads the field as-is and so reproduces the old inflation on those runs — replay them through the wizard instead.

--- a/.claude/docs/wpf-xaml.md
+++ b/.claude/docs/wpf-xaml.md
@@ -153,19 +153,32 @@ instead of `ButtonForegroundBrush`.
 
 **A second form of the same trap: `Button Content="…"` (no `TextBlock` in the markup at all).** WPF's
 `ContentPresenter` generates a `TextBlock` at runtime for string content, and that generated `TextBlock` hits
-the identical keyless-implicit-style rule — so it also paints `PrimaryBrush` on `ButtonBackgroundBrush`. Only
-the explicit-`TextBlock`-child form above is fixed plugin-wide today; the `Content="…"` form is not. The fix
-differs: an explicit `Foreground` on the `Button` itself, or the `ContentPresenter.Resources` empty-`Style`
-pattern already solved and commented in `StarDetection/Optimization/Review/StarReviewControl.xaml`
-(`HF_ReviewToolbarButton`, ~line 171) and reused in `AutoFocus/Review/AutoFocusFrameReviewControl.xaml` and
-`StarDetection/Optimization/Review/FrameReviewControl.xaml` — use that as the worked example. **13 known,
-unfixed `Content="…"` sites remain**, all in `StarDetection/Optimization/DataTemplates.xaml`: two `Browse…`
-(~437, ~612), `Optimize with feedback` (~1135), and the optimizer wizard's whole navigation footer
-(~1257–1331: Cancel, Start, Back, Review frames, Continue optimizing, Use run's settings, Accept, Back to
-summary, Optimize with feedback, Close). These predate this branch and are deliberately out of its scope — not
-fixed here, left for the maintainer to decide. Neither the button-content `TextBlock` scan nor
-`XamlResourceResolutionTests` catches this form — both check that resource keys resolve, not foreground-vs-
-background contrast — so there is no automated net against it; it needs a deliberate audit.
+the identical keyless-implicit-style rule — so it also paints `PrimaryBrush` on `ButtonBackgroundBrush`. The
+fix differs, and an explicit `Foreground` on the `Button` is **not** one: a style setter outranks an inherited
+value, so the generated label ignores it. It takes a `Style` whose template puts an empty
+`<Style TargetType="TextBlock" />` in `ContentPresenter.Resources` — that dictionary is nearest, so it wins the
+implicit-style lookup, and carrying no `Foreground` of its own it lets the inherited value through again. Two
+such styles exist; use one, or fall back to an explicit `<TextBlock Foreground="…">` child:
+
+| Style | Where | Use for |
+|---|---|---|
+| `HF_TextButton` | `StarDetection/Optimization/DataTemplates.xaml` | Ordinary themed buttons. Byte-for-byte NINA's `StandardButton` look (same theme brushes, borders, hover/pressed/disabled), with `Foreground` pinned to `ButtonForegroundBrush` in **every** visual state — NINA's own triggers re-point `Foreground` at the (selected) background brush on hover/press, which would re-hide the label. |
+| `HF_ReviewToolbarButton` | `.../Review/StarReviewControl.xaml`, `FrameReviewControl.xaml`, `AutoFocus/Review/AutoFocusFrameReviewControl.xaml` (one copy each) | The review panels' fixed dark chrome. Self-contained fixed light palette, deliberately theme-independent. |
+
+The 13 previously-unfixed `Content="…"` sites in `StarDetection/Optimization/DataTemplates.xaml` (two `Browse…`,
+`Optimize with feedback`, and the optimizer wizard's whole navigation footer) all carry `HF_TextButton` now; the
+footer's `Close`, which needs its own visibility triggers, gets it through `BasedOn` on its inline
+`<Button.Style>`.
+
+`Resources/ButtonContentForegroundGuardTests.cs` is the automated net — the one thing that was missing when this
+trap kept recurring. It walks every plugin `.xaml` and enforces both forms: a string `Content` must name a
+style from a small allowlist, and a `TextBlock` used as button content must name its own `Foreground` (or
+`Style`). Both rules are contrast rules, not resolution rules, which is exactly why
+`XamlResourceResolutionTests` could never see them — every key involved resolves fine.
+
+Residual limitation, left as-is deliberately: this only restores the plugin's own pre-existing convention — it
+takes the Dark and Alternative Custom schemas from 1.00:1 to 1.44:1, still short of WCAG AA (see the note under
+the explicit-`TextBlock` form above).
 
 **Related trap: a local value outranks a style *trigger*, not just a style setter.** WPF dependency-property
 precedence puts a local value (rank 3) above both a style setter (rank 8) and a style trigger (rank 6). So an

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/Resources/ButtonContentForegroundGuardTests.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/Resources/ButtonContentForegroundGuardTests.cs
@@ -1,0 +1,151 @@
+﻿using NUnit.Framework;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text.RegularExpressions;
+using System.Xml.Linq;
+
+namespace NINA.Joko.Plugins.HocusFocus.Tests.Resources {
+
+    /// <summary>
+    /// A <c>Button</c>'s label must bring its own foreground, or it renders invisible on some NINA themes.
+    ///
+    /// <para>NINA.WPF.Base ships a KEYLESS <c>TextBlock</c> style (Resources/Styles/TextBlock.xaml, BasedOn
+    /// StandardTextBlock ⇒ <c>Foreground = PrimaryBrush</c>) in <c>Application.Resources</c>, and an implicit
+    /// style setter outranks an inherited value. Its <c>StandardButton</c> style then sets
+    /// <c>Foreground = ButtonBackgroundBrush</c> on purpose — NINA's own buttons carry <c>Path</c> icons that
+    /// supply <c>ButtonForegroundBrush</c> themselves. So any label that does not name a foreground paints
+    /// <c>PrimaryBrush</c> on <c>ButtonBackgroundBrush</c>, and on the "Dark" and "Alternative Custom" schemas
+    /// those two are the SAME colour (#FF550C18): the label renders at 1.00:1, literally invisible.</para>
+    ///
+    /// <para>It bites in two forms, and this fixture guards both:</para>
+    /// <list type="number">
+    ///   <item>an explicit <c>TextBlock</c> child, which needs its own <c>Foreground</c>;</item>
+    ///   <item><c>Button Content="…"</c> with no TextBlock in the markup at all — <c>ContentPresenter</c>
+    ///   generates one at runtime and it hits the identical rule. Setting <c>Foreground</c> on the Button does
+    ///   NOT fix that form (a style setter still outranks the inherited value); it takes a Style whose template
+    ///   puts an empty <c>&lt;Style TargetType="TextBlock" /&gt;</c> in <c>ContentPresenter.Resources</c>, which
+    ///   wins the implicit-style lookup and, carrying no Foreground of its own, lets the inherited value through
+    ///   again.</item>
+    /// </list>
+    ///
+    /// <para>Neither the compiler nor <c>XamlResourceResolutionTests</c> can see this: every resource key
+    /// involved resolves perfectly. It is a foreground-vs-background contrast bug, so only a rule about the
+    /// markup itself catches it — which is what this fixture is. See <c>.claude/docs/wpf-xaml.md</c>.</para>
+    /// </summary>
+    [TestFixture]
+    public class ButtonContentForegroundGuardTests {
+
+        private static readonly XNamespace Wpf = "http://schemas.microsoft.com/winfx/2006/xaml/presentation";
+
+        /// <summary>
+        /// Styles whose template is known to give a string <c>Content</c> a readable foreground, each via the
+        /// <c>ContentPresenter.Resources</c> empty-Style pattern described above. Adding a key here is a claim
+        /// about that style's template — check it before you add one.
+        /// </summary>
+        private static readonly HashSet<string> ContentSafeButtonStyles = new HashSet<string>(StringComparer.Ordinal) {
+            // Theme-following: NINA's StandardButton look with Foreground pinned to ButtonForegroundBrush in
+            // every visual state (StarDetection/Optimization/DataTemplates.xaml).
+            "HF_TextButton",
+            // Self-contained fixed light toolbar button on the review panels' fixed dark chrome
+            // (StarReviewControl / FrameReviewControl / AutoFocusFrameReviewControl, one copy each).
+            "HF_ReviewToolbarButton",
+        };
+
+        // A Content attribute that starts with '{' is a markup extension (a Binding, a StaticResource, a
+        // template) — not a string, so no TextBlock is generated from it and the trap does not apply.
+        private static bool IsLiteralString(string content) =>
+            content != null && !content.TrimStart().StartsWith("{", StringComparison.Ordinal);
+
+        private static readonly Regex StaticResourceKey =
+            new Regex(@"\{StaticResource\s+(?:ResourceKey=)?(?<key>[A-Za-z0-9_.]+)\s*\}", RegexOptions.Compiled);
+
+        private static IEnumerable<FileInfo> PluginXamlFiles() {
+            var dir = new DirectoryInfo(TestContext.CurrentContext.TestDirectory);
+            while (dir != null && !Directory.Exists(Path.Combine(dir.FullName, "Joko.NINA.Plugins.HocusFocus"))) {
+                dir = dir.Parent;
+            }
+            Assert.That(dir, Is.Not.Null, "Could not locate the plugin project directory from the test output path");
+            return new DirectoryInfo(Path.Combine(dir.FullName, "Joko.NINA.Plugins.HocusFocus"))
+                .EnumerateFiles("*.xaml", SearchOption.AllDirectories)
+                .Where(f => !f.FullName.Contains($"{Path.DirectorySeparatorChar}obj{Path.DirectorySeparatorChar}")
+                         && !f.FullName.Contains($"{Path.DirectorySeparatorChar}bin{Path.DirectorySeparatorChar}"));
+        }
+
+        /// <summary>The style keys a Button element names: the Style attribute, plus the BasedOn of an inline
+        /// &lt;Button.Style&gt; (the form the optimizer wizard's Close button uses to add visibility triggers).</summary>
+        private static IEnumerable<string> StyleKeysOf(XElement button) {
+            var attribute = (string)button.Attribute("Style");
+            if (attribute != null) {
+                foreach (Match m in StaticResourceKey.Matches(attribute)) yield return m.Groups["key"].Value;
+            }
+            foreach (var inline in button.Elements(Wpf + "Button.Style").Elements(Wpf + "Style")) {
+                var basedOn = (string)inline.Attribute("BasedOn");
+                if (basedOn == null) continue;
+                foreach (Match m in StaticResourceKey.Matches(basedOn)) yield return m.Groups["key"].Value;
+            }
+        }
+
+        [Test]
+        public void EveryStringContentButton_UsesAStyleThatGivesItsLabelAForeground() {
+            var offenders = new List<string>();
+            var buttonsChecked = 0;
+
+            foreach (var file in PluginXamlFiles()) {
+                var doc = XDocument.Load(file.FullName, LoadOptions.SetLineInfo);
+                foreach (var button in doc.Descendants(Wpf + "Button")) {
+                    var content = (string)button.Attribute("Content");
+                    if (!IsLiteralString(content)) continue;
+                    buttonsChecked++;
+                    if (StyleKeysOf(button).Any(ContentSafeButtonStyles.Contains)) continue;
+                    var line = ((System.Xml.IXmlLineInfo)button).LineNumber;
+                    offenders.Add($"{file.Name}:{line}  Content=\"{content}\"");
+                }
+            }
+
+            Assert.That(buttonsChecked, Is.GreaterThan(0),
+                "Found no string-Content buttons at all — the scan is broken, not the XAML.");
+            Assert.That(offenders, Is.Empty,
+                "A Button with a string Content renders its label through a ContentPresenter-generated TextBlock, "
+                + "which picks up NINA's keyless TextBlock style (Foreground = PrimaryBrush) over the button's own "
+                + "foreground — invisible on the Dark and Alternative Custom schemas, where PrimaryBrush and "
+                + "ButtonBackgroundBrush are the same colour. Give it one of "
+                + string.Join(" / ", ContentSafeButtonStyles) + ", or use an explicit <TextBlock Foreground=\"...\"> "
+                + "child instead of Content. Offenders:" + Environment.NewLine
+                + string.Join(Environment.NewLine, offenders));
+        }
+
+        [Test]
+        public void EveryTextBlockUsedAsButtonContent_NamesItsOwnForeground() {
+            var offenders = new List<string>();
+            var labelsChecked = 0;
+
+            foreach (var file in PluginXamlFiles()) {
+                var doc = XDocument.Load(file.FullName, LoadOptions.SetLineInfo);
+                foreach (var button in doc.Descendants(Wpf + "Button")) {
+                    // Both spellings of "this TextBlock is the button's content": a direct child, and the
+                    // explicit <Button.Content> property element.
+                    var labels = button.Elements(Wpf + "TextBlock")
+                        .Concat(button.Elements(Wpf + "Button.Content").Elements(Wpf + "TextBlock"));
+                    foreach (var label in labels) {
+                        labelsChecked++;
+                        if (label.Attribute("Foreground") != null || label.Attribute("Style") != null) continue;
+                        var line = ((System.Xml.IXmlLineInfo)label).LineNumber;
+                        offenders.Add($"{file.Name}:{line}  Text=\"{(string)label.Attribute("Text")}\"");
+                    }
+                }
+            }
+
+            Assert.That(labelsChecked, Is.GreaterThan(0),
+                "Found no button-content TextBlocks at all — the scan is broken, not the XAML.");
+            Assert.That(offenders, Is.Empty,
+                "A TextBlock used as a Button's content does NOT inherit the button's foreground: NINA's keyless "
+                + "TextBlock style (Foreground = PrimaryBrush) outranks the inherited value, and on the Dark and "
+                + "Alternative Custom schemas PrimaryBrush equals ButtonBackgroundBrush. Set "
+                + "Foreground=\"{StaticResource ButtonForegroundBrush}\" (or the control's own local foreground key, "
+                + "as TiltDeviceAdjustmentPromptControl.xaml does). Offenders:" + Environment.NewLine
+                + string.Join(Environment.NewLine, offenders));
+        }
+    }
+}

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/TiltAdapterWizard/TiltAdapterWizardVMTests.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/TiltAdapterWizard/TiltAdapterWizardVMTests.cs
@@ -3136,6 +3136,155 @@ namespace NINA.Joko.Plugins.HocusFocus.Tests.TiltAdapterWizard {
             });
         }
 
+        // --- Auto Focus Binning (NINA's CAPTURE binning, not the star detector's software DetectionBinning) --
+
+        // The sensor as it physically is, and the one screw move the two runs below both measure.
+        //
+        // (A, B) are focuser steps per NORMALIZED image coordinate, so they are IDENTICAL whatever binning the
+        // frames were captured at -- normalized coordinates do not shrink with the frame. The only things that
+        // change between a 1x1 and a 2x2 run are the frame's pixel dimensions (halved) and the pitch of one of
+        // its pixels (doubled), and those two changes cancel: the sensor is the same piece of silicon. So the
+        // recovered thread pitch MUST come out the same, and the physical constants below are shared by both.
+        private const int SensorWidthPixels = 6248;
+        private const int SensorHeightPixels = 4176;
+        private const double NativePixelSizeMicrons = 3.76;      // the profile's CameraSettings.PixelSize
+        private const double BinningFocuserStepMicrons = 3.6;
+        private const double BinningScrewRadiusMm = 44.0;
+
+        // Screw 1's move, chosen along +x only (physical direction 90 deg); screw 2 gets the same magnitude at
+        // 210 deg -- a 3-screw adapter's ideal 120 deg gap, so no screw-angle-gap warning muddies the result.
+        private const double Screw1A = 50.0;
+
+        private static double BinningSensorWidthMicrons => SensorWidthPixels * NativePixelSizeMicrons;
+        private static double BinningSensorHeightMicrons => SensorHeightPixels * NativePixelSizeMicrons;
+
+        // |ΔG| for screw 1's move, in physical gradient units (µm of focuser travel per µm of sensor).
+        private static double BinningScrewMoveGradient => Screw1A * BinningFocuserStepMicrons / BinningSensorWidthMicrons;
+
+        // Runs one full 6-step calibration whose frames were captured at `binning`, and returns the pitch the
+        // wizard recovered. Everything except the FRAME (its dimensions and its pixel pitch) is held fixed --
+        // including the profile pixel size handed to RunCalibrationMath, which is always the camera's native
+        // value because that is what production reads from the profile.
+        private static (double recoveredPitch, bool hasWarning, string warningText) RunBinnedCalibration(int binning) {
+            var (vm, options, _, _) = Build(screwCount: 3);
+
+            double capturedPitch = double.NaN;
+            options.When(o => o.LastMeasuredThreadPitchMicrons = Arg.Any<double>())
+                   .Do(ci => capturedPitch = ci.Arg<double>());
+
+            // The frame as captured: binning shrinks the pixel grid and coarsens each pixel by the same factor.
+            var tiltPlane = new TiltPlaneModel(
+                new System.Drawing.Size(SensorWidthPixels / binning, SensorHeightPixels / binning), fRatio: 7,
+                a: 0, b: 0, c: 0, mean: 10000, focuserStepSizeMicrons: BinningFocuserStepMicrons,
+                centerPosition: 10000, topLeftPosition: 10000, topRightPosition: 10000,
+                bottomLeftPosition: 10000, bottomRightPosition: 10000,
+                pixelSizeMicrons: NativePixelSizeMicrons * binning);
+
+            double g = BinningScrewMoveGradient;
+            double screw2A = -0.5 * g * BinningSensorWidthMicrons / BinningFocuserStepMicrons;
+            double screw2B = (Math.Sqrt(3.0) / 2.0) * g * BinningSensorHeightMicrons / BinningFocuserStepMicrons;
+
+            // The all-inward step is a PURE PISTON: no tilt change, and a mean-focus shift sized so the
+            // geometry-free piston-implied pitch lands exactly on the true pitch. That makes the wizard's
+            // tilt-vs-piston agreement check a direct read-out of whether the tilt side got the geometry right.
+            double truePitchMicrons = 1.5 * BinningScrewRadiusMm * 1000.0 * g / vm.CalibrationAppliedAmount;
+            double pistonShiftSteps = truePitchMicrons * vm.CalibrationAppliedAmount / BinningFocuserStepMicrons;
+
+            vm.SeedStepReading(WizardStep.Baseline, 0.0, 0.0, 10000.0);
+            vm.SeedStepReading(WizardStep.AllInward, 0.0, 0.0, 10000.0 + pistonShiftSteps);
+            vm.SeedStepReading(WizardStep.ReBaseline1, 0.0, 0.0, 10000.0);
+            vm.SeedStepReading(WizardStep.Screw1, Screw1A, 0.0, 10000.0);
+            vm.SeedStepReading(WizardStep.ReBaseline2, 0.0, 0.0, 10000.0);
+            vm.SeedStepReading(WizardStep.Screw2, screw2A, screw2B, 10000.0);
+
+            vm.RunCalibrationForTest(radiusMm: BinningScrewRadiusMm, pixelSizeMicrons: NativePixelSizeMicrons,
+                focuserStepMicrons: BinningFocuserStepMicrons, tiltPlaneOverride: tiltPlane);
+
+            return (capturedPitch, vm.HasWarning, vm.WarningText);
+        }
+
+        // REGRESSION (Auto Focus Binning): the wizard used to pair the tilt plane's BINNED ImageSize with the
+        // profile's NATIVE CameraSettings.PixelSize, so the sensor's physical width/height came out N times too
+        // small and every physical gradient -- and with it the recovered thread pitch / stepper step size --
+        // was inflated by exactly the binning factor. A 2x2 run reported double the true pitch, which then
+        // became the µm-per-turn every automated correction divides by.
+        [Test]
+        public void RunCalibrationForTest_AutoFocusBinning_RecoversTheSamePitchAtEveryBinning() {
+            var bin1 = RunBinnedCalibration(1);
+            var bin2 = RunBinnedCalibration(2);
+            var bin4 = RunBinnedCalibration(4);
+
+            // The closed-form truth, independent of the wizard: a single screw on a 3-screw adapter moves with
+            // a 1.5*R lever arm, so its axial move is 1.5*R*|ΔG| and the pitch is that over the applied turns.
+            double expected = 1.5 * BinningScrewRadiusMm * 1000.0 * BinningScrewMoveGradient
+                / Build(screwCount: 3).vm.CalibrationAppliedAmount;
+
+            Assert.Multiple(() => {
+                Assert.That(expected, Is.GreaterThan(0),
+                    "precondition: the applied amount must be non-zero or every run is vacuously NaN");
+                Assert.That(bin1.recoveredPitch, Is.EqualTo(expected).Within(1e-6), "1x1");
+                Assert.That(bin2.recoveredPitch, Is.EqualTo(expected).Within(1e-6), "2x2 (was 2x the truth)");
+                Assert.That(bin4.recoveredPitch, Is.EqualTo(expected).Within(1e-6), "4x4 (was 4x the truth)");
+            });
+        }
+
+        // The user-visible face of the same bug: the piston-implied pitch needs NO sensor geometry, so it
+        // stayed honest while the tilt-derived pitch was inflated by the binning factor -- and the two were
+        // then compared. At 2x2 they differed by 50%, well past the 20% threshold, so a physically perfect
+        // calibration reported "the piston-implied pitch and the tilt-derived pitch differ".
+        [Test]
+        public void RunCalibrationForTest_AutoFocusBinning_DoesNotFireThePistonDisagreementWarning() {
+            var bin1 = RunBinnedCalibration(1);
+            var bin2 = RunBinnedCalibration(2);
+
+            Assert.Multiple(() => {
+                Assert.That(bin1.hasWarning, Is.False, $"1x1 baseline must be clean: {bin1.warningText}");
+                Assert.That(bin2.warningText, Does.Not.Contain("piston-implied"));
+                Assert.That(bin2.hasWarning, Is.False, $"2x2 must be equally clean: {bin2.warningText}");
+            });
+        }
+
+        // The other half of the same pairing: screw ORIENTATION survives symmetric binning untouched, because
+        // gx and gy are inflated by the same factor and atan2 is scale-invariant. Worth pinning explicitly --
+        // it is the reason the bug was invisible on the diagram while the pitch was silently doubling, and it
+        // would stop being true the moment someone "fixed" one axis' pixel pitch without the other.
+        [Test]
+        public void RunCalibrationForTest_AutoFocusBinning_LeavesScrewAnglesUnchanged() {
+            var (vm1, options1, _, _) = Build(screwCount: 3);
+            var (vm2, options2, _, _) = Build(screwCount: 3);
+
+            double captured1 = double.NaN, captured2 = double.NaN;
+            options1.When(o => o.Screw1AngleDegrees = Arg.Any<double>()).Do(ci => captured1 = ci.Arg<double>());
+            options2.When(o => o.Screw1AngleDegrees = Arg.Any<double>()).Do(ci => captured2 = ci.Arg<double>());
+
+            SeedBinningScrewMoves(vm1, 1);
+            SeedBinningScrewMoves(vm2, 2);
+
+            Assert.Multiple(() => {
+                Assert.That(captured1, Is.EqualTo(90.0).Within(1e-6), "screw 1's move points along +x, i.e. 90 deg");
+                Assert.That(captured2, Is.EqualTo(captured1).Within(1e-9));
+            });
+        }
+
+        private static void SeedBinningScrewMoves(TiltAdapterWizardVM vm, int binning) {
+            var tiltPlane = new TiltPlaneModel(
+                new System.Drawing.Size(SensorWidthPixels / binning, SensorHeightPixels / binning), fRatio: 7,
+                a: 0, b: 0, c: 0, mean: 10000, focuserStepSizeMicrons: BinningFocuserStepMicrons,
+                centerPosition: 10000, topLeftPosition: 10000, topRightPosition: 10000,
+                bottomLeftPosition: 10000, bottomRightPosition: 10000,
+                pixelSizeMicrons: NativePixelSizeMicrons * binning);
+            double g = BinningScrewMoveGradient;
+            vm.SeedStepReading(WizardStep.Baseline, 0.0, 0.0, 10000.0);
+            vm.SeedStepReading(WizardStep.Screw1, Screw1A, 0.0, 10000.0);
+            vm.SeedStepReading(WizardStep.ReBaseline2, 0.0, 0.0, 10000.0);
+            vm.SeedStepReading(WizardStep.Screw2,
+                -0.5 * g * BinningSensorWidthMicrons / BinningFocuserStepMicrons,
+                (Math.Sqrt(3.0) / 2.0) * g * BinningSensorHeightMicrons / BinningFocuserStepMicrons,
+                10000.0);
+            vm.RunCalibrationForTest(radiusMm: BinningScrewRadiusMm, pixelSizeMicrons: NativePixelSizeMicrons,
+                focuserStepMicrons: BinningFocuserStepMicrons, tiltPlaneOverride: tiltPlane);
+        }
+
         // --- Piston-implied-pitch warning wiring (Task 4) -------------------------------------------------
 
         // Both piston tests share the same clean screw geometry: Screw1's delta is (0, -g), Screw2's is

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/AutoFocus/TiltModel.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/AutoFocus/TiltModel.cs
@@ -36,12 +36,14 @@ namespace NINA.Joko.Plugins.HocusFocus.AutoFocus {
             double topLeftPosition,
             double topRightPosition,
             double bottomLeftPosition,
-            double bottomRightPosition) {
+            double bottomRightPosition,
+            double pixelSizeMicrons = double.NaN) {
             if (imageSize.Width <= 0 || imageSize.Height <= 0) {
                 throw new ArgumentException($"ImageSize ({imageSize.Width}, {imageSize.Height}) dimensions must be positive");
             }
 
             ImageSize = imageSize;
+            PixelSizeMicrons = pixelSizeMicrons;
             A = a;
             B = b;
             C = c;
@@ -76,6 +78,23 @@ namespace NINA.Joko.Plugins.HocusFocus.AutoFocus {
         }
 
         public System.Drawing.Size ImageSize { get; private set; }
+
+        /// <summary>
+        /// The pixel pitch, in microns, of ONE PIXEL OF <see cref="ImageSize"/> — i.e. the camera's native
+        /// pixel size multiplied by the binning the frame was captured at. NaN when the producer did not know
+        /// it (nothing derives physical units from such a model; callers fall back to their own source).
+        ///
+        /// It travels with the model because <see cref="A"/>/<see cref="B"/> are per-NORMALIZED image
+        /// coordinate, so recovering a physical gradient (microns of focuser travel per micron of sensor
+        /// displacement) needs the sensor's physical extent — <c>ImageSize.Width * PixelSizeMicrons</c> — and
+        /// that product is only correct if the two factors describe the SAME frame. Under NINA's Auto Focus
+        /// Binning of N the frame is N× coarser in both axes, so pairing this (binned) ImageSize with the
+        /// profile's native <c>CameraSettings.PixelSize</c> under-reports the sensor by N and inflates every
+        /// derived gradient — and therefore the tilt wizard's recovered thread pitch / stepper step size — by
+        /// exactly N. Keeping the pitch on the model is what makes that pairing impossible to get wrong.
+        /// </summary>
+        public double PixelSizeMicrons { get; private set; }
+
         public double A { get; private set; }
         public double B { get; private set; }
         public double C { get; private set; }
@@ -145,7 +164,8 @@ namespace NINA.Joko.Plugins.HocusFocus.AutoFocus {
             double bottomLeftFocuser,
             double bottomRightFocuser,
             double cornerXNorm = 0.5,
-            double cornerYNorm = 0.5) {
+            double cornerYNorm = 0.5,
+            double pixelSizeMicrons = double.NaN) {
             var ols = new OrdinaryLeastSquares() {
                 UseIntercept = true
             };
@@ -169,7 +189,8 @@ namespace NINA.Joko.Plugins.HocusFocus.AutoFocus {
                 imageSize: imageSize, fRatio: fRatio,
                 a: a, b: b, c: c, mean: mean, focuserStepSizeMicrons: focuserStepSizeMicrons, centerPosition: centerFocuser,
                 topLeftPosition: topLeftFocuser, topRightPosition: topRightFocuser,
-                bottomLeftPosition: bottomLeftFocuser, bottomRightPosition: bottomRightFocuser);
+                bottomLeftPosition: bottomLeftFocuser, bottomRightPosition: bottomRightFocuser,
+                pixelSizeMicrons: pixelSizeMicrons);
         }
     }
 

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/Inspection/SensorModelAberrationResult.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/Inspection/SensorModelAberrationResult.cs
@@ -464,9 +464,14 @@ namespace NINA.Joko.Plugins.HocusFocus.Inspection {
             var bottomLeftFocuser = centerFocuser + sensorModel.TiltAt(x: -width / 2.0, y: height / 2.0) / focuserStepSizeMicrons;
             var bottomRightFocuser = centerFocuser + sensorModel.TiltAt(x: width / 2.0, y: height / 2.0) / focuserStepSizeMicrons;
 
+            // pixelSizeMicrons is the pitch of one pixel of THIS frame (HocusFocusStarDetection already
+            // multiplies the camera's metadata pixel size by the capture binning), and it is what `width`/
+            // `height` above were built from. Carrying it on the model makes TiltPlaneModel.A/B invertible
+            // back to a physical gradient by anyone holding the model alone — see TiltPlaneModel.PixelSizeMicrons.
             return TiltPlaneModel.Create(imageSize: imageSize, fRatio: fRatio,
                 focuserStepSizeMicrons: focuserStepSizeMicrons, centerFocuser: centerFocuser,
-                topLeftFocuser: topLeftFocuser, topRightFocuser: topRightFocuser, bottomLeftFocuser: bottomLeftFocuser, bottomRightFocuser: bottomRightFocuser);
+                topLeftFocuser: topLeftFocuser, topRightFocuser: topRightFocuser, bottomLeftFocuser: bottomLeftFocuser, bottomRightFocuser: bottomRightFocuser,
+                pixelSizeMicrons: pixelSizeMicrons);
         }
     }
 }

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/DataTemplates.xaml
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/StarDetection/Optimization/DataTemplates.xaml
@@ -36,6 +36,66 @@
     <TextBlock x:Key="SDOpt_CaptureNewSweep_Tooltip" Text="Captures a whole new auto-focus sweep at this exposure and re-runs the optimization on the fresh frames — the only way to fix a run whose stars were too faint, since no setting recovers signal the frames never had. It takes new exposures and moves the focuser, so it costs a full sweep of sky time. The box starts at the recommended exposure and is yours to change. Any detection binning change you have already re-optimized at still applies. Nothing is saved until you Accept the new result." />
     <TextBlock x:Key="SDOpt_FocusRecovery_Tooltip" Text="Widens the live sweep by this many extra steps on EACH side, so the auto-focus curve can still bracket focus when you start well off focus. The extra far-from-focus frames are down-weighted in the fit and exempt from the star-count requirements, so they help find focus without skewing it. Set 0 to disable recovery." />
 
+    <!--  Themed button whose label is a plain string Content. Visually identical to NINA's StandardButton (same
+          theme brushes, same border/corner radii, same hover / pressed / disabled behaviour) — the ONLY change is
+          that the label is guaranteed to paint in ButtonForegroundBrush.
+
+          Why a whole Style is needed for that: a string Content is rendered by a TextBlock the ContentPresenter
+          generates, and NINA.WPF.Base ships a KEYLESS TextBlock style (Resources/Styles/TextBlock.xaml, BasedOn
+          StandardTextBlock => Foreground = PrimaryBrush) in Application.Resources. A style setter outranks an
+          inherited value, so that generated label ignores the button's own Foreground and paints PrimaryBrush —
+          and NINA's StandardButton deliberately sets Foreground = ButtonBackgroundBrush (its own buttons carry
+          Path icons that supply ButtonForegroundBrush themselves), so nothing else corrects it either. On the
+          "Dark" and "Alternative Custom" schemas PrimaryBrush and ButtonBackgroundBrush are the SAME colour
+          (#FF550C18), so the label rendered at 1.00:1 — literally invisible.
+
+          The empty style in ContentPresenter.Resources is found first (nearest dictionary wins the implicit-style
+          lookup) and carries no Foreground, so the inherited value — TextElement.Foreground below, i.e. the
+          button's own Foreground — reaches the glyph again. Setting Foreground on the Button alone does NOT
+          work, and neither does an implicit TextBlock style in this dictionary: a control-scope implicit style
+          does not reach template-generated content at all. Same fix, same reason, as HF_ReviewToolbarButton in
+          StarDetection/Optimization/Review/StarReviewControl.xaml.
+
+          The triggers keep Foreground on ButtonForegroundBrush in every state: NINA's own triggers re-point
+          Foreground at the (selected) background brush on hover/press, which would re-hide the label here.  -->
+    <Style x:Key="HF_TextButton" TargetType="Button">
+        <Setter Property="Background" Value="{StaticResource ButtonBackgroundBrush}" />
+        <Setter Property="Foreground" Value="{StaticResource ButtonForegroundBrush}" />
+        <Setter Property="BorderThickness" Value="0" />
+        <Setter Property="FontSize" Value="15" />
+        <Setter Property="SnapsToDevicePixels" Value="True" />
+        <Setter Property="Template">
+            <Setter.Value>
+                <ControlTemplate TargetType="Button">
+                    <Border BorderBrush="{StaticResource BorderBrush}" BorderThickness="{TemplateBinding BorderThickness}" CornerRadius="0">
+                        <Border x:Name="Fill" Background="{TemplateBinding Background}" CornerRadius="1">
+                            <ContentPresenter
+                                Margin="0"
+                                HorizontalAlignment="Center"
+                                VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
+                                TextElement.Foreground="{TemplateBinding Foreground}">
+                                <ContentPresenter.Resources>
+                                    <Style TargetType="TextBlock" />
+                                </ContentPresenter.Resources>
+                            </ContentPresenter>
+                        </Border>
+                    </Border>
+                    <ControlTemplate.Triggers>
+                        <Trigger Property="IsMouseOver" Value="True">
+                            <Setter TargetName="Fill" Property="Background" Value="{StaticResource ButtonBackgroundSelectedBrush}" />
+                        </Trigger>
+                        <Trigger Property="IsPressed" Value="True">
+                            <Setter TargetName="Fill" Property="Background" Value="{StaticResource ButtonBackgroundBrush}" />
+                        </Trigger>
+                        <Trigger Property="IsEnabled" Value="False">
+                            <Setter Property="Opacity" Value="0.4" />
+                        </Trigger>
+                    </ControlTemplate.Triggers>
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
+    </Style>
+
     <!--  Auto-focus curve chart for ONE settings variant. The Summary panel hosts this via a ContentControl bound to
           SelectedCurve, so toggling the variant rebuilds the plot from a fresh OptimizationCurve instance (a robust
           OxyPlot re-render without InvalidatePlot). Bindings are relative to the OptimizationCurve. Mirrors the AF
@@ -438,7 +498,8 @@
                                         Width="80"
                                         Command="{Binding DataContext.BrowseSourceCommand, RelativeSource={RelativeSource AncestorType=ItemsControl}}"
                                         CommandParameter="{Binding RelativeSource={RelativeSource AncestorType=ContentPresenter}, Path=(ItemsControl.AlternationIndex)}"
-                                        Content="Browse…" />
+                                        Content="Browse…"
+                                        Style="{StaticResource HF_TextButton}" />
                                     <TextBlock
                                         Width="440"
                                         Margin="8,0,0,0"
@@ -613,6 +674,7 @@
                                 Width="80"
                                 Command="{Binding BrowseSaveFolderCommand}"
                                 Content="Browse…"
+                                Style="{StaticResource HF_TextButton}"
                                 ToolTip="{StaticResource SDOpt_LiveSaveFolder_Tooltip}" />
                             <TextBlock
                                 Width="360"
@@ -1137,6 +1199,7 @@
                                         HorizontalAlignment="Left"
                                         Command="{Binding ReOptimizeCommand}"
                                         Content="Optimize with feedback"
+                                        Style="{StaticResource HF_TextButton}"
                                         ToolTip="{StaticResource SDOpt_ReOptimize_Tooltip}" />
                                 </StackPanel>
 
@@ -1259,6 +1322,7 @@
                     Margin="0,0,8,0"
                     Command="{Binding CancelCommand}"
                     Content="Cancel"
+                    Style="{StaticResource HF_TextButton}"
                     Visibility="{Binding ShowProgress, Converter={StaticResource BooleanToVisibilityCollapsedConverter}}" />
 
                 <!--  SelectSource: Start (Close is the shared button below).  -->
@@ -1267,6 +1331,7 @@
                     Margin="0,0,8,0"
                     Command="{Binding StartCommand}"
                     Content="Start"
+                    Style="{StaticResource HF_TextButton}"
                     Visibility="{Binding ShowSelectSource, Converter={StaticResource BooleanToVisibilityCollapsedConverter}}" />
 
                 <!--  Summary (results) page: Back, Review, Accept. Accept is always shown but disabled (via CanAccept)
@@ -1276,12 +1341,14 @@
                     Margin="0,0,8,0"
                     Command="{Binding BackCommand}"
                     Content="Back"
+                    Style="{StaticResource HF_TextButton}"
                     Visibility="{Binding ShowSummary, Converter={StaticResource BooleanToVisibilityCollapsedConverter}}" />
                 <Button
                     Width="120"
                     Margin="0,0,8,0"
                     Command="{Binding ReviewCommand}"
                     Content="Review frames"
+                    Style="{StaticResource HF_TextButton}"
                     ToolTip="{StaticResource SDOpt_Review_Tooltip}"
                     Visibility="{Binding ShowSummary, Converter={StaticResource BooleanToVisibilityCollapsedConverter}}" />
                 <!--  Continue optimizing: another pass from the current best. Disabled (greyed) once 3 passes have
@@ -1291,6 +1358,7 @@
                     Margin="0,0,8,0"
                     Command="{Binding ContinueOptimizationCommand}"
                     Content="Continue optimizing"
+                    Style="{StaticResource HF_TextButton}"
                     ToolTip="{StaticResource SDOpt_Continue_Tooltip}"
                     Visibility="{Binding ShowSummary, Converter={StaticResource BooleanToVisibilityCollapsedConverter}}" />
                 <!--  Import this run's saved settings: shown only when a loaded run actually carries a settings
@@ -1300,6 +1368,7 @@
                     Margin="0,0,8,0"
                     Command="{Binding ImportRunSettingsCommand}"
                     Content="Use run's settings"
+                    Style="{StaticResource HF_TextButton}"
                     ToolTip="{StaticResource SDOpt_ImportRunSettings_Tooltip}"
                     Visibility="{Binding CanImportRunSettings, Converter={StaticResource BooleanToVisibilityCollapsedConverter}}" />
                 <Button
@@ -1307,6 +1376,7 @@
                     Margin="0,0,8,0"
                     Command="{Binding AcceptCommand}"
                     Content="Accept"
+                    Style="{StaticResource HF_TextButton}"
                     Visibility="{Binding ShowSummary, Converter={StaticResource BooleanToVisibilityCollapsedConverter}}" />
 
                 <!--  Review (labeling) page: Back to summary + Optimize with feedback (enabled once anything is
@@ -1316,12 +1386,14 @@
                     Margin="0,0,8,0"
                     Command="{Binding BackToSummaryCommand}"
                     Content="Back to summary"
+                    Style="{StaticResource HF_TextButton}"
                     Visibility="{Binding ShowReview, Converter={StaticResource BooleanToVisibilityCollapsedConverter}}" />
                 <Button
                     Width="180"
                     Margin="0,0,8,0"
                     Command="{Binding ReOptimizeCommand}"
                     Content="Optimize with feedback"
+                    Style="{StaticResource HF_TextButton}"
                     ToolTip="{StaticResource SDOpt_ReOptimize_Tooltip}"
                     Visibility="{Binding ShowReview, Converter={StaticResource BooleanToVisibilityCollapsedConverter}}" />
 
@@ -1333,7 +1405,7 @@
                     <Button.Style>
                         <!--  BasedOn the theme's implicit Button style so Close matches the other footer buttons'
                               font/look (a style without BasedOn would drop the NINA default style).  -->
-                        <Style TargetType="Button" BasedOn="{StaticResource {x:Type Button}}">
+                        <Style TargetType="Button" BasedOn="{StaticResource HF_TextButton}">
                             <Setter Property="Visibility" Value="Collapsed" />
                             <Style.Triggers>
                                 <DataTrigger Binding="{Binding ShowSelectSource}" Value="True">

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/TiltAdapterWizard/TiltAdapterWizardVM.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/TiltAdapterWizard/TiltAdapterWizardVM.cs
@@ -1626,7 +1626,26 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
             }
         }
 
-        public string CalibrationPixelSizeDisplay => calibrationPixelSizeMicrons > 0 ? $"{calibrationPixelSizeMicrons:0.##} µm" : "—";
+        /// <summary>
+        /// The pixel pitch this calibration's geometry actually used. Under Auto Focus Binning that is the
+        /// BINNED pitch, which is deliberately not the number the user typed into the "Pixel size (µm)" box
+        /// further up the page (that one edits the camera profile's native value) — so when the two differ by
+        /// a clean integer factor, say so, rather than leaving a reader to wonder which of the two is wrong.
+        /// </summary>
+        public string CalibrationPixelSizeDisplay {
+            get {
+                if (!(calibrationPixelSizeMicrons > 0)) return "—";
+                double nativePixelSize = profileService.ActiveProfile.CameraSettings.PixelSize;
+                if (nativePixelSize > 0) {
+                    double ratio = calibrationPixelSizeMicrons / nativePixelSize;
+                    int binning = (int)Math.Round(ratio);
+                    if (binning >= 2 && Math.Abs(ratio - binning) < 0.01) {
+                        return $"{calibrationPixelSizeMicrons:0.##} µm ({nativePixelSize:0.##} µm at {binning}x{binning} binning)";
+                    }
+                }
+                return $"{calibrationPixelSizeMicrons:0.##} µm";
+            }
+        }
         public string CalibrationFocuserStepDisplay => calibrationFocuserStepMicrons > 0 ? $"{calibrationFocuserStepMicrons:0.###} µm" : "—";
         public string CalibrationScrewRadiusDisplay => calibrationScrewRadiusMm > 0 ? $"{calibrationScrewRadiusMm:0.##} mm" : "not set";
         public string CalibrationAppliedAmountDisplay => IsStepperAdjustment ? $"{CalibrationAppliedAmount:0.##} steps" : $"{CalibrationAppliedAmount:0.##} turns";
@@ -2474,6 +2493,9 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
                 ScrewThreadPitchMicrons = tiltAdapterOptions.ThreadPitchMicrons,
                 StepperStepSizeMicrons = tiltAdapterOptions.StepperStepSizeMicrons,
                 ScrewRadiusMillimeters = tiltAdapterOptions.ScrewRadiusMillimeters,
+                // Native pitch: no frame has been captured yet, so the binning is not knowable here.
+                // FinalizeMetadata overwrites this with the effective (binning-scaled) pitch the calibration
+                // actually used — see TiltCalibrationMetadata.PixelSizeMicrons.
                 PixelSizeMicrons = profileService.ActiveProfile.CameraSettings.PixelSize,
                 FocuserStepSizeMicrons = EffectiveFocuserStepMicrons(),
                 CalibrationAppliedAmount = CalibrationAppliedAmount,
@@ -2891,6 +2913,23 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
             }
         }
 
+        // The pixel pitch that must be paired with a tilt plane's ImageSize to get the sensor's PHYSICAL
+        // extent. Prefer the pitch the model itself was built from (TiltPlaneModel.PixelSizeMicrons — the
+        // camera's pixel size times the binning the frames were captured at, carried through from star
+        // detection), because that is exactly the value SensorModelAberrationResult.CreateTiltPlaneModel used
+        // to produce the (A, B) being inverted here, making the round trip exact.
+        //
+        // The profile's CameraSettings.PixelSize is the NATIVE pitch and is only a correct partner for a
+        // 1x1 frame. With NINA's Auto Focus Binning set to N, ImageSize is the binned (N× smaller) frame while
+        // the profile value stays native, so sensorWidth/Height came out N× too small and every gradient — and
+        // with it the recovered thread pitch / stepper step size, the per-step tilt-angle readout, and the
+        // tilt-vs-piston agreement check — was inflated by exactly N. It stays the fallback for models that
+        // do not know their own pitch (the 4-corner AF plane, test-injected planes).
+        private static double EffectivePixelSizeMicrons(TiltPlaneModel model, double profilePixelSizeMicrons) {
+            double modelPixelSize = model?.PixelSizeMicrons ?? double.NaN;
+            return modelPixelSize > 0 && !double.IsNaN(modelPixelSize) ? modelPixelSize : profilePixelSizeMicrons;
+        }
+
         // Converts a step's (A, B) tilt-plane reading (focuser steps per normalized image coordinate) into the
         // physical best-focus gradient (gx, gy): microns of focuser travel per micron of sensor displacement.
         // Shared by ComputeTiltAngleDeg (magnitude) and the per-state DirectionDeg (atan2(gx,-gy)) so both read
@@ -2899,7 +2938,7 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
         // model or the focuser/pixel size inputs are unavailable.
         private (double gx, double gy) StateGradient(double a, double b, TiltPlaneModel model) {
             if (model == null) return (double.NaN, double.NaN);
-            var pixelSizeMicrons = profileService.ActiveProfile.CameraSettings.PixelSize;
+            var pixelSizeMicrons = EffectivePixelSizeMicrons(model, profileService.ActiveProfile.CameraSettings.PixelSize);
             var fStepMicrons = model.FocuserStepSizeMicrons;
             // Fall back to the connected focuser's reported step size when the inspector
             // option (MicronsPerFocuserStep) hasn't been configured.
@@ -3133,7 +3172,7 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
             }
         }
 
-        private void RunCalibrationMath(int screwCount, double radiusMm, double pixelSize, double fStep,
+        private void RunCalibrationMath(int screwCount, double radiusMm, double profilePixelSize, double fStep,
             double appliedAmount, bool isStepper, bool deviceDriven) {
             bool measuredCurvature = stepReadings.ContainsKey(WizardStep.AllInward);
             // Task 6: the optional measured final re-baseline. Presence in stepReadings (NOT
@@ -3181,6 +3220,17 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
                 curvatureChannelDisagreement = null;
             }
 
+            // The tilt plane the whole calibration is built from. Read once here (not just where the
+            // TiltCalibrationInputs are assembled) because the effective pixel pitch below comes off it.
+            var model = CalibrationTiltPlane;
+
+            // AUTO FOCUS BINNING: model.ImageSize is the BINNED frame, so it must be paired with the BINNED
+            // pixel pitch — see EffectivePixelSizeMicrons. Resolved once, here, and used for everything
+            // downstream (the readouts, BOTH TiltCalibrationInputs, and the metadata this run saves) so no
+            // consumer can pick up the caller's native profile value by accident. The caller's value stays as
+            // the fallback for a model that does not know its own pitch (a seeded/test-only run).
+            double pixelSize = EffectivePixelSizeMicrons(model, profilePixelSize);
+
             calibrationScrewRadiusMm = radiusMm;
             calibrationPixelSizeMicrons = pixelSize;
             calibrationFocuserStepMicrons = fStep;
@@ -3193,7 +3243,7 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
             // Screw1..4AngleDegrees or the "unequal tilt changes" warning until this refactor. Tasks 3-6 add
             // fields to Calibrate's inputs/result; wiring them here (not duplicating them) is what makes them
             // reach production automatically.
-            var model = CalibrationTiltPlane;
+            //
             // A model-less run (e.g. a seeded/test-only run with no live/replayed tilt plane) has no known
             // sensor size; fall back to a square 1x1 pseudo-sensor so the angle/ratio/confidence conversion
             // stays isotropic instead of aspect-distorted -- a uniform scale of the raw (A,B) delta reproduces
@@ -4024,6 +4074,13 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
 
         private void FinalizeMetadata() {
             if (!saveAFRuns || currentMetadata == null) return;
+            // Record the pixel pitch the calibration ACTUALLY used, which under Auto Focus Binning is the
+            // binned pitch and not the profile's native value BuildInitialMetadata could only guess at. A
+            // replay or the headless TestApp validator re-derives the sensor's physical extent from this
+            // number and the saved frames' dimensions, so the two must describe the same frame.
+            if (calibrationPixelSizeMicrons > 0) {
+                currentMetadata.PixelSizeMicrons = calibrationPixelSizeMicrons;
+            }
             currentMetadata.Calibration = new TiltCalibrationResultRecord {
                 Screw1AngleDegrees = tiltAdapterOptions.Screw1AngleDegrees,
                 Screw2AngleDegrees = tiltAdapterOptions.Screw2AngleDegrees,

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/TiltAdapterWizard/TiltCalibrationMetadata.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/TiltAdapterWizard/TiltCalibrationMetadata.cs
@@ -125,7 +125,13 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
     /// </summary>
     public sealed class TiltCalibrationMetadata {
 
-        public const int CurrentSchemaVersion = 3;
+        // 4: PixelSizeMicrons became the EFFECTIVE (binning-scaled) pitch of the saved frames rather than the
+        //    profile's native camera pixel size. Purely informational — nothing gates on the version — but a
+        //    file written by version <= 3 at an Auto Focus Binning above 1x1 carries the native pitch, so its
+        //    sensor extent (and every gradient derived from it) is short by the binning factor. The wizard's
+        //    replay is immune either way: it prefers the pitch carried by the tilt plane it just re-fitted from
+        //    the frames themselves (TiltPlaneModel.PixelSizeMicrons) over this stored number.
+        public const int CurrentSchemaVersion = 4;
 
         /// <summary>The six discrete measurement steps, in capture order. Same for 3- and 4-screw adapters.</summary>
         public static readonly string[] StepOrder = {
@@ -151,6 +157,16 @@ namespace NINA.Joko.Plugins.HocusFocus.TiltAdapterWizard {
         public double ScrewThreadPitchMicrons { get; set; } = -1;     // µm/turn (screws)
         public double StepperStepSizeMicrons { get; set; } = -1;      // µm/step (steppers)
         public double ScrewRadiusMillimeters { get; set; }
+
+        /// <summary>
+        /// The EFFECTIVE pixel pitch of the frames this run measured — the camera's native pixel size times
+        /// the Auto Focus Binning they were captured at — because it only ever appears multiplied by a frame
+        /// dimension to get the sensor's physical extent, and the saved frames are binned. Seeded from the
+        /// profile's native <c>CameraSettings.PixelSize</c> when the run starts (no frame exists yet) and
+        /// overwritten with the value the calibration actually used once the run completes, so a saved run is
+        /// self-describing for replay and for the headless TestApp validator. Identical to the native pixel
+        /// size for the usual 1x1 case.
+        /// </summary>
         public double PixelSizeMicrons { get; set; }
         public double FocuserStepSizeMicrons { get; set; }
         public double CalibrationAppliedAmount { get; set; } = 1.0;   // turns/steps applied per screw step

--- a/Joko.NINA.Plugins/TestApp/TiltCalibrationRunner.cs
+++ b/Joko.NINA.Plugins/TestApp/TiltCalibrationRunner.cs
@@ -198,7 +198,13 @@ namespace TestApp {
                 Console.WriteLine($"  {r.Step,-10} -> {Path.GetFileName(r.Folder)} ({r.Frames.Count} frames, {r.Frames.Select(f => f.Focuser).Distinct().Count()} positions)");
             }
 
-            // PixelScale = arcsec/pixel from the dataset pixel size + the profile's focal length (binning 1).
+            // PixelScale = arcsec/pixel from the dataset pixel size + the profile's focal length.
+            // metadata.PixelSizeMicrons is the EFFECTIVE pitch of the saved frames (native x Auto Focus Binning)
+            // for runs written by schema 4 and later, so this is already the binned scale and every
+            // ImageSize x PixelSizeMicrons product below is the true sensor extent. A run saved by an older
+            // wizard at a binning above 1x1 stored the NATIVE pitch instead: this headless path then measures
+            // the same binning-factor-inflated gradients (and thus pitch) the wizard itself used to report.
+            // Replay such a run through the wizard, which re-derives the pitch from the frames.
             var pixelScale = MathUtility.ArcsecPerPixel(metadata.PixelSizeMicrons, activeProfile.TelescopeSettings.FocalLength);
 
             // Resolve the detection params: stored optimized settings (default), a fresh optimization run, or the


### PR DESCRIPTION
Two independent fixes, kept on one branch because the suite validated them together.

## 1. Tilt calibration measured N× off under Auto Focus Binning

The wizard's readings are `TiltPlaneModel.A`/`B` — focuser steps per **normalized** image coordinate — so
recovering a physical gradient needs the sensor's physical extent, `ImageSize.Width × pixelSize`. That product
is only right when both factors describe the same frame. The wizard paired the model's **binned** `ImageSize`
with the profile's **native** `CameraSettings.PixelSize`, understating the sensor by the binning factor.

Star detection already handles binning correctly (`PixelSize = metadata pixel size × BinX`), so the
paraboloid's `Gx/Gy/Kx/Ky` and the Inspector's per-screw correction targets were right all along. Only the
round trip back out of `(A, B)` was wrong.

Reproduced by mutating the fix back out (`RunCalibrationForTest_AutoFocusBinning_*`):

| | truth | 2×2 | 4×4 |
|---|---|---|---|
| recovered pitch (µm/turn) | 505.69 | **1011.39** | **2022.77** |

Exactly ×N. What that broke:

- **Recovered thread pitch / stepper step size inflated by N.** This is what `LastMeasuredThreadPitchMicrons`
  stores and what every automated correction later divides a required µm move by — adopting it made every
  correction N× too small.
- **The tilt-vs-piston agreement warning fired on a physically perfect run.**
  `PistonImpliedMicronsPerStep` uses no sensor geometry at all (mean focuser positions only), so it stayed
  honest while the tilt-derived pitch doubled: 50% apart at 2×2, past the 20% threshold.
- **Screw position angles were NOT affected** on symmetric binning — `gx` and `gy` inflate equally and `atan2`
  is scale-invariant. That is why the diagram looked right while the pitch was silently wrong. (It would not
  survive `BinX ≠ BinY`, but neither would the sensor model, which reads `BinX` alone.)

**Fix is structural rather than a patched call site:** `TiltPlaneModel` now carries the `PixelSizeMicrons` it
was built from, set by `SensorModelAberrationResult.CreateTiltPlaneModel` from the same value that produced
`(A, B)`, and `TiltAdapterWizardVM.EffectivePixelSizeMicrons` prefers it over the profile value — so the
pairing cannot be got wrong and the inversion is exact by construction.

Replays of **old** saved runs are fixed too, because the pitch is re-derived from the freshly re-fitted model
rather than read from `metadata.PixelSizeMicrons`. Saved metadata now records the effective pitch (schema 4),
and the wizard's "Inputs to this calculation" panel spells the binning out so the value is never mistaken for
the profile's pixel-size box.

**Detection binning was never affected** and is untouched: the detector scales every pixel-space output back
to source pixels before returning (`Star.ScaleToSourcePixels`, `metrics.ScaleBounds`), and the result header's
`PixelSize`/`ImageSize` come from camera metadata and the source frame. `DetectionBinning` reaches only
`PixelScale`, which the tilt path does not read.

## 2. `Button Content="…"` labels invisible on Dark / Alternative Custom

The 13 remaining `Content="…"` sites, all in the star-detection optimizer's DataTemplates, rendered at
**1.00:1**. A string `Content` is drawn by a `TextBlock` the `ContentPresenter` generates at runtime, which
picks up NINA's keyless `TextBlock` style (`Foreground = PrimaryBrush`); that setter outranks the inherited
value, and `StandardButton` sets `Foreground = ButtonBackgroundBrush` on purpose (NINA's own buttons carry
`Path` icons that supply `ButtonForegroundBrush`). On those two schemas the two brushes are the same colour,
`#FF550C18`.

Adds `HF_TextButton`: NINA's `StandardButton` look reproduced brush-for-brush, using the
`ContentPresenter.Resources` empty-`Style` pattern already solved in `HF_ReviewToolbarButton`. Note that an
explicit `Foreground` on the `Button` does **not** work — a style setter still outranks the inherited value —
and `Foreground` has to stay pinned in the hover/pressed triggers, since NINA's own triggers re-point it at
the (selected) background brush and would re-hide the label.

Also adds `ButtonContentForegroundGuardTests`, the automated net that was missing while this trap kept
recurring: it enforces both forms across every plugin XAML. Both are contrast rules rather than resolution
rules, which is exactly why `XamlResourceResolutionTests` could never see them.

## Testing

Full suite green: **4407 passed, 0 failed**. Every new test was mutation-checked — the binning tests fail with
2×/4× before the fix, and the XAML guards fail with file:line when a `Style=` or `Foreground=` is removed.

## Not done

- The headless `TestApp tilt` validator reads `metadata.PixelSizeMicrons` as-is, so it reproduces the old
  inflation on runs saved by metadata schema ≤ 3 at binning above 1×1. Documented at both ends; replay those
  through the wizard instead.
- Neither change has been verified live in NINA.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QTNWdSNar6g3Nj5wXnLZc6