### PR TITLE
Read the tilt harness's pixel pitch off the frames, not the metadata

### DIFF
--- a/.claude/docs/tilt-domain.md
+++ b/.claude/docs/tilt-domain.md
@@ -138,6 +138,12 @@ returning (`stars.Select(s => s.ScaleToSourcePixels(binning))`, `metrics.ScaleBo
 `PixelSize`/`ImageSize` are built from the camera metadata and the source frame, never from it. `DetectionBinning`
 touches only `PixelScale`, which the tilt path does not read. `DetectionBinningTests` pins the scale-back.
 
-`TiltCalibrationMetadata.PixelSizeMicrons` is the **effective** (binning-scaled) pitch from schema 4 onward.
-Files written by schema ≤ 3 at a binning above 1×1 hold the native pitch; the headless `TestApp tilt` validator
-reads the field as-is and so reproduces the old inflation on those runs — replay them through the wizard instead.
+`TiltCalibrationMetadata.PixelSizeMicrons` is the **effective** (binning-scaled) pitch from schema 4 onward;
+files written by schema ≤ 3 at a binning above 1×1 hold the native pitch. The headless `TestApp tilt` validator
+therefore does **not** trust that field: it reads the pitch off a saved frame's own header
+(`EffectivePixelSize.FromFrameHeader`, `Camera.PixelSize × max(BinX, 1)` — the same derivation
+`HocusFocusStarDetection.BuildResultHeader` uses live), which is unambiguous at every schema because NINA's FITS
+and XISF readers both divide the stored binned `XPIXSZ` back out by `XBINNING`. It falls back to the metadata
+value only when no frame carries a pixel size, and prints the provenance either way — plus an explicit note when
+the header and the metadata disagree, which is exactly the pre-schema-4 binned case. That also fixes the
+detection `PixelScale` the harness tunes with, which had the same native-pitch assumption.

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/Harness/EffectivePixelSizeTests.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/Harness/EffectivePixelSizeTests.cs
@@ -1,0 +1,106 @@
+﻿using NUnit.Framework;
+using TestApp;
+
+namespace NINA.Joko.Plugins.HocusFocus.Tests.Harness;
+
+/// <summary>
+/// The headless tilt validator's pixel-pitch decision. The stakes are the whole point: this number is only
+/// ever multiplied by a frame DIMENSION to get the sensor's physical extent, so getting it wrong scales every
+/// recovered gradient — and with it the reported thread pitch / stepper step size — by exactly the error.
+/// </summary>
+[TestFixture]
+public class EffectivePixelSizeTests {
+
+    // A 3.76 µm camera, the pitch NINA's readers hand back for any binning (both the FITS and XISF readers
+    // divide the stored XPIXSZ back out by XBINNING), so the binning has to be re-applied here.
+    private const double NativeMicrons = 3.76;
+
+    [Test]
+    public void FromFrameHeader_Unbinned_IsTheNativePitch() {
+        var resolution = EffectivePixelSize.FromFrameHeader(NativeMicrons, binX: 1, metadataPixelSizeMicrons: NativeMicrons, "f.fits");
+
+        Assert.Multiple(() => {
+            Assert.That(resolution.Microns, Is.EqualTo(3.76).Within(1e-12));
+            Assert.That(resolution.FromFrameHeader, Is.True);
+            Assert.That(resolution.Provenance, Does.Contain("unbinned"));
+        });
+    }
+
+    [TestCase(2, 7.52)]
+    [TestCase(3, 11.28)]
+    [TestCase(4, 15.04)]
+    public void FromFrameHeader_Binned_ScalesTheNativePitchByTheBinningFactor(int binning, double expected) {
+        // THE regression. Returning the native pitch here understates the sensor by `binning` and inflates the
+        // recovered hardware by exactly the same factor — the bug the tilt wizard shipped with.
+        var resolution = EffectivePixelSize.FromFrameHeader(NativeMicrons, binning, metadataPixelSizeMicrons: NativeMicrons, "f.fits");
+
+        Assert.Multiple(() => {
+            Assert.That(resolution.Microns, Is.EqualTo(expected).Within(1e-12));
+            Assert.That(resolution.Provenance, Does.Contain($"{binning}x{binning} binning"));
+        });
+    }
+
+    [Test]
+    public void FromFrameHeader_BeatsAMetadataValueThatDisagrees() {
+        // A run saved before metadata schema 4 at 2x2 stored the NATIVE pitch. Trusting it is precisely the
+        // old inflation, so the header has to win — and the disagreement has to be reportable.
+        var resolution = EffectivePixelSize.FromFrameHeader(NativeMicrons, binX: 2, metadataPixelSizeMicrons: NativeMicrons, "f.fits");
+
+        Assert.Multiple(() => {
+            Assert.That(resolution.Microns, Is.EqualTo(7.52).Within(1e-12));
+            Assert.That(EffectivePixelSize.DisagreesWithMetadata(resolution, NativeMicrons), Is.True);
+        });
+    }
+
+    [Test]
+    public void FromFrameHeader_AgreesWithSchema4MetadataForTheSameRun() {
+        // Schema 4 stores the effective pitch, so a binned run written by the current wizard must NOT be
+        // reported as a disagreement — otherwise every modern run prints a scary note about itself.
+        var resolution = EffectivePixelSize.FromFrameHeader(NativeMicrons, binX: 2, metadataPixelSizeMicrons: 7.52, "f.fits");
+
+        Assert.That(EffectivePixelSize.DisagreesWithMetadata(resolution, 7.52), Is.False);
+    }
+
+    [TestCase(0)]
+    [TestCase(-1)]
+    public void FromFrameHeader_NonsensicalBinning_IsClampedToOne(int binX) {
+        // A zero factor would scale the pitch — and the whole sensor extent — to zero, turning every gradient
+        // into an infinity rather than failing loudly. Clamp instead.
+        var resolution = EffectivePixelSize.FromFrameHeader(NativeMicrons, binX, metadataPixelSizeMicrons: NativeMicrons, "f.fits");
+
+        Assert.That(resolution.Microns, Is.EqualTo(3.76).Within(1e-12));
+    }
+
+    [TestCase(double.NaN)]
+    [TestCase(0.0)]
+    [TestCase(-3.76)]
+    public void FromFrameHeader_NoUsablePixelSize_FallsBackToMetadataAndSaysSo(double headerPixelSize) {
+        var resolution = EffectivePixelSize.FromFrameHeader(headerPixelSize, binX: 2, metadataPixelSizeMicrons: 4.63, "frame.fits");
+
+        Assert.Multiple(() => {
+            Assert.That(resolution.Microns, Is.EqualTo(4.63).Within(1e-12));
+            Assert.That(resolution.FromFrameHeader, Is.False);
+            Assert.That(resolution.Provenance, Does.StartWith("metadata (").And.Contain("frame.fits"));
+        });
+    }
+
+    [Test]
+    public void FromMetadata_CarriesTheReasonIntoTheProvenance() {
+        // The reason matters: on a pre-schema-4 binned run this fallback IS the inflated number, and the
+        // report has to admit the harness had to trust it rather than quoting it as measured.
+        var resolution = EffectivePixelSize.FromMetadata(3.76, "no frames to read a header from");
+
+        Assert.Multiple(() => {
+            Assert.That(resolution.Microns, Is.EqualTo(3.76).Within(1e-12));
+            Assert.That(resolution.FromFrameHeader, Is.False);
+            Assert.That(resolution.Provenance, Is.EqualTo("metadata (no frames to read a header from)"));
+        });
+    }
+
+    [Test]
+    public void DisagreesWithMetadata_UnsetMetadataIsNotADisagreement() {
+        var resolution = EffectivePixelSize.FromFrameHeader(NativeMicrons, binX: 1, metadataPixelSizeMicrons: 0, "f.fits");
+
+        Assert.That(EffectivePixelSize.DisagreesWithMetadata(resolution, 0), Is.False);
+    }
+}

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/Joko.NINA.Plugins.HocusFocus.Tests.csproj
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/Joko.NINA.Plugins.HocusFocus.Tests.csproj
@@ -26,6 +26,10 @@
     <Compile Include="..\TestApp\GoldenGeometry.cs" Link="Golden\GoldenGeometry.cs" />
     <Compile Include="..\TestApp\BankVerification.cs" Link="Bank\BankVerification.cs" />
     <Compile Include="..\TestApp\HarnessSettingsStore.cs" Link="Harness\HarnessSettingsStore.cs" />
+    <!-- Which pixel pitch a headless tilt validation reasons in. TiltCalibrationRunner loads NINA rendered
+         images and cannot be linked, so the whole frame-header-vs-metadata decision lives in this one pure
+         file, which the runner only calls: the same shape as TruthDisclosure/CapSemantics above. -->
+    <Compile Include="..\TestApp\EffectivePixelSize.cs" Link="Harness\EffectivePixelSize.cs" />
     <Compile Include="..\TestApp\HarnessFitInputs.cs" Link="Harness\HarnessFitInputs.cs" />
     <Compile Include="..\TestApp\LandingWriteback.cs" Link="Harness\LandingWriteback.cs" />
     <Compile Include="..\TestApp\MadFloorArgs.cs" Link="Harness\MadFloorArgs.cs" />

--- a/Joko.NINA.Plugins/TestApp/EffectivePixelSize.cs
+++ b/Joko.NINA.Plugins/TestApp/EffectivePixelSize.cs
@@ -1,0 +1,98 @@
+﻿#region "copyright"
+
+/*
+    Copyright © 2021 - 2026 George Hilios <ghilios+NINA@googlemail.com>
+
+    This Source Code Form is subject to the terms of the Mozilla Public
+    License, v. 2.0. If a copy of the MPL was not distributed with this
+    file, You can obtain one at http://mozilla.org/MPL/2.0/.
+*/
+
+#endregion "copyright"
+
+using System;
+using System.Globalization;
+
+namespace TestApp {
+
+    /// <summary>
+    /// Which pixel pitch a headless tilt validation should reason in, and why.
+    ///
+    /// <para>Everything downstream multiplies this by a frame DIMENSION to get the sensor's physical extent, so
+    /// it has to describe the same frame those dimensions came from. Under NINA's Auto Focus Binning of N the
+    /// captured frame is N× smaller per axis and each of its pixels is N× coarser; pairing a binned frame with a
+    /// NATIVE pitch understates the sensor by N and inflates every recovered gradient — and with it the reported
+    /// thread pitch / stepper step size — by exactly N. That is the bug the tilt wizard carried until
+    /// <c>TiltPlaneModel</c> started carrying its own pitch.</para>
+    ///
+    /// <para>The frame header wins over <c>TiltCalibrationMetadata.PixelSizeMicrons</c> deliberately: that field
+    /// is the EFFECTIVE pitch only from metadata schema 4 onward and the NATIVE pitch before it, so trusting it
+    /// would silently reproduce the old inflation on every run an older wizard saved. A header is unambiguous at
+    /// every schema — NINA's FITS and XISF readers both divide the stored (binned) XPIXSZ back out by XBINNING,
+    /// so <c>Camera.PixelSize</c> is always native and <c>BinX</c> always carries the factor, which is exactly
+    /// how <c>HocusFocusStarDetection.BuildResultHeader</c> derives it in the live app.</para>
+    ///
+    /// <para>Pure (no NINA or OpenCV coupling) so the decision is unit-testable; <c>TiltCalibrationRunner</c>
+    /// does the file I/O and calls in here for every judgement.</para>
+    /// </summary>
+    public static class EffectivePixelSize {
+
+        /// <summary>Below this the resolved pitch and the metadata's are the same number, not a disagreement.</summary>
+        public const double DisagreementToleranceMicrons = 1e-6;
+
+        public readonly struct Resolution {
+
+            public Resolution(double microns, string provenance, bool fromFrameHeader) {
+                Microns = microns;
+                Provenance = provenance;
+                FromFrameHeader = fromFrameHeader;
+            }
+
+            /// <summary>The pitch of one pixel OF THE SAVED FRAME, in microns.</summary>
+            public double Microns { get; }
+
+            /// <summary>Human-readable account of where <see cref="Microns"/> came from, for the console + report.</summary>
+            public string Provenance { get; }
+
+            /// <summary>False when this fell back to the metadata value (no header, or no pixel size in it).</summary>
+            public bool FromFrameHeader { get; }
+        }
+
+        /// <summary>
+        /// Resolve from a loaded frame's camera metadata. <paramref name="headerPixelSizeMicrons"/> is the NATIVE
+        /// pitch (both NINA readers divide the binning back out) and <paramref name="binX"/> the factor it was
+        /// captured at, so the effective pitch is their product. Falls back to
+        /// <paramref name="metadataPixelSizeMicrons"/> when the header carries no usable pixel size — a frame
+        /// written without XPIXSZ tells us nothing, and the metadata is still better than nothing.
+        /// </summary>
+        public static Resolution FromFrameHeader(
+            double headerPixelSizeMicrons, int binX, double metadataPixelSizeMicrons, string frameName) {
+            if (double.IsNaN(headerPixelSizeMicrons) || headerPixelSizeMicrons <= 0) {
+                return FromMetadata(metadataPixelSizeMicrons, $"{frameName} carries no pixel size");
+            }
+            // Clamp rather than trust: a header that omits XBINNING leaves BinX at its 1 default, and a
+            // nonsensical 0 or negative must never scale the pitch to zero and take the whole sensor extent
+            // with it.
+            int binning = Math.Max(binX, 1);
+            double microns = headerPixelSizeMicrons * binning;
+            string provenance = binning > 1
+                ? $"frame header: {Format(headerPixelSizeMicrons)} um native x {binning}x{binning} binning"
+                : $"frame header: {Format(headerPixelSizeMicrons)} um, unbinned";
+            return new Resolution(microns, provenance, fromFrameHeader: true);
+        }
+
+        /// <summary>The fallback: no frame could answer, so the metadata's stored value stands — with the reason
+        /// carried in the provenance, because on a pre-schema-4 binned run that value is the one that inflates
+        /// the result and the reader deserves to know the harness had to trust it.</summary>
+        public static Resolution FromMetadata(double metadataPixelSizeMicrons, string reason) =>
+            new Resolution(metadataPixelSizeMicrons, $"metadata ({reason})", fromFrameHeader: false);
+
+        /// <summary>True when the resolved pitch and the metadata's stored one are genuinely different numbers —
+        /// the signal that this run predates metadata schema 4 and was captured binned.</summary>
+        public static bool DisagreesWithMetadata(Resolution resolution, double metadataPixelSizeMicrons) =>
+            metadataPixelSizeMicrons > 0
+            && Math.Abs(resolution.Microns - metadataPixelSizeMicrons) > DisagreementToleranceMicrons;
+
+        private static string Format(double value) => value.ToString("0.####", CultureInfo.InvariantCulture);
+    }
+}

--- a/Joko.NINA.Plugins/TestApp/TiltCalibrationRunner.cs
+++ b/Joko.NINA.Plugins/TestApp/TiltCalibrationRunner.cs
@@ -198,14 +198,25 @@ namespace TestApp {
                 Console.WriteLine($"  {r.Step,-10} -> {Path.GetFileName(r.Folder)} ({r.Frames.Count} frames, {r.Frames.Select(f => f.Focuser).Distinct().Count()} positions)");
             }
 
-            // PixelScale = arcsec/pixel from the dataset pixel size + the profile's focal length.
-            // metadata.PixelSizeMicrons is the EFFECTIVE pitch of the saved frames (native x Auto Focus Binning)
-            // for runs written by schema 4 and later, so this is already the binned scale and every
-            // ImageSize x PixelSizeMicrons product below is the true sensor extent. A run saved by an older
-            // wizard at a binning above 1x1 stored the NATIVE pitch instead: this headless path then measures
-            // the same binning-factor-inflated gradients (and thus pitch) the wizard itself used to report.
-            // Replay such a run through the wizard, which re-derives the pitch from the frames.
-            var pixelScale = MathUtility.ArcsecPerPixel(metadata.PixelSizeMicrons, activeProfile.TelescopeSettings.FocalLength);
+            // The pitch of one pixel of the SAVED frames, read from a frame header rather than from the metadata
+            // (see ResolveEffectivePixelSizeAsync) — this is the single number every ImageSize x pixelSize
+            // product below turns into the sensor's physical extent, and getting it wrong scales the recovered
+            // thread pitch / stepper step size by the binning factor.
+            var pixelSizeResolution = await ResolveEffectivePixelSizeAsync(orderedRuns, metadata, profileService).ConfigureAwait(false);
+            double pixelSizeMicrons = pixelSizeResolution.Microns;
+            string pixelSizeProvenance = pixelSizeResolution.Provenance;
+            Console.WriteLine($"Pixel size: {F(pixelSizeMicrons)} um effective ({pixelSizeProvenance})");
+            if (EffectivePixelSize.DisagreesWithMetadata(pixelSizeResolution, metadata.PixelSizeMicrons)) {
+                // Expected, and benign, for any run saved before metadata schema 4 at a binning above 1x1: the
+                // stored value is the native pitch. Say so rather than silently disagreeing with the file.
+                Console.WriteLine($"  NOTE: metadata records {F(metadata.PixelSizeMicrons)} um. The frame header wins -- " +
+                    "a run saved before metadata schema 4 stored the NATIVE pitch, which would inflate the recovered " +
+                    "hardware by the binning factor.");
+            }
+
+            // PixelScale = arcsec/pixel of the frames as captured. Matches the live app, which multiplies the
+            // profile's native arcsec/pixel by the capture binning (HocusFocusStarDetection.ApplyDetectionImageContext).
+            var pixelScale = MathUtility.ArcsecPerPixel(pixelSizeMicrons, activeProfile.TelescopeSettings.FocalLength);
 
             // Resolve the detection params: stored optimized settings (default), a fresh optimization run, or the
             // optimizer is forced via --reoptimize. The result is applied only to this transient params object.
@@ -228,7 +239,7 @@ namespace TestApp {
                 Console.WriteLine($"Measuring 4-corner tilt for {run.Step} ({Path.GetFileName(run.Folder)}, {run.Frames.Count} frames x 5 regions) ...");
                 var sw4c = System.Diagnostics.Stopwatch.StartNew();
                 var stepResult = await MeasureTiltAsync(run, detection, detectionParams, regions, fRatio,
-                    metadata.FocuserStepSizeMicrons, metadata.PixelSizeMicrons,
+                    metadata.FocuserStepSizeMicrons, pixelSizeMicrons,
                     profileService, alglibAPI, afOptions.HyperbolicFitModel).ConfigureAwait(false);
                 perStep.Add(stepResult);
                 Console.WriteLine($"    [4-corner {run.Step}] done in {sw4c.ElapsedMilliseconds} ms");
@@ -256,7 +267,7 @@ namespace TestApp {
                 FallbackCurvatureSign = metadata.Calibration?.CurvatureSign ?? 0,
                 ImageWidthPixels = imageSize.Width,
                 ImageHeightPixels = imageSize.Height,
-                PixelSizeMicrons = metadata.PixelSizeMicrons,
+                PixelSizeMicrons = pixelSizeMicrons,
                 FocuserStepMicrons = metadata.FocuserStepSizeMicrons,
                 ScrewRadiusMillimeters = metadata.ScrewRadiusMillimeters,
                 CalibrationAppliedAmount = metadata.CalibrationAppliedAmount,
@@ -271,7 +282,7 @@ namespace TestApp {
                 Console.WriteLine($"Paraboloid (per-star) tilt for {run.Step} ...");
                 var mean = byStep[run.Step].Gradient.MeanFocuserPosition;
                 var ps = await MeasureTiltViaParaboloidAsync(run, detector, detectionParams, metadata.FocuserStepSizeMicrons,
-                    metadata.PixelSizeMicrons, mean, profileService, inspectorOptions, afOptions, alglibAPI,
+                    pixelSizeMicrons, mean, profileService, inspectorOptions, afOptions, alglibAPI,
                     diagDir: Path.Combine(outDir, "diag")).ConfigureAwait(false);
                 paraboloidSteps.Add(ps);
                 Console.WriteLine(ps.Fitted
@@ -296,7 +307,7 @@ namespace TestApp {
                     FallbackCurvatureSign = metadata.Calibration?.CurvatureSign ?? 0,
                     ImageWidthPixels = imageSize.Width,
                     ImageHeightPixels = imageSize.Height,
-                    PixelSizeMicrons = metadata.PixelSizeMicrons,
+                    PixelSizeMicrons = pixelSizeMicrons,
                     FocuserStepMicrons = metadata.FocuserStepSizeMicrons,
                     ScrewRadiusMillimeters = metadata.ScrewRadiusMillimeters,
                     CalibrationAppliedAmount = metadata.CalibrationAppliedAmount,
@@ -305,7 +316,7 @@ namespace TestApp {
                 paraboloidCalibration = TiltCalibrationCalculator.Calibrate(pinputs);
             }
 
-            WriteReport(outDir, metadata, optimizationSource, perStep, inputs, calibration, paraboloidSteps, paraboloidCalibration, pinputs, regions);
+            WriteReport(outDir, metadata, optimizationSource, perStep, inputs, calibration, paraboloidSteps, paraboloidCalibration, pinputs, regions, pixelSizeProvenance);
             Console.WriteLine($"Wrote tilt_summary.txt and tilt_summary.json to {outDir}");
         }
 
@@ -770,6 +781,42 @@ namespace TestApp {
         /// BuildDetectionContext each build their own source Mat), so one load per frame serves every region and
         /// every candidate evaluation.
         /// </summary>
+        /// <summary>
+        /// The EFFECTIVE pixel pitch of the saved frames — the camera's own pixel size times the binning they
+        /// were captured at — derived exactly as the live app derives it in
+        /// <c>HocusFocusStarDetection.BuildResultHeader</c>: <c>MetaData.Camera.PixelSize × max(BinX, 1)</c>.
+        ///
+        /// <para>Every consumer here multiplies this by a frame DIMENSION to get the sensor's physical extent, so
+        /// it must describe the same frame those dimensions came from. Under NINA's Auto Focus Binning of N the
+        /// frame is N× smaller per axis and each of its pixels N× coarser; pairing a binned frame with a native
+        /// pitch understates the sensor by N and inflates every recovered gradient — and with it the reported
+        /// thread pitch / stepper step size — by exactly N. That is the bug the wizard carried until
+        /// <c>TiltPlaneModel</c> started carrying its own pitch.</para>
+        ///
+        /// <para>Read from the FRAMES rather than from <c>metadata.PixelSizeMicrons</c> on purpose: that field is
+        /// the effective pitch only from metadata schema 4 onward and the NATIVE pitch before it, so trusting it
+        /// would silently reproduce the old inflation on every run an older wizard saved. The header is
+        /// unambiguous at every schema — both the FITS and XISF readers divide the stored (binned) XPIXSZ back out
+        /// by XBINNING, so <c>Camera.PixelSize</c> is always native and <c>BinX</c> always carries the factor.
+        /// Falls back to the metadata value only when a header carries no pixel size at all.</para>
+        /// </summary>
+        private static async Task<EffectivePixelSize.Resolution> ResolveEffectivePixelSizeAsync(
+            List<RunStep> orderedRuns, TiltCalibrationMetadata metadata, ProfileService profileService) {
+            var firstFrame = orderedRuns.SelectMany(r => r.Frames).OrderBy(f => f.Focuser).Select(f => f.Path).FirstOrDefault();
+            if (firstFrame == null) {
+                return EffectivePixelSize.FromMetadata(metadata.PixelSizeMicrons, "no frames to read a header from");
+            }
+            try {
+                var image = await DiagnosticUtil.LoadRenderedImage(firstFrame, profileService).ConfigureAwait(false);
+                var camera = image.RawImageData.MetaData.Camera;
+                return EffectivePixelSize.FromFrameHeader(
+                    camera.PixelSize, camera.BinX, metadata.PixelSizeMicrons, Path.GetFileName(firstFrame));
+            } catch (Exception ex) {
+                Logger.Warning($"Could not read the pixel size from {firstFrame}: {ex.Message}");
+                return EffectivePixelSize.FromMetadata(metadata.PixelSizeMicrons, $"header unreadable: {ex.Message}");
+            }
+        }
+
         private static async Task<List<(int Focuser, string Path, IRenderedImage Image)>> LoadRunImagesAsync(RunStep run, ProfileService profileService) {
             var result = new List<(int, string, IRenderedImage)>(run.Frames.Count);
             foreach (var (focuser, path) in run.Frames.OrderBy(f => f.Focuser)) {
@@ -819,9 +866,13 @@ namespace TestApp {
             string outDir, TiltCalibrationMetadata metadata, string optimizationSource, List<StepResult> perStep,
             TiltCalibrationInputs inputs, TiltCalibrationResult calibration,
             List<ParaboloidStepResult> paraboloidSteps, TiltCalibrationResult paraboloidCalibration,
-            TiltCalibrationInputs pinputs, List<StarDetectionRegion> regions) {
+            TiltCalibrationInputs pinputs, List<StarDetectionRegion> regions, string pixelSizeProvenance) {
 
             bool isStepper = inputs.IsStepperAdjustment;
+            // The pitch the calibration actually ran on, taken off the inputs Calibrate() consumed rather than
+            // re-read from the metadata — the two differ on a pre-schema-4 run captured with binning, and the
+            // report has to quote the number the numbers below were produced with.
+            double pixelSizeMicrons = inputs.PixelSizeMicrons;
             double groundTruthHardware = isStepper ? metadata.StepperStepSizeMicrons : metadata.ScrewThreadPitchMicrons;
             double measuredHardware = calibration.MeasuredHardwareMicrons;
             double hardwarePctDelta = (groundTruthHardware > 0 && !double.IsNaN(measuredHardware))
@@ -836,7 +887,10 @@ namespace TestApp {
             Line($"Screws: {metadata.NumberOfScrews}   Adjustment: {(isStepper ? "StepperMotors" : "Screws")}");
             Line($"Ground truth: radius={F(metadata.ScrewRadiusMillimeters)} mm, " +
                 $"{(isStepper ? "step size" : "thread pitch")}={F(groundTruthHardware)} um/{(isStepper ? "step" : "turn")}, " +
-                $"pixel={F(metadata.PixelSizeMicrons)} um, focuser={F(metadata.FocuserStepSizeMicrons)} um/step");
+                $"focuser={F(metadata.FocuserStepSizeMicrons)} um/step");
+            Line($"Pixel size: {F(pixelSizeMicrons)} um effective ({pixelSizeProvenance})" +
+                (metadata.PixelSizeMicrons > 0 && Math.Abs(pixelSizeMicrons - metadata.PixelSizeMicrons) > EffectivePixelSize.DisagreementToleranceMicrons
+                    ? $"; metadata records {F(metadata.PixelSizeMicrons)} um" : string.Empty));
             Line($"Applied per screw step: {F(metadata.CalibrationAppliedAmount)} {(isStepper ? "steps" : "turns")}");
             Line($"Expected Screw 1 angle: {F(metadata.ExpectedPositionAngleScrew1Deg)} deg   Defocus-aware: {metadata.DefocusAwareDetectionNeeded}");
             Line($"Detection settings source: {optimizationSource}");
@@ -978,8 +1032,8 @@ namespace TestApp {
             // vs. this harness's own paraboloid-predicted sag) — useful for noticing a large same-run disagreement,
             // but its magnitude should NOT be expected to reproduce the design doc's live-AF-report-derived ×2.
             var (cornerXNorm, cornerYNorm) = CornerDesignPoint(regions);
-            double sensorWidthMicrons = perStep[0].ImageSize.Width * metadata.PixelSizeMicrons;
-            double sensorHeightMicrons = perStep[0].ImageSize.Height * metadata.PixelSizeMicrons;
+            double sensorWidthMicrons = perStep[0].ImageSize.Width * pixelSizeMicrons;
+            double sensorHeightMicrons = perStep[0].ImageSize.Height * pixelSizeMicrons;
             double rEffMicrons = Math.Sqrt(Math.Pow(cornerXNorm * sensorWidthMicrons, 2) + Math.Pow(cornerYNorm * sensorHeightMicrons, 2));
             double rEffSquaredMicrons2 = rEffMicrons * rEffMicrons;
 


### PR DESCRIPTION
Closes the residual left open by #205.

## The problem

`TestApp tilt` still took its pixel pitch from `metadata.PixelSizeMicrons`. That field is the **effective**
(binning-scaled) pitch only from metadata schema 4 onward — #205's change — and the **native** pitch before it.
So on any run an older wizard saved at a binning above 1×1, the harness understated the sensor by the binning
factor and reproduced exactly the inflation the wizard itself used to report: a headless validator quietly
disagreeing with the tool it exists to validate, in the same direction, for the same reason.

## The fix

Read the pitch off a saved frame's own header instead: `Camera.PixelSize × max(BinX, 1)`, the same derivation
`HocusFocusStarDetection.BuildResultHeader` uses in the live app.

That is unambiguous at **every** metadata schema, because NINA's FITS and XISF readers both divide the stored
(binned) `XPIXSZ` back out by `XBINNING` on load:

```csharp
// NINA.Image/FileFormat/FITS/FITSHeader.cs — write, then read
Add("XPIXSZ", metaData.Camera.PixelSize * Math.Max(metaData.Camera.BinX, 1), ...);
metaData.Camera.PixelSize = ParseDouble(card.OriginalValue) / metaData.Camera.BinX;
```

so `Camera.PixelSize` is always native and `BinX` always carries the factor. The metadata value survives only
as the fallback for a frame that carries no pixel size at all.

**The same number also feeds the detection `PixelScale`** the harness tunes and scores with, which had the
identical native-pitch assumption — so a binned dataset was being optimized at the wrong arcsec/pixel too.

Provenance is printed to the console and into the report either way, with an explicit note when the header and
the metadata disagree — precisely the pre-schema-4 binned case, and worth saying out loud rather than silently
overriding the file:

```
Pixel size: 7.52 um effective (frame header: 3.76 um native x 2x2 binning)
  NOTE: metadata records 3.76 um. The frame header wins -- a run saved before metadata schema 4 stored the
  NATIVE pitch, which would inflate the recovered hardware by the binning factor.
```

## Structure

The whole decision lives in a pure `EffectivePixelSize` that the runner only calls — the same shape as
`TruthDisclosure` / `CapSemantics` — so it is reachable from unit tests even though `TiltCalibrationRunner`
loads NINA rendered images and cannot be linked into the test project.

## Testing

Full suite green: **4420 passed, 0 failed**. The 13 new `EffectivePixelSizeTests` were mutation-checked —
dropping the `× binning` fails 5 of them with the exact 3.76-instead-of-7.52 signature of the original bug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QTNWdSNar6g3Nj5wXnLZc6