### PR TITLE
Fix inspection crash when an AutoFocus frame detects no stars

### DIFF
--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/Inspection/SensorModelDegenerateFrameTests.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus.Tests/Inspection/SensorModelDegenerateFrameTests.cs
@@ -1,0 +1,239 @@
+#region "copyright"
+
+/*
+    Copyright © 2021 - 2026 George Hilios <ghilios+NINA@googlemail.com>
+
+    This Source Code Form is subject to the terms of the Mozilla Public
+    License, v. 2.0. If a copy of the MPL was not distributed with this
+    file, You can obtain one at http://mozilla.org/MPL/2.0/.
+*/
+
+#endregion "copyright"
+
+using NINA.Core.Model;
+using NINA.Image.ImageAnalysis;
+using NINA.Joko.Plugins.HocusFocus.Inspection;
+using NINA.Joko.Plugins.HocusFocus.Interfaces;
+using NINA.Joko.Plugins.HocusFocus.StarDetection;
+using NINA.Joko.Plugins.HocusFocus.Utility;
+using NINA.Profile.Interfaces;
+using NSubstitute;
+using NUnit.Framework;
+using System;
+using System.Collections.Generic;
+using System.Drawing;
+using System.Linq;
+using System.Threading;
+
+namespace NINA.Joko.Plugins.HocusFocus.Tests.Inspection {
+
+    /// <summary>
+    /// Frames that detect no stars (or too few to normalise brightness against) are a NORMAL outcome of an
+    /// AutoFocus sweep — the extreme-defocus endpoints and any frame lost to cloud — and the AutoFocus curve
+    /// fit already tolerates them by discarding the point. The sensor model must tolerate them too.
+    ///
+    /// <para>The regression this guards: <c>RegisterStarsAndFit</c> normalised each frame's brightness with an
+    /// unguarded <c>StarList.Max()</c>/<c>Min()</c>. A single starless frame threw
+    /// "Sequence contains no elements" and killed the whole aberration inspection AFTER a successful AF run,
+    /// and a single-star frame divided by a zero brightness range, producing a NaN
+    /// <see cref="HocusFocusDetectedStar.NormalisedBrightness"/> that silently made those stars unmatchable in
+    /// the KdTree brightness filter.</para>
+    /// </summary>
+    [TestFixture]
+    public class SensorModelDegenerateFrameTests {
+        private const int ImageWidth = 1000;
+        private const int ImageHeight = 1000;
+        private const double CenterX = ImageWidth / 2.0;
+        private const double CenterY = ImageHeight / 2.0;
+        private const double FocuserSizeMicrons = 5.0;
+        private const double PixelSize = 3.76;
+        private const int StepSize = 2000;
+        private const double FinalFocusPosition = 30000.0;
+
+        private static readonly int[] FocuserOffsets = { -8000, -6000, -4000, -2000, 0, 2000, 4000, 6000, 8000 };
+
+        private IAlglibAPI alglibAPI;
+
+        [SetUp]
+        public void SetUp() {
+            alglibAPI = new AlglibAPI();
+        }
+
+        [Test]
+        public void RegisterStarsAndFit_OneFrameDetectedNoStars_SkipsItAndStillFits() {
+            var frames = BuildFrames();
+            // The far-defocus endpoint of the sweep comes back empty, exactly as the detector reports it.
+            ReplaceStarList(frames[0], new List<DetectedStar>());
+
+            var reports = new List<string>();
+            var (model, _) = Run(frames, reports);
+
+            Assert.That(model, Is.Not.Null, "A starless frame must not prevent the remaining frames from fitting");
+            Assert.That(model.StarsInModel, Is.GreaterThanOrEqualTo(9));
+            Assert.That(reports, Has.Some.Contains("1 frame(s) had no detected stars"),
+                "The skipped frame should be surfaced in the registration report");
+            // A starless frame forms no triangles, so RANSAC must record it as unaligned rather than
+            // registering it on a transform estimated from nothing.
+            Assert.That(frames[0].HasBeenAligned, Is.False);
+        }
+
+        [Test]
+        public void RegisterStarsAndFit_MultipleFramesDetectedNoStars_SkipsThemAndStillFits() {
+            var frames = BuildFrames();
+            ReplaceStarList(frames[0], new List<DetectedStar>());
+            ReplaceStarList(frames[frames.Count - 1], new List<DetectedStar>());
+
+            var reports = new List<string>();
+            var (model, _) = Run(frames, reports);
+
+            Assert.That(model, Is.Not.Null);
+            Assert.That(reports, Has.Some.Contains("2 frame(s) had no detected stars"));
+        }
+
+        [Test]
+        public void RegisterStarsAndFit_FrameWithSingleStar_AssignsFiniteNormalisedBrightness() {
+            var frames = BuildFrames();
+            var singleStarFrame = frames[0];
+            ReplaceStarList(singleStarFrame, singleStarFrame.StarDetectionResult.StarList.Take(1).ToList());
+
+            var (model, _) = Run(frames, new List<string>());
+
+            Assert.That(model, Is.Not.Null);
+            var lone = (HocusFocusDetectedStar)singleStarFrame.StarDetectionResult.StarList.Single();
+            Assert.That(float.IsNaN(lone.NormalisedBrightness), Is.False,
+                "A single-star frame has no brightness range; the normalised value must not be NaN");
+            Assert.That(lone.NormalisedBrightness, Is.EqualTo(0.5f));
+        }
+
+        [Test]
+        public void RegisterStarsAndFit_FrameWithUniformBrightness_AssignsFiniteNormalisedBrightness() {
+            var frames = BuildFrames();
+            var uniformFrame = frames[0];
+            foreach (var star in uniformFrame.StarDetectionResult.StarList.Cast<HocusFocusDetectedStar>()) {
+                star.AverageBrightness = 1000.0;
+            }
+
+            var (model, _) = Run(frames, new List<string>());
+
+            Assert.That(model, Is.Not.Null);
+            Assert.That(uniformFrame.StarDetectionResult.StarList.Cast<HocusFocusDetectedStar>(),
+                Has.All.Matches<HocusFocusDetectedStar>(s => !float.IsNaN(s.NormalisedBrightness)),
+                "A frame whose stars are all equally bright has no brightness range to normalise against");
+        }
+
+        [Test]
+        public void RegisterStarsAndFit_NormalisedBrightnessUnchangedForHealthyFrames() {
+            // The degenerate-frame handling must not perturb the normal path: a frame with a brightness range
+            // still maps its faintest star to 0 and its brightest to 1.
+            var frames = BuildFrames();
+            Run(frames, new List<string>());
+
+            var healthy = frames[4].StarDetectionResult.StarList.Cast<HocusFocusDetectedStar>().ToList();
+            Assert.Multiple(() => {
+                Assert.That(healthy.Min(s => s.NormalisedBrightness), Is.EqualTo(0.0f).Within(1e-6f));
+                Assert.That(healthy.Max(s => s.NormalisedBrightness), Is.EqualTo(1.0f).Within(1e-6f));
+            });
+        }
+
+        [Test]
+        public void RegisterStarsAndFit_EveryFrameDetectedNoStars_ThrowsDescriptiveError() {
+            var frames = BuildFrames();
+            foreach (var frame in frames) {
+                ReplaceStarList(frame, new List<DetectedStar>());
+            }
+
+            // Without the guard the reference-frame index stays -1 and the run dies on an index-out-of-range
+            // deep inside alignment/matching, which says nothing about what actually went wrong.
+            var ex = Assert.Catch(() => Run(frames, new List<string>()));
+            Assert.That(ex.Message, Does.Contain("had any detected stars"));
+        }
+
+        private (SensorParaboloidModel, RegistrationAndFitResult) Run(List<SensorDetectedStars> frames, List<string> reports) {
+            var sensorModel = new SensorModel(
+                Substitute.For<IProfileService>(),
+                BuildInspectorOptions(),
+                new FakeAutoFocusOptions(),
+                alglibAPI) {
+                RegistrationReportSink = reports.Add
+            };
+
+            return sensorModel.RegisterStarsAndFit(
+                frames,
+                new Size(ImageWidth, ImageHeight),
+                FocuserSizeMicrons,
+                FinalFocusPosition,
+                PixelSize,
+                progress: new Progress<ApplicationStatus>(),
+                stepSize: StepSize,
+                ct: CancellationToken.None);
+        }
+
+        private static void ReplaceStarList(SensorDetectedStars frame, List<DetectedStar> starList) {
+            frame.StarDetectionResult.StarList = starList;
+        }
+
+        private static FakeInspectorOptions BuildInspectorOptions() {
+            return new FakeInspectorOptions {
+                // Exercise the alignment path, which is where a starless frame would otherwise fail to form
+                // triangles — it must degrade to "frame did not align" rather than throwing.
+                UseRANSAC = true,
+                RejectBadBrightnessMatches = false,
+                RejectBadlyFittingMatches = false,
+                StartingBrightnessDiff = -1,
+                MaxStarsPerRegion = -1,
+                FixedSensorCenter = true
+            };
+        }
+
+        // Mirrors SensorModelRepeatabilityTests' synthetic run: a 5x5 grid of stars swept through focus across
+        // 9 focuser positions, with a tilted + mildly curved best-focus surface.
+        private static List<SensorDetectedStars> BuildFrames() {
+            var starSpecs = new List<(double X, double Y, double BestFocus, double AvgBrightness)>();
+            double[] grid = { 180, 330, 500, 670, 820 };
+            int index = 0;
+            foreach (var gx in grid) {
+                foreach (var gy in grid) {
+                    var jitterX = ((index * 37) % 11 - 5) * 1.3;
+                    var jitterY = ((index * 53) % 11 - 5) * 1.3;
+                    var x = gx + jitterX;
+                    var y = gy + jitterY;
+                    var dx = x - CenterX;
+                    var dy = y - CenterY;
+                    var bestFocus = FinalFocusPosition + 0.9 * dx + 0.6 * dy + 0.0008 * (dx * dx + dy * dy);
+                    var avgBrightness = 800.0 + 40.0 * index;
+                    starSpecs.Add((x, y, bestFocus, avgBrightness));
+                    ++index;
+                }
+            }
+
+            const double minHfr = 1.5;
+            const double slopePerStep = 1.5 / 3000.0;
+            const double background = 80.0;
+
+            var frames = new List<SensorDetectedStars>();
+            foreach (var offset in FocuserOffsets) {
+                var focuserPosition = FinalFocusPosition + offset;
+                var starList = new List<DetectedStar>();
+                foreach (var spec in starSpecs) {
+                    var fromMin = focuserPosition - spec.BestFocus;
+                    var hfr = Math.Sqrt(minHfr * minHfr + slopePerStep * slopePerStep * fromMin * fromMin);
+                    starList.Add(new HocusFocusDetectedStar {
+                        HFR = hfr,
+                        Position = new Accord.Point((float)spec.X, (float)spec.Y),
+                        AverageBrightness = spec.AvgBrightness,
+                        MaxBrightness = spec.AvgBrightness * 2.0,
+                        Background = background,
+                        BoundingBox = new Rectangle((int)(spec.X - 5), (int)(spec.Y - 5), 10, 10)
+                    });
+                }
+
+                var result = new HocusFocusStarDetectionResult {
+                    StarList = starList,
+                    ImageSize = new Size(ImageWidth, ImageHeight)
+                };
+                frames.Add(new SensorDetectedStars(focuserPosition, result, image: null));
+            }
+            return frames;
+        }
+    }
+}

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/Inspection/SensorModel.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/Inspection/SensorModel.cs
@@ -499,21 +499,68 @@ namespace NINA.Joko.Plugins.HocusFocus.Inspection {
                 }
                 ReferenceImage = refIndex;
 
+                // refIndex stays -1 only when EVERY frame detected zero stars, which would index [-1] into the
+                // frame list further down (RANSAC alignment, or the KdTree match when RANSAC is off). Fail with
+                // a message that names the actual problem instead.
+                if (refIndex < 0) {
+                    throw new Exception($"Sensor modeling failed. None of the {allDetectedStars.Count} frames in this run had any detected stars.");
+                }
+
                 ct.ThrowIfCancellationRequested();
 
                 RegisteredStar[] registeredStars = null;
                 TrianglesByImage = new Dictionary<int, List<RANSACRegistration.StarTriangle>>();
 
                 // set relative brightness level for each star in each image
+                //
+                // Star detection legitimately returns an EMPTY star list for a frame (an extreme-defocus sweep
+                // endpoint, a frame lost to cloud), and the AutoFocus curve fit tolerates that by discarding the
+                // point (it filters on Y > 0). This loop did not: Max/Min over the empty list threw
+                // "Sequence contains no elements" and killed the whole inspection AFTER a successful AF run.
+                // Empty frames are skipped here and contribute nothing downstream: the KdTree match iterates
+                // their (empty) star list, and RANSAC alignment builds no triangles for them, so they end up
+                // reported as unaligned (see RANSACRegistration.BuildStarTriangles, which needed the same
+                // empty-input guard). They are deliberately left IN the list so frame indices stay aligned with
+                // ReferenceImage / TrianglesByImage and with the Review Frames snapshot, which is built from the
+                // same unfiltered list and is where the user goes to see which frame came back empty.
+                var framesWithoutStars = 0;
+                var framesWithoutBrightnessRange = 0;
                 foreach (var detectedStars in allDetectedStars) {
-                    double imageMaxBrightness = detectedStars.StarDetectionResult.StarList.Max(s => s.AverageBrightness);
-                    double imageMinBrightness = detectedStars.StarDetectionResult.StarList.Min(s => s.AverageBrightness);
-                    foreach (var (star, index) in detectedStars.StarDetectionResult.StarList
+                    var starList = detectedStars.StarDetectionResult.StarList;
+                    if (starList.Count == 0) {
+                        ++framesWithoutStars;
+                        continue;
+                    }
+
+                    double imageMaxBrightness = starList.Max(s => s.AverageBrightness);
+                    double imageMinBrightness = starList.Min(s => s.AverageBrightness);
+                    // A frame with a single star (or, degenerately, several of identical brightness) has no
+                    // brightness range to normalise against, and the division produced NaN. NaN silently poisons
+                    // the brightness-difference match filter in MatchStarsUsingKdTree — every |NaN - x| < tol
+                    // comparison is false, so those stars were unmatchable rather than merely unreliable — and
+                    // rides along into the RANSAC Point2D brightness component. Use the midpoint of the [0, 1]
+                    // normalised range instead: finite, in-range, deterministic, and (being equidistant from
+                    // both ends) the choice that minimises the worst-case error against the unknown true value.
+                    var brightnessRange = imageMaxBrightness - imageMinBrightness;
+                    var hasBrightnessRange = brightnessRange > 0.0;
+                    if (!hasBrightnessRange) {
+                        ++framesWithoutBrightnessRange;
+                    }
+                    foreach (var (star, index) in starList
                                                                     .Select((star, index) => ((HocusFocusDetectedStar)star, index))) {
-                        star.NormalisedBrightness = (float)((star.AverageBrightness - imageMinBrightness) / (imageMaxBrightness - imageMinBrightness));
+                        star.NormalisedBrightness = hasBrightnessRange
+                            ? (float)((star.AverageBrightness - imageMinBrightness) / brightnessRange)
+                            : 0.5f;
                         star.OriginalPosition = star.Position;
                         star.OriginalBoundingBox = star.BoundingBox;
                     }
+                }
+                if (framesWithoutStars > 0) {
+                    Logger.Warning($"{framesWithoutStars} of {allDetectedStars.Count} frames had no detected stars and contribute nothing to the sensor model. Review Frames shows which.");
+                    Report($"{framesWithoutStars} frame(s) had no detected stars and were skipped.  A run where every frame detects stars will give more reliable results.");
+                }
+                if (framesWithoutBrightnessRange > 0) {
+                    Logger.Warning($"{framesWithoutBrightnessRange} of {allDetectedStars.Count} frames had too few stars to normalise brightness against; their stars were assigned a neutral brightness.");
                 }
                 stopwatch.RecordEntry("normalise brightness");
                 ct.ThrowIfCancellationRequested();

--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/Utility/RANSACRegistration.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/Utility/RANSACRegistration.cs
@@ -270,6 +270,13 @@ namespace NINA.Joko.Plugins.HocusFocus.Utility {
             private List<double> normalizeBrightnesses(double minBrightness, double maxBrightness) {
                 var brightnesses = Points.Select(p => p.NormalisedBrightness).ToList();
                 double range = maxBrightness - minBrightness;
+                // Pass the values through unscaled when the frame has no brightness range, rather than dividing
+                // by zero: the resulting NaNs flow into AsBrightnessMatrix/AsShapeAndBrightnessMatrix and corrupt
+                // every triangle-similarity distance computed from them. Mirrors the guard normalizePositions
+                // (the sibling below, called on the same two arguments) has always had.
+                if (range <= 0.0) {
+                    return brightnesses;
+                }
                 for (int i = 0; i < brightnesses.Count; i++) {
                     brightnesses[i] = (brightnesses[i] - minBrightness) / range;
                 }
@@ -418,6 +425,15 @@ namespace NINA.Joko.Plugins.HocusFocus.Utility {
             // of an O(n) SameTriangle scan per candidate. Point2D uses reference equality, matching SameTriangle.
             var seenTriangles = new HashSet<(Point2D, Point2D, Point2D)>();
             int id = 0;
+            // A triangle needs three points, so a frame with fewer can produce none — and star detection
+            // legitimately returns zero stars for a frame (an extreme-defocus sweep endpoint, a frame lost to
+            // cloud). Bail out before the Min/Max below, which threw "Sequence contains no elements" on such a
+            // frame and took the whole aberration inspection down with it. Returning empty is what the caller
+            // already handles: no triangles means no putative matches, which means the frame simply fails to
+            // align (SensorModel reports "N frames failed to align").
+            if (point2Ds.Count < 3) {
+                return triangles;
+            }
             var brightnesses = point2Ds.Select(p => p.NormalisedBrightness);
             var minBrightness = brightnesses.Min();
             var maxBrightness = brightnesses.Max();


### PR DESCRIPTION
## The bug

A user hit this after a **successful** AutoFocus run (`HF_SequenceError.txt`):

```
ERROR|InspectorVM.cs|AnalyzeAutoFocusImpl|615|Inspection analysis failed
System.InvalidOperationException: Sequence contains no elements
   at System.Linq.Enumerable.MaxFloat[TSource,TResult](...)
   at ...Inspection.SensorModel.RegisterStarsAndFit(...) SensorModel.cs:line 509
```

A frame that detects **zero stars** is a normal outcome of an AF sweep — an extreme-defocus endpoint, or a frame lost to cloud. `HocusFocusStarDetection` returns such a frame with an empty `StarList` and `AverageHFR = 0`, and the AutoFocus curve fit already tolerates it by discarding the point (`focusPoints.Where(p => p.Y > 0.0)`). The sensor model did not.

That asymmetry is the bug: AF succeeds, broadcasts the run, and then the aberration inspection dies on the frame AF had already thrown away.

Reproduced in a test before fixing — one healthy frame plus one starless frame gives the exact exception type, message, and origin from the log.

## Fixes

**`SensorModel.RegisterStarsAndFit`** — normalised each frame's brightness with an unguarded `StarList.Max()`/`Min()`. Empty frames are now skipped, and reported via `Logger.Warning` plus a `Report(...)` line that appears in the registration report.

**`RANSACRegistration.BuildStarTriangles`** — took `Min()`/`Max()` over the point list before doing anything else, so the same frame crashed here too. (I had read this path as already safe; the regression test proved otherwise.) A triangle needs three points, so it now returns empty below that — which is exactly what the caller already handles: no triangles → no putative matches → frame reported unaligned.

**Empty frames stay in the frame list** rather than being filtered out, so indices stay aligned with `ReferenceImage`, `TrianglesByImage`, and the Review Frames snapshot — which is built from the same list and is where the user goes to see which frame came back empty.

**Latent NaN in the same normalisation** — a frame with a single star (or several of identical brightness) has a zero brightness range, so `(b - min) / (max - min)` produced `NaN`. That silently made those stars *unmatchable* in `MatchStarsUsingKdTree` (every `|NaN - x| < tol` is false) rather than merely unreliable, and rode along into the RANSAC brightness component. Now assigns `0.5f` — the midpoint of the `[0,1]` range: finite, in-range, deterministic, equidistant from both ends. `RANSACRegistration.normalizeBrightnesses` had the same division; its sibling `normalizePositions`, called on the same two arguments, always had the guard — the two now match.

**All-frames-empty** — `refIndex` stayed `-1` and would have indexed `[-1]` into the frame list inside alignment/matching. Now throws a message naming the actual problem.

Not a regression — this has been present since the RANSAC alignment work (`53a8bc8`).

## Tests

New `Tests/Inspection/SensorModelDegenerateFrameTests.cs`, 6 tests, all running through the real RANSAC alignment path:

| Test | Pins |
|---|---|
| One frame with zero stars | Fits anyway; report names it; the empty frame is recorded as *unaligned*, not registered on a transform estimated from nothing |
| Multiple frames with zero stars | Fits anyway; count reported correctly |
| Single-star frame | `NormalisedBrightness` is finite, `0.5f` |
| Uniform-brightness frame | No NaN |
| Healthy frames | Normalisation unchanged — min→0, max→1 |
| Every frame empty | Descriptive error, not an index-out-of-range deep in alignment |

Full suite: **4426 passed, 0 failed.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AEcUpJsdNjUhWE3vnrScwv