### PR TITLE
Refresh the manual against the code, and fix the drift found on the way

### DIFF
--- a/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/Properties/AssemblyInfo.cs
+++ b/Joko.NINA.Plugins/Joko.NINA.Plugins.HocusFocus/Properties/AssemblyInfo.cs
@@ -26,8 +26,8 @@ using System.Runtime.InteropServices;
 
 // [MANDATORY] The assembly versioning
 //Should be incremented for each new release build of a plugin
-[assembly: AssemblyVersion("4.0.0.17")]
-[assembly: AssemblyFileVersion("4.0.0.17")]
+[assembly: AssemblyVersion("4.0.0.18")]
+[assembly: AssemblyFileVersion("4.0.0.18")]
 
 // [MANDATORY] The name of your plugin
 [assembly: AssemblyTitle("Hocus Focus")]

--- a/documentation/docs/optimization/af-curve-fitting.md
+++ b/documentation/docs/optimization/af-curve-fitting.md
@@ -156,9 +156,12 @@ steps per side and is clamped to at least 1 (and to the focuser's limits when kn
 
 See [Step-size recommendation](step-size.md) for the full derivation.
 
-A degenerate or near-flat fit (no finite minimum, non-positive minimum HFR, or a curve that never
-reaches three times the minimum within the search budget) yields no usable half-width; the wizard then
-leaves your current step size unchanged rather than guessing. The recommendation is most reliable when
+A degenerate fit yields no usable half-width: no fit at all, a minimum that is not finite, or a non-positive
+minimum HFR. The wizard then leaves your current step size unchanged and marks the number as held rather than
+measured. A curve that never reaches three times the minimum within the bounded outward search from best focus is treated the same way
+only when the sweep cannot say whether the band was missed; when the sweep's own HFRs span less than three
+times their minimum, the band demonstrably was missed and the wizard widens the step to the most this sweep
+supports. The recommendation is most reliable when
 the fit is clean and the V-curve is well-formed, exactly the runs where the optimizer also scores high.
 
 !!! note

--- a/documentation/docs/optimization/exposure-recommendation.md
+++ b/documentation/docs/optimization/exposure-recommendation.md
@@ -46,6 +46,11 @@ t_{\text{new}} = t_{\text{old}} \left(\frac{10}{S_{\text{now}}}\right)^{2}
 where 10 is the shipped default Brightness Sensitivity gate: the faintest star that default,
 out-of-the-box gate would still admit.
 
+That law answers the signal question and nothing else. When the signal already meets the target but every
+usable frame is short of stars, the ratio is at or below 1 and the formula would argue for a shorter exposure,
+so the block sets the law aside; what it offers instead depends on whether the gate rejected anything. See
+[When the field is short of stars, not signal](#when-the-field-is-short-of-stars-not-signal).
+
 Below `MinFramesForRecommendation` = 3 usable frames, with no per-star SNR data recorded, or with a
 non-positive current exposure to scale from, there is not enough to trust a derived number: the block
 still names the floored gate, but the recommended-exposure row and its number are hidden. Older saved
@@ -108,18 +113,50 @@ evenly, so a value capped at 30 s always rounds to exactly 30 s, never past it.
     ```
 
     Its tooltip carries the arithmetic: "Sky-limited scaling: 3 s × (10 / 4.1)² = 18 s per frame,
-    roughly 3 minutes per auto-focus run. Capped at 12 s: one run may not raise the exposure by more than
-    4x, so a second run refines it."
+    roughly 3 minutes per auto-focus run. Capped at 12 s: one run raises exposure at most 4x. Run again to
+    refine."
 
 ## What it never does
 
-The recommender never proposes a **shorter** exposure than the one the run already used. If your
-brightest stars already clear the default gate (\(S_{\text{now}} \ge 10\)), the block says exactly that:
-exposure is not what is limiting this run, and the floored gate is instead admitting a long tail of far
-fainter candidates below your genuinely bright stars. When even one frame found fewer stars than the
-objective's star-count target, the block adds the count: "N of M frames found fewer stars than the
-star-count target, so the low gate is scraping for count in a star-poor field." That is a different
-problem than exposure.
+The recommender never proposes a **shorter** exposure than the one the run already used. When the measured
+signal already meets the target (\(S_{\text{now}} \ge 10\)) and at least one frame found a full
+\(N_{\text{target}}\) stars, the block says so: "Star brightness is not the problem: your brightest stars
+measure S/N 22.4, meeting the default S/N target of 10. Brightness Sensitivity is low, so far fainter
+candidates are being admitted below them." If some, but not all, frames came up short of the star-count
+target it adds the count: "3 of 9 frames found fewer stars than the star-count target; Brightness Sensitivity
+is low to scrape for count in a star-poor field."
+
+The instruction it ends on is about the gate, not the exposure: "The gate was lowered to admit more
+candidates, not because star brightness was missing. Set Brightness Sensitivity by hand in the star detection
+options and run this wizard again in 'use current settings' mode to compare that landing against this one."
+
+## When the field is short of stars, not signal
+
+When \(S_{\text{now}}\) meets the target but **every** usable frame found fewer than \(N_{\text{target}}\)
+stars, the run is short of stars rather than short of signal, and the sky-limited law has nothing to derive
+from. The block splits that case on one further measurement: did the Brightness Sensitivity gate reject any
+candidate?
+
+If the gate rejected candidates, or if it is provably inert, more signal might still convert something. The
+gate is inert when its threshold sits at or below Star Peak Response times the effective Star Clipping
+Multiplier, because the clipping stage guarantees every candidate that reaches the gate already measures above
+that, so a count of zero rejections there is empty by construction rather than evidence. The block then offers
+a fixed **2× probe** with its own stopping rule instead of a derived number: "All 9 frames found fewer stars
+than the star-count target: the stars found are bright enough (S/N 14.2), there are just too few. A longer
+exposure may or may not find more; try doubling it, and if the star count does not rise, the field is the
+limit and no exposure will fix it." The row's tooltip says the same about the arithmetic, that there is no S/N
+shortfall to derive from, and it names the 30 s ceiling when a doubling would cross it. The run-relative 4×
+cap never binds on a probe that only doubles.
+
+If the gate could have rejected something and did not, the run has shown that these frames hold every star the
+detector can find, and no exposure is offered: "All 9 frames found fewer stars than the star-count target, and
+no candidate was rejected for being too faint — these frames contain every star the detector can find. A
+longer exposure will not add more. Long focal lengths see few stars per frame; detection binning, a wider
+field, or accepting that this field supports fewer stars are the options."
+
+In both states the block adds a sweep-geometry note when candidates were discarded for being flat and
+featureless. That happens on frames far enough from focus that stars spread into plain discs, which no
+exposure recovers; a smaller step size keeps more of the sweep close enough to focus to be measurable.
 
 ## Live vs. saved runs
 
@@ -138,10 +175,10 @@ auto-focus exposure to about the recommended value in NINA's focuser options and
 Live mode once you have frames at the new exposure.
 
 Whichever of those three shapes applies, the block adds the same rider whenever the number it just quoted
-was trimmed by the absolute 30 s ceiling rather than the run-relative 4× cap: "if you are shooting
-narrowband, consider auto-focusing through a broadband filter with a filter offset instead." The capped
-number is still worth capturing in that case — the rider offers an alternative alongside it, not a
-replacement.
+was trimmed by the absolute 30 s ceiling rather than the run-relative 4× cap: the sentence loses its full stop
+and continues "; or, if you shoot narrowband, auto-focus through a broadband filter with a filter offset
+instead." The capped number is still worth capturing in that case: the rider offers an alternative alongside
+it, not a replacement.
 
 **Accepting the run in front of you is still a legitimate choice** in every case: the settings it found
 are the best fit for the frames you actually have.
@@ -155,19 +192,19 @@ are the best fit for the frames you actually have.
 
 ## When exposure has run out
 
-There is a second state, beyond the \(S_{\text{now}} \ge 10\) case in [What it never
-does](#what-it-never-does), where the block does not offer a longer exposure: the run's exposure is
+There is a third state where the block does not offer a longer exposure, beyond the \(S_{\text{now}} \ge
+10\) case in [What it never does](#what-it-never-does) and the no-rejections case in [When the field is
+short of stars, not signal](#when-the-field-is-short-of-stars-not-signal): the run's exposure is
 already at or past the 30 second absolute ceiling (see [The two caps](#the-two-caps)), and the measured
 signal still falls short of the default gate (\(S_{\text{now}} < 10\)). Unlike the \(S_{\text{now}} \ge
 10\) case, this is not a healthy field — the data genuinely wants more exposure. But the recommender's
 raw, uncapped factor would ask for something past 30 s, and the absolute cap pulls that back down to the
 current exposure rather than proposing anything shorter, so there is nothing longer left to recommend.
-The block says so directly: "Reaching the default gate would take longer per frame than an auto-focus
-sweep can spend, so there is no longer exposure to offer."
+The block says so directly: "Reaching the default S/N target would need more time per frame than an
+auto-focus sweep can spend; no longer exposure is offered."
 
-With the exposure route genuinely exhausted, the block's remedy here is a different lever entirely: "If
-you are shooting narrowband, consider auto-focusing through a broadband filter with a filter offset
-instead."
+With the exposure route genuinely exhausted, the block's remedy here is a different lever entirely: "If you
+shoot narrowband, auto-focus through a broadband filter with a filter offset instead."
 
 A narrowband filter passes so little broadband sky and star light that the exposure this recommendation
 would need to reach the default gate is already impractical for an autofocus sweep. Auto-focusing through

--- a/documentation/docs/optimization/index.md
+++ b/documentation/docs/optimization/index.md
@@ -114,14 +114,24 @@ A live run goes like this:
    on the current focuser position, so it has to start near focus.
 2. Choose **Live Auto-Focus**, set the **Exposure**, and choose the folder to **Save captured frames
    to**. The camera and focuser must be connected, and **Start** stays disabled until you pick a save
-   folder. The panel also shows the step size, number of points, capture binning, filter, and gain the
-   sweep will use; these come from your profile's auto-focus settings. **Detection binning** can also be
-   changed here; the whole search is tuned at whatever factor is in effect when the run starts (see
+   folder. The panel also shows the step size, capture binning, filter, and gain the sweep will
+   use; these come from your profile's auto-focus settings. **Focus recovery (extra
+   steps/side)** is editable and defaults to 1. Each recovery step widens the captured sweep by
+   one extra focuser step on each side, so the curve can still bracket focus when you start well
+   off it. Those outer frames are down-weighted in the fit and exempt from the star-count
+   requirements. Set it to 0 to capture exactly your profile's sweep. **Number of points** and
+   **Total frames** follow from the widened sweep, and **Estimated time** multiplies those
+   frames by the exposure you set here; the estimate counts exposure only, not
+   downloads or focuser moves. **Detection binning** can also be changed here; the whole search is
+   tuned at whatever factor is in effect when the run starts (see
    [Detection Binning](../settings/detection-binning.md)). A Replay run has the same control.
 3. Press **Start** and confirm the telescope is roughly focused when prompted. The wizard moves the
    focuser out and steps back across the range set by your profile's auto-focus step size and offset
-   steps, saves a frame at each point, then returns the focuser to where it started. The sweep does not
-   try to converge, so it captures a full set of frames even when the current settings detect nothing.
+   steps plus the recovery steps, saves a frame at each point, then returns the focuser to where it
+   started. The sweep does not try to converge, so it captures a full set of frames even when the
+   current settings detect nothing. If the outermost positions come back starless and no focus curve
+   can be fit at all, the wizard widens the recovery exemption far enough to leave those positions
+   out of the curve, optimizes on the rest, and says so on the page.
 4. From there the run behaves like a replay: the frames are optimized and the summary appears.
 
 !!! tip "Make the exposure long enough for the wings of the sweep"
@@ -176,7 +186,8 @@ ground-truth labels are present a further term \( W_\ell = 0.25 \) is added and 
 renormalized to sum to one. The weighted score is then scaled by two multiplicative penalties that
 default to 1.0: one for defocus-relaxed junk, and one for leaning on a saturated bright star's
 inflated HFR. A hard floor guards against starved frames: if any frame falls below 3 accepted stars,
-that run scores \( J_{\text{run}} = 0 \).
+that run scores \( J_{\text{run}} = 0 \). A Live sweep's focus-recovery frames are exempt, since they
+are captured beyond the profile's sweep and are expected to be sparse.
 
 The full breakdown of each sub-score lives on the dedicated pages below.
 

--- a/documentation/docs/optimization/objective-function.md
+++ b/documentation/docs/optimization/objective-function.md
@@ -35,6 +35,27 @@ J_{\text{run}} \;=\; \frac{W_f\,S_{\text{focus}} + W_s\,S_{\text{stars}} + W_c\,
 The label term and \(W_\ell\) are present only when labels exist for the run; otherwise both the numerator
 term and the denominator term are dropped (the weights always renormalize to sum to 1).
 
+One last step follows the penalties. Most of the sub-scores stop improving once the data is good enough:
+\(S_{\text{stars}}\) saturates once the counts clear their knees, \(S_{\text{fit}}\) once the fit is clean, and
+\(S_{\text{focus}}\) flattens out as the focus uncertainty falls below its reference. On an easy run \(J\)
+therefore sits at 1.0, or a hair under, across a whole plateau of settings, and a search that accepts only
+strictly-improving moves stops at an arbitrary point on that plateau. So the score is blended with a small
+tie-breaker \(T\) that never saturates:
+
+\[
+J_{\text{run}} \;\leftarrow\; (1 - W_{\text{tie}})\,J_{\text{run}} + W_{\text{tie}}\,T, \qquad
+T = 0.6\,\frac{\bar{n}}{\bar{n} + N_{\text{target}}} + 0.4\,\frac{\rho_{\text{ref}}}{\rho_{\text{ref}} + \rho},
+\qquad W_{\text{tie}} = 0.02
+\]
+
+Here \(\bar{n}\) is the mean accepted-star count over the sweep's frames, leaving out the focus-recovery frames
+described below, while \(\rho\), \(\rho_{\text{ref}} = 0.25\) and \(N_{\text{target}} = 20\) are the normalized
+focus uncertainty, its reference value, and the median star-count knee, all defined in the sections below. Neither term saturates: the first
+keeps rising with star count, the second as focus uncertainty falls. \(T\) therefore still has a gradient where
+the primary sub-scores have none, and because \(W_{\text{tie}}\) is small, a real difference in \(J\) still
+decides the ranking. A genuine tie goes to the star-rich, sharper setting. A run
+that hits one of the hard floors below scores zero and is never blended.
+
 | Weight | Symbol | Value | Rewards |
 |---|---|---|---|
 | Focus | \(W_f\) | 0.55 | A tight, repeatable best-focus position |
@@ -61,8 +82,11 @@ Before any of the weighted math, two hard constraints can force \(J_{\text{run}}
 
 - **Starved frames.** If more than \(\text{MaxFramesBelowHardFloor} = 0\) frames have fewer than
   \(N_{\text{hard}} = 3\) accepted stars, the run scores zero. In other words, **every** frame in the sweep
-  (including the most defocused extremes) must hold at least 3 stars. A setting that loses the curve at the
-  ends is rejected outright.
+  must hold at least 3 stars. A setting that loses the curve at the ends is rejected outright. A Live sweep's
+  focus-recovery frames are the one exception: the extra positions added by **Focus recovery (extra
+  steps/side)** on the start page are tagged, and a tagged frame is exempt from this floor and left out of
+  \(S_{\text{stars}}\), because it sits far enough from focus to be sparse by design. A replayed run carries
+  no recovery tags, so there the floor applies to every frame.
 - **Unusable focus uncertainty.** If the fit produces no finite \(\sigma_{\text{focus}}\) and no finite
   leave-one-out fallback, the run scores zero.
 
@@ -275,6 +299,7 @@ Two properties make this safe:
 | Curve-fit weight | \(W_c\) | 0.25 | \(S_{\text{fit}}\) |
 | Coverage weight | \(W_{\text{cov}}\) | 0.05 | \(S_{\text{cov}}\) |
 | Label weight | \(W_\ell\) | 0.25 | \(S_{\text{label}}\) (labels only) |
+| Tie-breaker weight | \(W_{\text{tie}}\) | 0.02 | Plateau tie-breaker blend |
 | Focus reference | \(\rho_{\text{ref}}\) | 0.25 | \(S_{\text{focus}}\) |
 | Min-count knee | \(N_{\text{floor}}\) | 8 | \(S_{\text{stars}}\) |
 | Median-count knee | \(N_{\text{target}}\) | 20 | \(S_{\text{stars}}\) |

--- a/documentation/docs/optimization/search-variables.md
+++ b/documentation/docs/optimization/search-variables.md
@@ -17,7 +17,7 @@ Each row is one tunable axis. **Type** governs quantization (see [Quantization r
 | `StarClippingMultiplier` | Continuous | 0.25 | 10 | 0.5 | Star clipping multiplier |
 | `NoiseClippingMultiplier` | Continuous | 1 | 10 | 0.5 | Noise clipping multiplier (see [structure detection](../settings/structure-detection.md)) |
 | `PeakResponse` | Continuous | 0.1 | 1 | 0.05 | Peak response / flatness gate (see [acceptance gates](../settings/acceptance-gates.md)) |
-| `MaxDistortion` | Continuous | 0.1 | 1 | 0.1 | Max distortion gate |
+| `MaxDistortion` | Continuous | 0.1 | 0.785 (π/4) | 0.1 | Max distortion gate |
 | `MinHFR` | Continuous | 0.1 | 5 | 0.25 | Minimum HFR |
 | `StarCenterTolerance` | Continuous | 0.05 | 1 | 0.05 | Star center tolerance |
 | `StructureLayers` | Integer | 1 | 8 | 1 | Structure layers (see [structure detection](../settings/structure-detection.md)) |
@@ -31,6 +31,8 @@ Each row is one tunable axis. **Type** governs quantization (see [Quantization r
 Those are the **12** always-on axes. The two synthetic rows in the table above (`DefocusAwareGates`, `DefocusAwareStructure`) plus seven further defocus-tuning knobs (`DefocusDistortionSizeReference`, `DefocusDistortionMinFactor`, `DefocusCenteringToleranceFactor`, `DonutMorphCloseSize`, `DonutMinAnnularityHoleFraction`, `DonutMaxStreakEccentricity`, `DonutSaturationBloomRadius`) are added only when *Recover out-of-focus donut stars* is enabled, taking the curated set to **21** axes. With that master toggle off (the default) the optimizer never touches any defocus parameter.
 
 Several bounds are open-ended in the detector (there is no hard UI validation range), so the wizard applies pragmatic heuristic limits. `Sensitivity` was widened from a 20 to a 50 ceiling and `StarClippingMultiplier` to a `[0.25, 10]` range because rich star fields kept pinning the older, tighter bounds.
+
+`MaxDistortion` is the exception: its ceiling is geometric, not heuristic. Despite the name, the setting is a minimum fill ratio, and the gate rejects a candidate whose star pixels fill less of its bounding box than the threshold, so raising it makes the gate stricter (see [Max Distortion](../settings/acceptance-gates.md#max-distortion)). A perfectly round star can only reach the fill ratio of a disk inscribed in its own box, π/4 ≈ 0.785, so any threshold above that rejects every round star. The search axis stops there rather than leaving a dead band the pattern search could walk into.
 
 The two highest-impact axes, `Sensitivity` and `StarClippingMultiplier`, are also the pair the search grids over first in its coarse Phase A (see [search algorithm](search-algorithm.md)).
 

--- a/documentation/docs/optimization/step-size.md
+++ b/documentation/docs/optimization/step-size.md
@@ -24,7 +24,11 @@ which the fitted HFR reaches \(3 \times \text{HFR}_{\min}\): a coarse outward wa
 bisection refines it to high precision. The search is bounded (at most a few times the sampled focuser span)
 so a flat or degenerate fit cannot send it off to infinity. The left and right offsets are **averaged** so an
 asymmetric model still yields a single half-width; if only one side reaches the target, that side is used on
-its own, and if neither does, the recommender leaves your current step alone.
+its own. If neither side reaches it, the recommender checks what the sweep itself measured: when the sweep's
+own HFRs span less than three times their minimum, the band demonstrably was never sampled, so it widens the
+half-width to the most this sweep supports rather than holding your current step. Holding would stall a
+too-shallow sweep for good, since the next run would sweep at that same step again. Only when the sweep cannot
+say either way does the recommender leave your step alone.
 
 ![Step size derived from the 3x-minimum-HFR half-width with about 3.5 points per side](../assets/figures/step-size.png){ width=620 }
 *The shaded band spans the region where HFR is below three times its minimum. The recommended step (green lines)
@@ -50,16 +54,32 @@ that many points on each side of the estimated minimum lands neatly inside the f
     exceed the focuser's travel.
 
     The half-width is therefore capped at **1.5× the sampled half-span**, and the summary marks the
-    recommendation *capped by this sweep's width; re-run auto-focus to refine*. The cap does not change where
-    the recommendation converges, only how fast: each run widens the sweep, and a shallow rig reaches the same
-    answer in about three runs. It only engages when the sweep's ends reach less than roughly 2.1× the minimum
-    HFR; a well-shaped sweep is untouched.
+    recommendation as a partial step, naming how far this sweep reached and how fast it is converging: "14 → 24
+    (partial step: this sweep reaches 1.8× its minimum HFR and the step is sized from where HFR reaches 3×;
+    each run widens by about 1.7× until it gets there; re-run auto-focus to refine)". The cap does not change
+    where the recommendation converges, only how fast: each run widens the sweep, and a shallow rig reaches the
+    same answer in about three runs. It only engages when the sweep's ends reach less than roughly 2.1× the
+    minimum HFR; a well-shaped sweep is untouched.
+
+Capping the half-width at 1.5× the sampled half-span bounds how far one run may widen the sweep; a second bound works in the other direction. The
+half-width is also limited by the outermost offset from focus at which an ordinary (non-recovery) frame still
+detected the hard floor of three stars, so a fitted band reaching past where this run could still see stars is
+pulled back toward what the sweep measured. The 3× band is pure curve geometry and asks nothing about whether
+stars are still visible out there; this bound is measured, so it can only ever report a distance the sweep
+actually visited. It only ever tightens, and it may not pull the half-width below half the sampled half-span
+in one run, so a sweep whose only star-bearing frames sit near focus roughly halves the step instead of
+collapsing. The bound is absent when every sampled frame cleared the floor, the ordinary case on a healthy
+sweep, and it needs at least three qualifying frames: below that the recommender treats the limit as
+unmeasured rather than as proof that nothing is detectable.
 
 !!! note "Degenerate fits are left alone"
-    If the fit is missing, its minimum is not finite, the minimum HFR is not positive, or the curve never
-    reaches three times its minimum on either side within the bounded search, the recommender returns your
-    **current** step unchanged (with an undefined half-width) rather than guessing. You only get a new number
-    when the curve genuinely supports one.
+    If the fit is missing, its minimum is not finite, or the minimum HFR is not positive, the recommender
+    returns your **current** step unchanged (with an undefined half-width) rather than guessing. A curve that
+    never reaches three times its minimum on either side within the bounded search is treated the same way,
+    unless the sweep's own HFRs prove the band was never sampled, in which case the step is widened instead.
+    A held value is labeled as one: the summary reads "21 (NOT measured: the fitted curve has no usable
+    best-focus point, so your current step size was kept [non-finite-vertex])", so a number that was held is
+    never mistaken for a number that was measured.
 
 !!! tip "How to use the recommendation"
     Treat it as a starting point for your profile's **Auto Focus Step Size** on the same rig and filter. With

--- a/documentation/docs/overview/autofocus.md
+++ b/documentation/docs/overview/autofocus.md
@@ -9,7 +9,7 @@ A focus sweep produces a set of (focuser position, HFR) points that form a V: sh
 - **Multiple curve-fitting models.** Hyperbolic (several asymmetric variants), parabolic, and trendline fits, each with a goodness-of-fit rejection gate (\(R^2\) or reduced \(\chi^2\)). See [Hyperbolic Curve Fitting](hyperbola-fitting.md) for the model formulas and when each applies.
 - **Hybrid model selection.** At the end of a run every hyperbolic model is refit and the one with the least expected error for the best-focus position is kept, so each run self-selects its most trustworthy fit.
 - **Weighted fitting.** Each point carries its own measurement uncertainty \(\sigma\) (the per-frame star-HFR scatter), and the fit can weight points by \(1/\sigma^2\) so a noisy point counts for less.
-- **Outlier rejection.** An iterative two-tailed Grubbs test removes points that do not belong on the curve (e.g. a frame ruined by a cloud or satellite).
+- **Outlier rejection.** An iterative two-tailed Grubbs test can drop points that do not belong on the curve (e.g. a frame ruined by a cloud or satellite). It removes nothing until you raise **Max Outlier Rejections**, which is 0 by default.
 - **Stability reporting.** A leave-one-out (LOO) cross-validation estimates how much the best-focus position would move if any single point were dropped.
 - **HFR-improvement validation.** An optional before/after check confirms the run actually made the stars sharper, retrying the run if it did not.
 
@@ -26,7 +26,9 @@ A focus sweep produces a set of (focuser position, HFR) points that form a V: sh
 
 **Initial HFR (optional).** When *Validate HFR Improvement* is on, the engine first takes Frames Per Point exposures at the starting position and averages their HFR into the baseline `InitialHFR`.
 
-**Bracketing the minimum.** The focuser moves outward by the configured offset-steps × step-size, then steps back inward. After each group of frames a trendline is refit to all points collected so far; the sweep continues until the trendline establishes a clear minimum with enough points on both sides, then queues whatever extra points are needed to reach the target count on each side of the V.
+**Bracketing the minimum.** The focuser moves outward by the configured offset-steps × step-size, then steps back inward. After each group of frames a trendline is refit to all points collected so far; the sweep continues until the trendline establishes a clear minimum with enough points on both sides, then queues whatever extra points are needed to reach the target count on each side of the V. **Max Blind Steps Per Direction** limits how far the sweep walks one way without bracketing focus. Any step that lowers the lowest measured HFR resets the count, so only steps that make no progress add to it; when the limit is reached the focuser returns to the starting position and the sweep walks the other way once.
+
+**Frames with no usable stars.** When the detector finds no usable stars in a frame, that point measures an HFR of 0 and is left out of every fit. Failed points are also counted: when that count reaches the sweep's initial offset steps, the attempt stops walking that direction. With **Max Blind Steps Per Direction** above 0 it reverses once and keeps going; otherwise the attempt ends, NINA shows a warning, and the whole run is retried up to NINA's configured number of attempts. Longer exposures, or detection settings tuned for the defocused ends of the sweep, are the usual fix.
 
 **Per-point measurement.** At each focuser position the engine collects Frames Per Point frames, runs star detection on each, measures HFR, and, when more than one frame is taken, combines them into a single point with an associated \(\sigma\). The fit is updated live as each new point arrives, so the chart fills in during the run.
 
@@ -83,11 +85,12 @@ All tooltips below are quoted verbatim from the plugin UI.
 | **Fit Rejection Criterion** | R² | R² / Reduced χ² | "Which goodness-of-fit metric decides whether an auto-focus run is rejected. R² (default) keeps the existing behavior, rejecting when the fit's R² falls below NINA's R² threshold (Focuser settings). Reduced χ² instead rejects when the hyperbolic fit's reduced χ² exceeds the threshold below — a scatter-units goodness-of-fit bound for a focus curve, but it is only valid when 'Weighted Hyperbolic Fit' is enabled (it relies on per-point measurement σ). Quadratic and trendline fits always use R² regardless of this setting." |
 | **Reduced χ² Rejection Threshold** | 5.0 | 0–1000 (0 disables) | "Upper bound on the hyperbolic fit's reduced χ² (χ² per degree of freedom) above which the run is rejected, when the rejection criterion is set to Reduced χ². … Treat this threshold as a coarse sanity bound rather than a calibrated statistical test. Set to 0 to disable. Meaningful only with weighted fits." |
 | **R² Rejection Threshold** | from NINA | 0–1 | "The minimum R² (coefficient of determination) below which an auto-focus run is rejected, when the rejection criterion is set to R². This is NINA's own R² threshold from the Focuser settings; editing it here changes that same profile setting. R² closer to 1 indicates a better fit to the measured focus curve." |
-| **Max Outlier Rejections** | 1 | ≥ 0 | "Controls the maximum number of points that can be rejected as outliers during Auto Focus curve fitting." |
+| **Max Outlier Rejections** | 0 | ≥ 0 (0 disables) | "Controls the maximum number of points that can be rejected as outliers during Auto Focus curve fitting." |
 | **Outlier Rejection Confidence** (entered as a percentage) | 0.95 | > 0.5, < 1.0 | "Confidence level for a two-tailed Grubbs statistical test of outliers to use during Auto Focus curve fitting. 95% is a reasonable default. Must be above 50% and below 100%." |
 | **Save** | Off | — | "Saves details about every Auto Focus run, including a copy of the image, the star detection results, and the stretched annotated image" |
 | **Save Path** | (empty) | folder | "The folder to save Auto Focus runs" |
 | **Focuser Offset** | 0 | any | "Advanced Only! Moves the focuser this fixed amount at the end of an AutoFocus" |
+| **Max Blind Steps Per Direction** | 8 | ≥ 0 (0 disables) | "Maximum number of blind AutoFocus steps attempted in each direction before reversing to try the other side. Set to 0 to disable the cap." |
 
 !!! tip "When these help"
     - Leave **Weighted Hyperbolic Fit** on and **Hyperbolic Fit Model** set to **Hybrid (Best Fit)**. Those are the defaults, and they let each run pick its most reliable model and discount noisy points; only the reduced-\(\chi^2\) gate depends on the weighting being enabled.
@@ -101,7 +104,8 @@ Two separate settings decide how many pixels an autofocus frame is measured on.
 **NINA's Auto Focus Binning** (Options → Focuser, and per filter in the filter wheel settings) changes the
 capture: the camera returns a smaller frame with larger pixels. Set it to the binning you image at, so focus
 is found for the frames you actually shoot. Hocus Focus reads it back from the frame's metadata to compute
-pixel scale.
+pixel scale, and everything built on that scale uses the binned pitch, including the calibration in the
+[Tilt Adapter Wizard](tilt-adapter-wizard.md).
 
 **Hocus Focus Detection Binning** (Star Detector tab, default **1x1**) does not touch the capture. It
 resamples the frame for star detection only, to bring star sizes into the range the detector is tuned for,
@@ -112,6 +116,31 @@ setting recommends a factor from your last measured in-focus HFR, and you choose
 The two multiply. If you raise Detection Binning while Auto Focus Binning is above 1x1, Hocus Focus explains
 the difference and offers to set the NINA setting back to 1x1. The recommendation already accounts for camera
 binning, so it backs off on its own when the camera is already binning.
+
+## Replaying and reviewing a run
+
+The **Auto Focus** panel in NINA's **Imaging** tab carries three controls of its own, below the chart.
+
+**Replay Saved AF** re-runs the analysis on a run you saved earlier, with no hardware involved. Point it at the
+`AutoFocus_<date>_<time>` folder, or at the `attemptNN` folder inside it when a run needed more than one attempt.
+If the saved run recorded the settings it was captured with, a prompt asks how to replay it:
+
+- **Use current settings**: replay with your current profile's detection and AutoFocus settings.
+- **Use the captured settings (don't change my profile)**: replay with the settings from when the run was
+  captured, held in memory only.
+- **Update my profile to the captured settings**: overwrite your profile's detection, AutoFocus, and ROI settings
+  with the captured ones, then replay.
+
+**Keep frames for review** keeps every frame of a run started from this panel in memory so you can look at it
+afterwards. It is off by default and applies only to runs started here: auto focus during an imaging sequence
+never keeps frames. The frames are released when you start another run or close the review window. With [**Fit
+PSF**](../settings/psf-modeling.md) enabled on the Star Detector tab, a run kept for review also fits PSF models,
+which a normal auto-focus run skips for speed; the HFR points are the same either way.
+
+**Review Frames** opens the review window on the last run started from this panel, one frame at a time: the frame
+with its detected stars drawn to your Star Annotator settings, the focuser position, **Detected stars**, and the
+frame's median HFR (its mean, if **Measurement Averaging** is set to Mean + Outlier Detection). It is the fastest
+way to see which frame of a sweep came up empty, and what the detector made of the rest.
 
 ## How it uses the star detector
 

--- a/documentation/docs/overview/camera-simulator-rendering.md
+++ b/documentation/docs/overview/camera-simulator-rendering.md
@@ -11,7 +11,9 @@ position and the aberration surface, renders a point-spread function of the righ
 the star's magnitude into photoelectrons, and stamps the result into an electron accumulator. A
 uniform sky and dark-current background is added, and the accumulated electrons are then developed
 into a 16-bit frame by applying photon noise, read noise, gain, and the bias pedestal, pixel by
-pixel.
+pixel. The render always runs at the sensor's native resolution; when the exposure was requested at
+a binning above 1×1, the finished frame is binned last, by summing each block and clipping the sum
+at the ADC's full scale.
 
 ## From catalog to pixel positions
 
@@ -75,7 +77,7 @@ below, so switching from OIII to SII slightly changes the diffraction-limited PS
 
 ### Sensors
 
-The four sensor models carry datasheet-derived parameters. All share a Sony
+The five sensor models carry parameters taken from published specifications. All share a Sony
 back-illuminated QE curve anchored to a published IMX455 measurement (about 80% peak QE, falling
 toward the red: roughly 0.75 at 530 nm, 0.50 at Hα, 0.46 at SII).
 
@@ -85,6 +87,10 @@ toward the red: roughly 0.75 at 530 nm, 0.50 at Hα, 0.46 at SII).
 | IMX571 | 6248 × 4176 | 3.76 | 16 | 50000 | 2.8 → 1.5 |
 | IMX533 | 3008 × 3008 | 3.76 | 14 | 50000 | 3.8 → 1.5 |
 | IMX294 | 4144 × 2822 | 4.63 | 14 | 66000 | 7.0 → 1.3 |
+| IMX585 | 3840 × 2160 | 2.90 | 12 | 40000 | 3.3 → 1.0 |
+
+Sony publishes no full datasheet for the IMX585, so its row is assembled from ZWO and QHY published
+specifications for the ASI585MM and is approximate.
 
 ### Sky and dark current
 
@@ -171,6 +177,12 @@ tilt across the sensor therefore collapses onto a small set of kernels instead o
 With astigmatism enabled a kernel is identified by both of its defocuses and by its orientation,
 which is quantized on the same quarter-pixel budget; a 61-megapixel frame with tilt and backfocus
 injected typically builds a few hundred kernels rather than one.
+
+The cache has a fixed budget of 384 MB. An injected aberration large enough to exceed it makes the
+render coarsen the defocus quantum, by up to 16 times, and if that still does not fit it drops the
+elliptical model and renders circular donuts. Both fallbacks go to NINA's log with the numbers
+behind them, so stars that come back round with **Model Astigmatism** on have an explanation there.
+Reducing the tilt, the backfocus error, or the astigmatism brings the elliptical model back.
 
 ## Tilt and field curvature
 
@@ -296,8 +308,8 @@ Two options control it, inside the Field Aberrations group:
   1.67:1 corner at any tilt. Raise it to model a rig whose tilt is mostly a sagging focuser; set it to 0
   for a camera that is simply crooked in a square adapter. It is **signed**, and adds to the other two
   contributions signed, so a large enough tilt term of the opposite sign flips the whole field's
-  elongation direction the same way a bigger spacer would. Values at or beyond ±1 are rejected — at 1 the
-  star collapses to a line everywhere at once.
+  elongation direction the same way a bigger spacer would. The box accepts values up to ±0.95,
+  stopping short of the ±1 at which the star collapses to a line everywhere at once.
 
 Two things this deliberately does not change. The **inspector still recovers exactly what you
 inject**: the two surfaces' mean is the surface it fits, and reversing the defocus swaps the two
@@ -315,8 +327,8 @@ Development converts that to ADU with the full noise chain, per pixel:
    electrons, a Gaussian approximation above, where the distributions agree to within a percent).
 2. **Full-well clamp**: electrons saturate at the sensor's full-well capacity.
 3. **Read noise**: a Gaussian draw whose width follows the sensor's gain-dependent read-noise
-   curve, including the step down at the dual-conversion-gain threshold (gain 100 on the IMX
-   sensors here, 120 on the IMX294).
+   curve, including the step down at the dual-conversion-gain threshold (gain 100 on the
+   IMX455, IMX571 and IMX533, 120 on the IMX294, and 252 on the IMX585).
 4. **Digitization**: electrons divide by the e⁻/ADU gain, the **Bias Pedestal** is added, and the
    result clamps to the sensor's bit depth. The gain law is ZWO-style, 0.1 dB per gain unit:
    \(g_{e^-/\text{ADU}} = (\text{full well} / 2^{\text{bits}}) \cdot 10^{-\text{gain}/200}\).

--- a/documentation/docs/overview/camera-simulator.md
+++ b/documentation/docs/overview/camera-simulator.md
@@ -40,8 +40,11 @@ else, point **ASTAP Catalog Path** on the plugin's **Camera Sim** options tab at
 folder. The path is re-read for every exposure, so a change takes effect on the next frame without
 reconnecting the camera.
 
-If the database is missing, exposures fail with an error naming the folder it searched, and the
-Camera Sim tab's path field is where to fix it.
+A missing database does not fail the exposure. The simulator renders sky, dark current and noise
+with no stars, and logs the folder it searched. A frame that comes back starless is the symptom;
+**ASTAP Catalog Path** on the **Camera Sim** tab is where to fix it. A pointing with no catalog
+stars down to the **Limiting Magnitude** renders the same starless frame, and the log says which
+of the two happened.
 
 ## Connect it
 
@@ -70,7 +73,7 @@ Simulator Setup** dialog. This is the physical rig, set once:
 
 | Setting | Default | What it does |
 |---|---|---|
-| **Sensor Model** | IMX455 (ASI6200MM / QHY600M) | Chooses the sensor: IMX455, IMX571 (ASI2600MM / QHY268M), IMX533 (ASI533MM), or IMX294 (ASI294MM). Each brings its real resolution, pixel size, bit depth, full-well capacity, read-noise curve, and dark current. Change it while disconnected: NINA latches resolution and pixel size when the camera connects. |
+| **Sensor Model** | IMX455 (ASI6200MM / QHY600M) | Chooses the sensor: IMX455, IMX571 (ASI2600MM / QHY268M), IMX533 (ASI533MM), IMX294 (ASI294MM), or IMX585 (ASI585MM). Each brings its real resolution, pixel size, bit depth, full-well capacity, read-noise curve, and dark current. Change it while disconnected: NINA latches resolution and pixel size when the camera connects. |
 | **Aperture** (mm) | blank | Leave blank to infer from your NINA telescope settings; the greyed hint shows the value in effect. |
 | **Focal Length** (mm) | blank | Leave blank to take the focal length from **Options → Equipment → Telescope**. A fresh profile falls back to 980 mm at f/7. |
 | **Central Obstruction** | on | Whether the optic has a central obstruction. This is what puts the hole in defocused donut stars. |
@@ -162,6 +165,15 @@ The simulated adapter can also stand in for a **motorized** adapter: select an A
 preset in the wizard and connect to the **Simulator** port to run the hands-off calibration and the
 inspector's Automatic Adjustment against it. See the [Simulator
 port](motorized-tilt-adapter.md#the-simulator-port).
+
+Beside **Copy from adapter settings** is **Copy to adapter settings…**, which goes the opposite
+way: it overwrites your real tilt-adapter calibration with the simulated adapter's geometry. It
+asks first, and the confirmation names the fields it replaces. The copy sets the wizard's
+**Device** to **Manual** and marks the calibration as manually entered, which turns off the
+Aberration Inspector's **Automatic Adjustment** until you re-run the calibration with the device
+connected. NINA shows a warning when the copy actually took automation away. The wizard's
+**Trust This Calibration for Automation** button is not offered afterwards, because it appears
+only on a motorized device preset.
 
 !!! note "Match the simulated adapter to the real settings"
     The inspector computes its guidance from the *real* tilt-adapter settings, while the simulated

--- a/documentation/docs/overview/motorized-tilt-adapter.md
+++ b/documentation/docs/overview/motorized-tilt-adapter.md
@@ -30,8 +30,9 @@ correction takes at most three commands.
 2. Click **Connect**. Opening the port restarts the adapter's controller, so it takes a few seconds
    to boot before it responds; the status line then reads *Connected on COM7* (or whichever port you
    chose). There is no auto-connect: the plugin only opens the port when you click.
-3. Click **Disconnect** when you are done. If the connection sits unused for 30 minutes, a dialog
-   asks whether to disconnect it.
+3. Click **Disconnect** when you are done. If the connection sits unused for 30 minutes, a banner in
+   the tilt panels counts down for a minute and then disconnects on its own. **Stay connected** keeps
+   it, and so does moving the adapter or starting a run.
 
 While connected, a **Motor positions (steps)** grid shows each corner's current position counter,
 polled from the device. Each cell names its corner and the screw it holds (**TR · M1**, **TL · M2**,
@@ -80,12 +81,24 @@ you must do.
 Completing a calibration with the device connected also records that the calibration is **linked to
 that device**: because the wizard sent every move itself, the correspondence between wizard screws
 and physical corners is established by measurement rather than assumption. [Automatic
-Adjustment](#automatic-adjustment) requires this link. It is cleared by any calibration the wizard
-did not drive itself: a
+Adjustment](#automatic-adjustment) requires that link, and requires the calibration to have passed
+its own confidence check. The link is cleared by any calibration the wizard did not drive itself: a
 [Manual Calibration Entry](tilt-adapter-wizard.md#manual-calibration-entry), a
 [replayed](tilt-adapter-wizard.md#saving-and-replaying-a-calibration-run) calibration, a run
-performed without the device connected, or substituting **Use Saved AF** for a live measurement
-partway through a connected run.
+performed without the device connected, substituting **Use Saved AF** for a live measurement
+partway through a connected run, or copying the [Camera
+Simulator](camera-simulator.md)'s adapter geometry over it.
+
+A hand-entered calibration is the one case you can re-link without repeating the run. With a
+motorized preset selected, the wizard's saved-calibration panel offers [**Trust This Calibration for
+Automation**](tilt-adapter-wizard.md#trusting-a-hand-entered-calibration), which links the
+calibration to the selected preset and marks it reliable, the two things Automatic Adjustment tests
+for. Confirm the numbering yourself before you use it: with [Manual adjustment](#manual-adjustment),
+move one screw a small amount and check that the corner that moves is the one you expect for that
+screw's label. Trusting lifts nothing else, so Automatic Adjustment still needs a connected device
+and a fresh measurement to adjust from. It is not offered for a run that drove the device but failed
+its confidence check. That case has to be re-measured: confirming which corner moves proves the
+numbering, and numbering is not what a noisy run got wrong.
 
 ## Automatic Adjustment
 
@@ -294,12 +307,24 @@ few seconds to boot after the port opens, so a slow first response is normal.
 Connect it from the wizard's **Motorized Device Connection** section; the inspector uses the same
 connection.
 
-**Automatic Adjustment is disabled with "This calibration is not linked to the connected
-device."** Run a calibration with the device connected (Auto Run All is the easiest path). A
-calibration entered by hand or replayed from disk cannot prove which physical corner its screw 1
-refers to, and unattended automation applying a rotated correction would make tilt worse. The
-companion message, "This calibration is low-confidence", means the connected
-calibration ran but did not pass its own quality validation; re-run it under better conditions.
+**Automatic Adjustment is disabled, with an italic note below the button.** The note names one of
+three causes.
+
+- *"This calibration was entered or edited by hand..."* The saved calibration came from **Manual
+  Calibration Entry**, or from copying the [Camera Simulator](camera-simulator.md)'s adapter
+  geometry over it, so nothing has confirmed that its screw 1 is the corner the device's motor 1
+  drives. Run a calibration with the device connected (Auto Run All is the easiest path), or use
+  **Trust This Calibration for Automation** in the wizard after checking the numbering as [described
+  above](#hands-off-calibration).
+- *"This calibration is not linked to the connected device."* The calibration was measured some other
+  way: replayed from disk, run with nothing connected, or measured against a different **Device**
+  preset than the one now selected. Re-select the preset it was measured on, or re-run the
+  calibration with the device connected. Unattended automation applying a rotated correction would
+  make tilt worse, which is why the link is required.
+- *"This calibration is low-confidence (it did not pass quality validation)."* The run did drive the
+  device, but its screw moves did not stand clear of the measurement noise. Re-run it on a star-rich
+  field with a finer focus step. There is no Trust button for this case; only a better measurement
+  clears it.
 
 **Automatic Adjustment is disabled right after an adjustment.** That is the
 one-adjustment-per-measurement rule. Run a new Detailed Analysis; the button re-enables when it

--- a/documentation/docs/overview/sensor-model.md
+++ b/documentation/docs/overview/sensor-model.md
@@ -63,8 +63,11 @@ because there are only four points to fit.
 
 **Backfocus** is read off the same regions rather than the plane: it is the mean of the four corner
 best-focus positions minus the center position, converted to microns with *Focuser Step Size*,
-and compared against the critical focus zone. A positive value means the corners focus past the
-center, a sign the sensor sits too far from the corrector. The screw-by-screw guidance built from this
+and compared against the critical focus zone. A positive value means the corners reach focus at a
+higher focuser position than the center. With **Increasing focuser position** left at its default,
+that means the sensor sits too far from the corrector, and the panel says so: *Move sensor TOWARDS
+flattener*. Set that option to **reversed** and the same reading points the other way (see [which way
+does your focuser travel](tilt-aberration-inspector.md#which-way-does-your-focuser-travel)). The screw-by-screw guidance built from this
 plane is covered under
 [Guiding tilt-adapter screw adjustments](tilt-adapter-wizard.md).
 
@@ -105,6 +108,13 @@ older parameterization written directly in \((\theta, \varphi, K)\); writing the
 function of \(G_x, G_y, K_x, K_y\) removes a numerical trap at zero tilt (where the tilt direction is
 undefined) and lets the curvature cross zero, so a single fit covers a bowl, a dome, and a flat field
 without special cases.
+
+The fit also yields a tilt plane in the same form as the 4-corners model above: the planar part of the
+surface evaluated at the four sensor corners. It carries the pixel pitch it was fit at, so the [Tilt
+Adapter Wizard](tilt-adapter-wizard.md), which reads the plane's slopes back as microns of focuser
+travel per micron of sensor displacement, uses the pitch of the frames the plane came from rather than
+the camera profile's unbinned value. A calibration measured at 2x2 binning therefore recovers the same
+hardware numbers as one measured at 1x1.
 
 ![The fitted sensor surface rendered as a 3D best-focus map, decomposed into its tilt-plane and curvature parts](../assets/figures/sensor-surface-decomposition.png){ width=720 }
 
@@ -155,12 +165,27 @@ aligns on the first pass, is neither altered nor slowed. If any frame still cann
 matching for the whole sweep reverts to the wider nearest-neighbor search radius used when alignment
 is off.
 
+A frame whose star detection comes back empty (an extreme-defocus end of the sweep, a frame lost to
+cloud) does not stop the analysis. It stays in the run but contributes nothing: with no stars it has
+nothing to match and forms no triangles, so it never aligns. With alignment on, it therefore counts
+toward the "*N frames failed to align*" line that drops the whole sweep back to the wider search
+radius, and the inspector warns about it separately as well: "*N frame(s) had no detected stars and
+were skipped*". The remaining frames fit the model normally. If every frame in the run is empty there
+is no reference frame to register against, and the analysis fails with a message that says so
+("*Sensor modeling failed. None of the … frames in this run had any detected stars.*"). Longer
+exposures, or more sensitive [star detection settings](../settings/index.md), are the fix.
+
 A star must be matched in **at least five frames** to be fit, so its focus curve has enough points to
 be meaningful.
 
 **Building the points.** Each surviving star contributes one data point: its sensor position in
 microns, \(\bigl((\text{pixel} - \tfrac{W}{2})\cdot p,\ (\text{pixel} - \tfrac{H}{2})\cdot p\bigr)\)
-for pixel size \(p\), and its best-focus position in microns. The point carries the per-star
+for pixel size \(p\), and its best-focus position in microns. \(p\) is the pitch of the frames as they
+were captured: the camera pixel size from the frame's own metadata, multiplied by the binning the frame
+was taken at. A sweep captured with NINA's **Auto Focus Binning** at 2x2 uses twice the native pitch, so
+the sensor's physical size still comes out right. [Detection Binning](../settings/detection-binning.md)
+does not enter it, because the detector reports star positions back in the captured frame's pixels. The
+point carries the per-star
 uncertainty \(\sigma\), which becomes the fit weight
 
 \[
@@ -169,7 +194,10 @@ w_i = \frac{1}{\sigma_i} .
 
 A tightly-pinned star pulls on the fit harder than a loosely-pinned one. When a star's \(\sigma\) is
 unavailable it is filled in with the **median** \(\sigma\) of the other stars, so an unknown
-uncertainty is treated like a typical star rather than dominating or being ignored.
+uncertainty is treated like a typical star rather than dominating or being ignored. Every \(\sigma\),
+imputed or not, then gets a 2-micron floor added in quadrature. A per-star curve fit can report a
+formal standard error far below the real star-to-star scatter, and without that floor a handful of
+stars would carry nearly all of the fit's weight.
 
 ## Fitting the surface
 
@@ -203,12 +231,17 @@ A bad star (a blend, a hot pixel mistaken for a star, a cosmic ray) can land far
 surface. The model rejects outliers at three levels, from the individual measurement up to the whole
 surface.
 
-**Within a star's focus curve.** Before a star's best focus is trusted, its own HFR points are
-screened with a Grubbs test on the median- and MAD-scaled residuals, dropping a single gross outlier
-and refitting. The screen never prunes a star below five points, so it cannot manufacture a tight fit
-by deleting data.
+**Within a star's focus curve.** With the inspector's **Outlier rejection** on (the default), a star's
+own HFR points are screened with a Grubbs test on the median- and MAD-scaled residuals before its best
+focus is trusted, and the star is refit without the point that fails. How many points the screen may
+drop is capped by the AutoFocus **Max Outlier Rejections** setting, which is 0 out of the box, so no
+point is dropped until you raise it. Under the default **Hybrid (Best Fit)** model each candidate curve
+proposes its own outliers and only the points every one of them flags are removed, so no curve can win
+the [model comparison](hyperbola-fitting.md#the-hybrid-selector-default) by pruning its own data. The
+screen never prunes a star below five points.
 
-**Across the surface.** After the surface is fit, the residual of every point is measured and the
+**Across the surface.** After the surface is fit, every point's weighted residual is measured (its
+distance from the surface divided by its own \(\sigma\), the quantity the fit minimizes) and the
 spread of those residuals is summarized robustly with the scaled median absolute deviation
 
 \[
@@ -216,10 +249,11 @@ spread of those residuals is summarized robustly with the scaled median absolute
 \]
 
 where the constant makes the MAD a consistent estimate of the standard deviation for clean Gaussian
-scatter. Any point whose residual exceeds \(2.5\,\operatorname{MAD}\) in magnitude is dropped and the
-surface is refit on what remains. This repeats until no point is dropped (capped at ten passes), and
-it backs out to the previous fit if a pass fails to improve the overall fit quality, so the rejection
-can never make the model worse.
+scatter. Any point that lands more than \(2.5\,\operatorname{MAD}\) from the median residual is dropped
+and the surface is refit on what remains. This repeats until a pass drops nothing, capped at ten passes
+and at a tenth of the points in total. That cap is the backstop: rejection is there to remove a few bad
+stars, so once more than 10% of the data looks like an outlier the pruning stops rather than trimming
+the data into agreeing with the model.
 
 ![A cross-section of the fitted surface with per-star best-focus points; points outside the band are dropped and the surface is refit](../assets/figures/sensor-outlier-rejection.png){ width=640 }
 
@@ -266,7 +300,9 @@ Reduced chi-squared is the \(\chi^2\) per degree of freedom,
 \chi^2_\nu = \frac{1}{n - p} \sum_i w_i^2 \,\bigl(z(x_i, y_i) - z_i\bigr)^2 ,
 \]
 
-with \(n\) enabled points and \(p\) free parameters. Because the per-star \(\sigma\) is an approximate
+with \(n\) enabled points and \(p\) the model's parameter count (six, or seven with **Astigmatic
+field curvature** on; a pinned center still counts here, unlike in the covariance below). Because the
+per-star \(\sigma\) is an approximate
 uncertainty rather than a calibrated one, \(\chi^2_\nu\) routinely runs above 1 even for good fits and
 its absolute scale depends on the rig, which is why it only rejects a model in combination with a low
 \(R^2\).

--- a/documentation/docs/overview/star-annotation.md
+++ b/documentation/docs/overview/star-annotation.md
@@ -37,7 +37,7 @@ These controls govern the always-on overlay drawn for accepted stars. ("Property
 | Show Star Bounds | On | on / off | *"Whether to draw the bounding box or ellipse around the star"*. |
 | Star Bounds Type | Box | Box, Ellipse, PSF | *"The type of boundary surrounding the star. Star detection internally uses a box, but an ellipse can be more aesthetically pleasing"*. |
 | Star Bounds Color | Red, 50% | ARGB color | *"The color of the bounding box or ellipse around the star"*. |
-| Show Property | HFR | None, HFR, FWHM, FWHM X, FWHM Y, FWHM Pixels, Eccentricity, PSF Rotation, Background, PSF Background, PSF Peak, Moffat Beta | *"What type of annotation to show for each star"*. Picks the text label drawn beside each star. |
+| Show Property | HFR | None, HFR, FWHM Arcseconds, FWHM X (Pixels), FWHM Y (Pixels), FWHM Pixels, Eccentricity, PSF Rotation, Background, PSF Background, PSF Peak, Moffat Beta | *"What type of annotation to show for each star"*. Picks the text label drawn beside each star. |
 | Property Color | Yellow | ARGB color | *"The color of the annotation text next to the star"*. |
 | Property Font | Arial | system font | Font family used for the text labels. |
 | Font size (inline pt box under **Property Font**) | 18 pt | > 0 | Point size of the text labels. It has no separate label in the UI. |
@@ -62,8 +62,8 @@ The label drawn beside each star reflects the selected annotation type. **HFR** 
 |---|---|---|
 | None | no label | — |
 | HFR | Half-Flux Radius (pixels) | No |
-| FWHM | FWHM in arcseconds | Yes |
-| FWHM X / FWHM Y | per-axis FWHM (pixels) | Yes |
+| FWHM Arcseconds | FWHM in arcseconds | Yes |
+| FWHM X (Pixels) / FWHM Y (Pixels) | per-axis FWHM in pixels | Yes |
 | FWHM Pixels | FWHM in pixels | Yes |
 | Eccentricity | axis-ratio eccentricity | Yes |
 | PSF Rotation | fit rotation angle in degrees | Yes |
@@ -116,7 +116,7 @@ The mask pixels are blended onto the image in **Structure Map Color** (*"The col
 
 **Tuning detection quality.** Cap labels (**Show All Stars** off, **Maximum Stars** ≈ 50), then enable the rejection toggles one or two at a time with distinct colors. Walk the gates until the accepted set looks right for your focal ratio and seeing.
 
-**Checking focus quality across the field.** Set **Show Property** to FWHM or Eccentricity (PSF modeling required) and watch for consistent, low values near best focus. The star-center reticule makes off-center or trailed stars at the defocus extremes easy to spot.
+**Checking focus quality across the field.** Set **Show Property** to FWHM Arcseconds or Eccentricity (PSF modeling required) and watch for consistent, low values near best focus. The star-center reticule makes off-center or trailed stars at the defocus extremes easy to spot.
 
 **Mapping the PSF across the sensor.** Combine **Star Bounds Type = PSF** with the Eccentricity or PSF Rotation label to overlay the actual fitted ellipse shape and orientation everywhere in the frame. Systematic stretch toward the corners points to tilt, coma, or curvature, the kind of thing the Tilt & Aberration Inspector quantifies.
 

--- a/documentation/docs/overview/tilt-aberration-inspector.md
+++ b/documentation/docs/overview/tilt-aberration-inspector.md
@@ -91,7 +91,7 @@ outliers are detected and rejected, see [Sensor Model Fitting](sensor-model.md).
     matched star) and needs enough matched stars to be meaningful, so leave it off for a quick tilt
     check.
 
-!!! note "Frame alignment holds up under heavy defocus"
+!!! note "When frames fail to align or come back empty"
     Matching stars across frames is hardest at the defocused extremes of the sweep, where stars are
     bloated and sparse. The matcher chains alignment through neighboring frames, retries against a
     denser reference, and escalates its search box for the hardest frames rather than giving up, so the
@@ -101,6 +101,16 @@ outliers are detected and rejected, see [Sensor Model Fitting](sensor-model.md).
     [donut-recovery settings](../settings/acceptance-gates.md#recover-out-of-focus-donut-stars)) and
     re-run.
 
+    A frame where the detector finds no stars at all (one from an extreme end of the sweep, or one
+    lost to cloud) does not stop the analysis. It is skipped, and the run reports
+    "*N frame(s) had no detected stars and were skipped*". Such a frame cannot align either, so
+    with **Align images before matching** on, it also counts toward the failed-to-align total. To see
+    which frame it was, run with **Keep frames for Review** on and open **Review Frames**, where it
+    reads *Detected stars: 0*. If every frame comes back empty there is no reference frame to build
+    on and the analysis stops outright, reporting
+    "*Sensor modeling failed. None of the N frames in this run had any detected stars*"; longer
+    exposures or looser detection settings are the fix.
+
 ## Correcting tilt with a tilt adapter
 
 Once tilt is measured, a **tilt adapter** lets you correct the linear (tilt-plane) part of it. The
@@ -109,12 +119,29 @@ hardware model, then converts the measured tilt into concrete screw-turn (or ste
 instructions. See [Tilt Adapter Wizard](tilt-adapter-wizard.md).
 
 The arrows describe what the adapter must do: ⬆ means that corner of the adapter plate moves toward
-the objective, ⬇ toward the camera — the same on every rig with the same **Increasing focuser
-position** setting ([below](#which-way-does-your-focuser-travel)). The numeric rows each carry the screw
-rotation that produces the move: `1.25 ⟳` means 1.25 turns clockwise (tighten), `0.50 ⟲`
-counter-clockwise (loosen); stepper adapters show signed steps (`+35 steps`) matching the wizard's
-prompts. A legend at the top of the section defines both conventions and is marked "(assumed)" until
-the adapter direction has been measured in the wizard.
+the objective, ⬇ toward the camera, the same on every rig with the same **Increasing focuser
+position** setting ([below](#which-way-does-your-focuser-travel)). ⬆ and ⬇ are the larger moves,
+↑ and ↓ the smaller ones. In the **Tilt** row the sizing is relative: a screw needing at least half
+the largest correction in the row gets a large arrow, one needing under a tenth of it gets a dash.
+In the **Backfocus** row it is absolute, taken from the measured **Curvature Effect**: a dash below
+10 µm, a small arrow up to 50 µm, a large arrow at 50 µm or more. That row reads the same on every
+screw, because backfocus moves the whole plate, and it appears only once a sensor curve model has
+been fit, since the curvature it corrects comes from that fit.
+
+Below the arrows, a second table gives the amount for each screw. Its three rows split the job into
+**Tilt**, **Backfocus**, and the **Total** you apply, and each amount carries the rotation that
+produces it: `1.25 ⟳` means 1.25 turns clockwise (tighten), `0.50 ⟲` counter-clockwise (loosen). A
+screw with nothing worth turning shows a dash instead. Stepper adapters show signed steps
+(`+35 steps`) matching the wizard's prompts; screw adapters get a **Display** selector for Turns,
+Degrees, or Minutes (60 minutes to a turn, a clock face rather than arcminutes). This table also
+needs a fitted sensor curve model, plus the adapter's thread pitch (or stepper step size) and screw
+radius from the wizard. A legend at the top of the section defines both conventions and is marked
+"(assumed)" until the adapter direction has been measured in the wizard.
+
+If the thread pitch (or stepper step size) saved for your adapter differs by more than 15% from the
+value the wizard last measured, a warning box naming both appears under the numbers. The amounts
+above are computed from the saved value, so settle that difference in the Tilt Adapter Wizard, by
+re-running the calibration or adopting the measured value, before you act on them.
 
 With a connected motorized adapter, the guidance section also shows the adapter's live motor
 positions and an **Automatic Adjustment** button: after you approve the planned motor moves in a

--- a/documentation/docs/overview/tilt-adapter-wizard.md
+++ b/documentation/docs/overview/tilt-adapter-wizard.md
@@ -88,8 +88,9 @@ comes from the adapter direction setting in the wizard's **Measurement** section
 moves adapter** (or **+ steps move adapter** for steppers):
 either **Toward the camera** (outward, the default) or **Toward the objective** (inward). Until it
 is measured, guidance marks the direction "(assumed)". To measure it, turn on **Measure direction**:
-this adds two steps (an all-screws-clockwise move plus a return to baseline) and reads the direction
-off the **change in mean best-focus position** between them. Turning every screw clockwise is a pure
+this adds two steps (**All Screws Clockwise**, or **All Motors Positive Steps** on a stepper adapter,
+followed by **Return to Baseline**) and reads the direction off the **change in mean best-focus
+position** between them. Turning every screw clockwise is a pure
 piston, so if the mean best-focus position *drops*, the plate moved toward the camera — on a standard
 focuser, that means clockwise moves the adapter toward the camera. The saved calibration then reports
 the direction as measured. That same all-screws step also feeds the **Piston-implied** pitch estimate
@@ -158,6 +159,41 @@ click **Apply**; if you change that setting later, click **Apply** again. If gui
 tilt the wrong way after a manual entry, the numbering direction is flipped: switch it and Apply
 again. A wrong adapter direction setting inverts guidance the same way; correct that setting and
 click **Apply** again.
+
+**Apply** also blocks [Automatic Adjustment](motorized-tilt-adapter.md#automatic-adjustment),
+because a typed angle cannot show that your screw numbering matches how the motors are wired. If the
+calibration you replaced was one Automatic Adjustment could have used, a notification says so;
+otherwise there was nothing to lose and **Apply** stays quiet.
+
+### Trusting a hand-entered calibration
+
+[Automatic Adjustment](motorized-tilt-adapter.md#automatic-adjustment) asks two things of a
+calibration: that the wizard drove the adapter itself, which is what establishes which physical
+corner each screw number belongs to, and that the run passed its own confidence check. A hand-entered
+calibration has neither. With a motorized preset selected and a hand-entered calibration saved, the
+saved-calibration panel shows a warning headed **Automatic Adjustment is disabled**. The device does
+not have to be connected for it to appear.
+
+The warning carries a **Trust This Calibration for Automation** button. Clicking it trusts nothing
+yet: it replaces itself with the risk (wrong numbering means unattended automation drives the adapter
+the wrong way and makes tilt worse) and a **Yes, trust it** / **Cancel** pair. Do the check the
+warning asks for before you confirm. Use [Manual
+adjustment](motorized-tilt-adapter.md#manual-adjustment) to move one screw a small amount, and
+confirm the corner that moves is the one you expect for that screw's label.
+
+**Yes, trust it** links the calibration to the selected preset and marks it reliable, which is what
+Automatic Adjustment tests for, and the warning disappears. Nothing else changes: the panel still
+reads "Manually entered calibration (not measured by the wizard)", and every other condition on
+Automatic Adjustment still applies, including the one-adjustment-per-measurement rule.
+
+Trust lasts only as long as the numbering it vouched for. Applying a manual entry again and **Clear
+Calibration** both drop it, and any completed calibration run replaces it with that run's own result.
+It also belongs to the preset that was selected when you confirmed: switch the **Device** list to
+another preset and automation is blocked again, switch back and the trust returns.
+
+The button is not offered for a calibration the wizard measured but flagged as low-confidence. The
+check above can confirm a screw numbering; it cannot recover angles that measurement noise dominated.
+Re-run that calibration instead.
 
 ## Hardware model and device presets
 
@@ -231,6 +267,20 @@ radius yourself.
 
     Without a valid hardware model, adjustments are still reported in focuser steps (and, if *Focuser
     Step Size* is set, in microns); you just do not get the turn/step figure.
+
+At the foot of the **Measured Adapter Hardware** panel, **Inputs to this calculation** lists the four
+numbers the measurement used: **Pixel size**, **Focuser step size**, **Screw radius**, and **Applied
+per screw**. The pixel size is the pitch of the frames as they were captured, so with NINA's [Auto
+Focus Binning](autofocus.md#binning-during-autofocus) above 1x1 it is the binned pitch and says so,
+for example `7.52 µm (3.76 µm at 2x2 binning)`. That is deliberately not the **Pixel size (µm)** box
+higher up the pane, which edits your camera profile's native pixel size.
+
+A calibration measured before Hocus Focus 4.0.0.17 with Auto Focus Binning above 1x1 recovered a
+thread pitch (or step size) too large by the binning factor. If you clicked **Use measured value** on
+such a run, that inflated figure is your saved hardware now, and every correction computed from it
+comes out that much too small. Nothing repairs it on its own. Replay that run (replay re-fits the tilt
+plane from the saved frames, so the pitch comes out right whatever the file recorded) or re-calibrate,
+then click **Use measured value** again.
 
 ## Saving and replaying a calibration run
 

--- a/documentation/docs/settings/acceptance-gates.md
+++ b/documentation/docs/settings/acceptance-gates.md
@@ -34,7 +34,7 @@ This page documents the gates exposed as **Advanced** star-detection options. Th
 | Min Bounding Box Size | 5 px | ≥ 1 | Smallest allowed candidate side; rejects tiny structures as **Too Small** |
 | Min HFR | 1.2 px | > 0 | Smallest viable Half-Flux Radius; rejects hot-pixel-like spikes as **Too Low HFR** |
 | Background Box Expansion | 3 px | ≥ 1 | Annulus width for the local-background estimate |
-| Defocus-Aware Gates | Off | on/off | Relaxes distortion + centering for large (defocused) candidates |
+| Defocus-Aware Gates | Off | on/off | Relaxes distortion + centering for large (defocused) candidates, but the Defocus-Aware Donut Detection master toggle is what switches that relaxation on; this toggle changes nothing on its own |
 | Defocus Size Reference | 30 px | 1–1000 | Size at/below which strict thresholds still apply |
 | Defocus Distortion Min Factor | 0.25 | 0.01–1 | Most permissive distortion multiplier for huge donuts |
 | Defocus Centering Tolerance Factor | 2.0 | 1–10 | Most permissive centering multiplier for huge donuts |
@@ -92,9 +92,9 @@ The option is shown as a percentage (default 75%), so a candidate fails when its
 
 ## Max Distortion
 
-Rejects candidates whose pixels do not fill their bounding box compactly enough, tagging them **Too Distorted**.
+Rejects candidates whose pixels do not fill their bounding box compactly enough, tagging them **Too Distorted**. The field is labeled **Max Distortion (min fill ratio)** in the advanced list.
 
-> The ratio of star pixels to the size of a perfect square bounding box. A perfect circule has a distortion of PI/4, which is approximately 0.7. The default value of 0.5 allows for some distortion and measurement error and should work for most cases.
+> A MINIMUM fill ratio, despite the name: the ratio of star pixels to the area of the bounding box, where a candidate is rejected as Too Distorted when its fill ratio falls BELOW this value. Raising it makes the gate stricter, not looser. A perfectly round star fills PI/4, approximately 0.785, so values above that reject every round star. The default of 0.5 allows for some distortion and measurement error and should work for most cases.
 
 This is a **fill ratio**: the number of structure pixels divided by \(d^2\), where \(d\) is the larger of the bounding-box width and height. A perfectly round star fills about \(\pi/4 \approx 0.79\) of its square box. Elongated or stringy shapes (diffraction spikes, satellite trails, merged double stars, hot columns) fill much less and are rejected when
 
@@ -177,7 +177,7 @@ The detector fits a robust local background plane to the annulus of pixels just 
 
 ## Defocus-Aware Gates
 
-A single opt-in toggle that relaxes both the Max Distortion and Star Center Tolerance gates for large candidates, which act as a proxy for heavy defocus. It is **off by default**, and when off, detection is bit-identical to the strict gates.
+A toggle that relaxes both the Max Distortion and Star Center Tolerance gates for large candidates, which act as a proxy for heavy defocus. It is **off by default**. What actually switches the two relaxations on is the **Defocus-Aware Donut Detection** master toggle described further down this page: with the master off neither relaxation runs, whatever this toggle says, and detection is bit-identical to the strict gates; with the master on both run whether or not this toggle is ticked. The three numeric knobs below are what change how far the relaxation goes.
 
 ![The Defocus-Aware Gates, Defocus-Aware Structure, and Defocus-Aware Donut Detection settings at the bottom of the advanced list](../assets/screenshots/advanced-defocus-donut.png){ width=400 }
 
@@ -211,7 +211,7 @@ A single opt-in toggle that relaxes both the Max Distortion and Star Center Tole
 Stars admitted only by the relaxation are flagged internally so the optimizer can discourage over-relaxing into false positives.
 
 !!! tip "When this helps"
-    Enable it when you deliberately collect autofocus frames far from focus (wide sweeps) and see donut stars dropped as **Too Distorted** or **Not Centered** at the sweep extremes. It does nothing for near-focus imaging frames, and it should stay off there so the strict gates keep filtering noise. If even heavily defocused stars never appear as candidates at all (not merely rejected), that is a structure-detection problem, not a gate problem; see Defocus-Aware Structure on the [Structure detection](structure-detection.md) page.
+    Enable the **Defocus-Aware Donut Detection** master toggle when you deliberately collect autofocus frames far from focus (wide sweeps) and see donut stars dropped as **Too Distorted** or **Not Centered** at the sweep extremes. That is what puts this relaxation into effect, and it only loosens the two gates for large candidates. It does nothing for near-focus imaging frames, and it should stay off there so the strict gates keep filtering noise. If even heavily defocused stars never appear as candidates at all (not merely rejected), that is a structure-detection problem, not a gate problem; see Defocus-Aware Structure on the [Structure detection](structure-detection.md) page.
 
 ### Defocus Size Reference
 

--- a/documentation/docs/settings/detection-binning.md
+++ b/documentation/docs/settings/detection-binning.md
@@ -25,14 +25,16 @@ Advanced mode.
 **Default:** `1x1 (Off)` &nbsp;•&nbsp; **Range:** 1x1 (Off), 2x2, 3x3, 4x4.
 
 Nothing chooses the factor for you. A line appears under the dropdown only when there is something to act on:
-no measurement yet, or a factor change:
+no measurement yet, a factor change, or a measurement below the range the detector is calibrated for:
 
 ```
 Run an auto-focus to get a recommendation
 Measured in-focus HFR 6.1 px - 2x2 recommended
+Measured in-focus HFR 1.4 px - below the 2-4 px range
 ```
 
-Once your setting matches what the measurement calls for, the line disappears: there is nothing to act on.
+Once your setting matches the factor the measurement calls for, and the measurement is not below the
+calibrated 2 to 4 px range, the line disappears: there is nothing to act on.
 Hover it for the reasoning, including when the measurement was taken. In the
 [Optimization Wizard](../optimization/index.md) the same line sits to the right of its dropdown, under the
 same rule, and its summary offers to re-run the search at the recommended factor.

--- a/documentation/docs/settings/donut-aware.md
+++ b/documentation/docs/settings/donut-aware.md
@@ -9,8 +9,10 @@ them off, detection is identical to having them absent.
 ## The settings
 
 All defocus-aware behavior is gated by the **Defocus-Aware Donut Detection** master toggle. With the master off,
-**Defocus-Aware Gates** and **Defocus-Aware Structure** have no effect; with it on, those two act independently of
-each other. The numeric knobs and their full reference live on the
+**Defocus-Aware Gates** and **Defocus-Aware Structure** have no effect and detection is exactly as if the features
+were absent. With the master on, the distortion and centering relaxations run whether or not **Defocus-Aware
+Gates** is ticked, and the wavelet residual is computed two layers coarser unless **Defocus-Aware Structure** is
+ticked, in which case **Structure Layer Boost** sets the extra layers instead. The numeric knobs and their full reference live on the
 [Acceptance Gates](acceptance-gates.md#recover-out-of-focus-donut-stars) and
 [Structure Detection](structure-detection.md#defocus-aware-structure) pages:
 

--- a/documentation/docs/settings/index.md
+++ b/documentation/docs/settings/index.md
@@ -62,7 +62,7 @@ This preset compensates for pixel scale by nudging a few knobs. [Detection Binni
 
 ### How the optimized snapshot interacts with the presets
 
-When **Use Optimized Settings** is on and a wizard result exists, Simple mode first derives the preset baseline, then overlays the curated subset of parameters from the saved snapshot (sensitivity, clipping multipliers, peak response, distortion, min HFR, center tolerance, structure layers, noise-reduction radius, minimum bounding box, and the hotpixel knobs). Non-curated advanced knobs keep their preset defaults; the curated ones win. See [Labels, Recall & Precision](../optimization/labels-recall-precision.md) for how those values are chosen.
+When **Use Optimized Settings** is on and a wizard result exists, Simple mode first derives the preset baseline, then overlays the curated subset of parameters from the saved snapshot (sensitivity, clipping multipliers, peak response, distortion, min HFR, center tolerance, structure layers, noise-reduction radius, minimum bounding box, the hotpixel knobs, the two adaptive-binarization settings, and the whole defocus-aware and donut group, including the Defocus-Aware Donut Detection master toggle). Non-curated advanced knobs keep their preset defaults; the curated ones win. See [Labels, Recall & Precision](../optimization/labels-recall-precision.md) for how those values are chosen.
 
 ### Exporting and importing star-detection settings
 

--- a/documentation/docs/settings/structure-detection.md
+++ b/documentation/docs/settings/structure-detection.md
@@ -23,7 +23,7 @@ The detector removes large-scale structure with an **à-trous (dyadic) B3-spline
 | Setting | Default | Range | Effect |
 |---|---|---|---|
 | Structure Layers | 4 | integer > 0 | Wavelet layers kept; structures larger than ~\(2^{\text{layers}}\) px are removed as background. More layers keep larger (e.g. defocused) stars. |
-| Defocus-Aware Structure | Off | On / Off | When on, removes background more coarsely so heavily defocused donut stars survive and form candidates. Detection is unchanged while off. |
+| Defocus-Aware Structure | Off | On / Off | Needs the Defocus-Aware Donut Detection master toggle. With the master on, it replaces the default 2-layer donut boost with your own Structure Layer Boost; with the master off it changes nothing. |
 | Structure Layer Boost | 0 | 0–6 | Extra wavelet layers added *only* while Defocus-Aware Structure is on. Higher values remove background more coarsely, so bigger donuts survive. |
 | Structure Dilation Size | 3 | 3–30 px | Diameter of the morphological filter that grows candidate blobs in the structure map. |
 | Structure Dilation Iterations | 0 | ≥ 0 | How many times the dilation is applied. 0 disables dilation. |
@@ -52,13 +52,15 @@ A targeted fix for the case where a heavily out-of-focus star is wiped out by ba
 
 **Default:** Off. **Range:** On / Off.
 
-When this is **off**, the effective layer count is exactly `StructureLayers`, so candidate formation is **bit-identical** to having the feature absent. When **on**, the wavelet residual is computed at `StructureLayers + StructureLayerBoost` layers (a coarser residual removes less star-scale structure), while the post-subtraction blur stays keyed to the unboosted `StructureLayers`.
+This option does nothing on its own. Like every defocus-aware setting it needs the **Defocus-Aware Donut Detection** master toggle as well, and with the master off the effective layer count is exactly `StructureLayers` whatever this option and the boost are set to, so candidate formation is **bit-identical** to having the feature absent.
+
+With the master on, the wavelet residual is already computed two layers coarser than `StructureLayers`, because donut recovery cannot un-erase a ring the residual has already removed. Turning this option on replaces that fixed 2 with your own number: the residual is computed at `StructureLayers + StructureLayerBoost` layers. A boost of 0 therefore gives *fewer* layers than leaving the option off, so raise the boost above 2 when you turn it on. The post-subtraction blur stays keyed to the unboosted `StructureLayers` in every case.
 
 ![Focused star versus a large defocused donut with a hollow center, plus a horizontal intensity cut](../assets/figures/defocused-donut.png){ width=620 }
 *A heavily defocused star becomes a large hollow donut, exactly the structure that aggressive background removal can erase before it is ever evaluated.*
 
 !!! tip "When to adjust"
-    **Enable it** only when collecting autofocus frames far from focus *and* you observe donut stars missing entirely (no candidate at all), not merely rejected by a gate. Pair it with a **Structure Layer Boost above 0**. On its own, with boost at 0, it changes nothing. If the donuts are present but rejected with a reason (**Too Distorted** / **Not Centered**), the fix is the **Defocus-Aware Gates** on the [Acceptance Gates](acceptance-gates.md) page, not this; if the donuts fragment into small arcs (rejected as **Too Small**), reach for the [Recover Out-of-Focus Donut Stars](acceptance-gates.md#recover-out-of-focus-donut-stars) group, which reconnects the ring. **Leave it off** for normal near-focus imaging; it adds nothing there and only widens what counts as a star.
+    **Enable it** only when collecting autofocus frames far from focus *and* you observe donut stars missing entirely (no candidate at all), not merely rejected by a gate. It also needs the **Defocus-Aware Donut Detection** master toggle on; without that, nothing here reaches detection at any boost. With the master on, pair it with a **Structure Layer Boost above 2**, because the master already adds 2 layers by itself and a smaller boost takes layers away. If the donuts are present but rejected with a reason (**Too Distorted** / **Not Centered**), the fix is the **Defocus-Aware Gates** on the [Acceptance Gates](acceptance-gates.md) page, not this; if the donuts fragment into small arcs (rejected as **Too Small**), reach for the [Recover Out-of-Focus Donut Stars](acceptance-gates.md#recover-out-of-focus-donut-stars) group, which reconnects the ring. **Leave it off** for normal near-focus imaging; it adds nothing there and only widens what counts as a star.
 
 ## Structure Layer Boost
 
@@ -71,7 +73,7 @@ The strength knob for Defocus-Aware Structure: how many extra wavelet layers to 
 Each extra layer roughly doubles the size scale that is preserved rather than erased, so a boost of \(n\) keeps structures up to about \(2^{(\text{StructureLayers}+n)}\) px.
 
 !!! tip "When to adjust"
-    **Raise it 1–6** when very out-of-focus stars never appear, increasing it gradually until they do. **Leave it at 0** unless Defocus-Aware Structure is enabled. It is ignored while that toggle is off. It can hurt when pushed too high: a coarser residual leaves more large-scale structure behind, so nebulosity and background gradients start registering as false candidates.
+    **Raise it above 2** when very out-of-focus stars never appear, increasing it gradually until they do. A boost of 2 changes nothing and anything below 2 takes layers away, because the **Defocus-Aware Donut Detection** master toggle already adds 2 layers by itself. **Leave it at 0** unless Defocus-Aware Structure is enabled. It is ignored while that toggle is off. It can hurt when pushed too high: a coarser residual leaves more large-scale structure behind, so nebulosity and background gradients start registering as false candidates.
 
 ## Structure Dilation Size
 


### PR DESCRIPTION
The manual was last touched at `fe45d24`; 42 commits landed after it, through v4.0.0.18. Every page was re-read against the current source, each edit was verified against the C#/XAML that backs it, and the result went through a formatting and house-voice pass.

**19 pages, +403 / -108.** `mkdocs build --strict` is clean and every internal anchor resolves.

## From the code changes in that range

- **Trust This Calibration for Automation** was entirely undocumented. New *Trusting a hand-entered calibration* section on the wizard page, with the re-link route on the motorized page. It records what the code actually gates on: manual entry only (deliberately not offered for a low-confidence measured run), no device connection required, and every path that revokes it — a fresh manual entry, `Clear Calibration`, a new run, a preset switch.
- **Manual entry blocks Automatic Adjustment**, and the warning fires only when automation was available beforehand. Both now stated.
- The all-motors step is titled **All Screws Clockwise** / **All Motors Positive Steps**, not "All Screws Inward".
- `AutomaticAdjustmentRemediationText` has **three** branches now. The troubleshooting entry was headed by a message a hand-entered calibration no longer produces; it is three named cases instead.
- **The Auto Focus Binning pitch fix**: the wizard's *Inputs to this calculation* panel and its binned-pitch readout, and a warning that a calibration measured before 4.0.0.17 above 1x1 stored a thread pitch too large by the binning factor, with the remedy. The tilt plane carrying its own pitch is documented on the sensor-model page.
- **A frame that detects no stars** is a supported outcome rather than a crash, on both the sensor-model and inspector pages, including the all-empty case.
- The simulator's **Copy to adapter settings…** clears the automation markers.

## Drift that predates `fe45d24`

Corrected here because the pages state it as fact:

- `Max Outlier Rejections` documented as defaulting to 1 when it is **0**, so the Grubbs screen never fires out of the box.
- Star Annotator dropdown labels that do not exist (`FWHM` vs `FWHM Arcseconds`, etc.).
- A wrong `MaxDistortion` optimizer bound.
- Several stale quoted in-app strings on the exposure-recommendation and step-size pages.
- An outlier-rejection "back-out" the solver does not perform.
- A missing IMX585 simulator sensor.

## Follow-up (not blocking)

Two screenshots are stale and want re-capturing: `inspector-tilt-guidance.png` (pre-`2e2911a` misaligned guidance tables) and the optimizer wizard shots (old button chrome). No page text depends on either.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AEcUpJsdNjUhWE3vnrScwv